### PR TITLE
fix: rabbitai cancels running test

### DIFF
--- a/.github/workflows/backend_integration_tests_pr.yml
+++ b/.github/workflows/backend_integration_tests_pr.yml
@@ -12,8 +12,8 @@ on:
       - edited
 
 concurrency:
-  group: backend-e2e-${{ github.event.number || github.event.pull_request.number}}
-  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: ${{ github.event.action == 'synchronize' }}
 
 jobs:
   triggers:


### PR DESCRIPTION
Fixes #DXP-361

# What

<!-- Describe the changes you made. -->

- Updated the concurrency group in the GitHub Actions workflow file `.github/workflows/backend_integration_tests_pr.yml` to use `${{ github.workflow }}-${{ github.event.pull_request.number }}`.
- Modified the `cancel-in-progress` condition to `${{ github.event.action == 'synchronize' }}`:
   - You push a new commit → synchronize event → cancel-in-progress is true → cancels previous runs
   - Someone comments → not a synchronize event → cancel-in-progress is false → doesn't cancel anything

# Why

<!-- Why are you making these changes? This should be related to the issue created, and the value we are adding with this PR -->

- To improve the workflow by canceling in-progress runs only when a commit is pushed

# Testing done

<!-- Describe the tests you ran to verify your changes. -->

- Verified the behaviour in #1109

# Decisions made

<!-- Describe any decisions made during the implementation of this PR. This should in general be in the code, but sometimes they are more related to the issue. For example: decisions on PR workflow -->

# Checks

- [x] I have tested this code
- [x] I have reviewed my own PR
- [x] I have created an issue for this PR
- [x] I have set a descriptive PR title compliant with [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)

# Reviewing tips

<!-- What can you tell the reviewer to make the review easier? -->

- Focus on the changes in the concurrency settings and ensure they align with the intended workflow behavior.

# User facing release notes

<!-- What should the user know about this change? Think of it going into public forums for end users to read -->

- Improved the GitHub Actions workflow concurrency settings for better resource management and workflow identification.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated workflow run handling to group runs by workflow and pull request number.
  - Changed cancellation behavior so previous runs are only cancelled on pull request updates, improving workflow efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->