### PR TITLE
fix: gen_call error with arguments

### DIFF
--- a/backend/protocol_rpc/transactions_parser.py
+++ b/backend/protocol_rpc/transactions_parser.py
@@ -251,10 +251,19 @@ class TransactionParser:
 
     def decode_method_call_data(self, data: str) -> DecodedMethodCallData:
         raw_bytes = eth_utils.hexadecimal.decode_hex(data)
-        # Check if we have the newer format with extra bytes
-        if len(raw_bytes) > 3 and raw_bytes[-1] == 0:
-            # Strip the first 2 bytes and the last null byte
-            raw_bytes = raw_bytes[2:-1]
+
+        # Remove the null byte
+        raw_bytes = raw_bytes[:-1]
+
+        # Try to decode the outer list first
+        if raw_bytes[0] >= 0xF8:  # Long list
+            raw_bytes = raw_bytes[2:]  # Skip list prefix and length
+        elif raw_bytes[0] >= 0xC0:  # Short list
+            raw_bytes = raw_bytes[1:]  # Skip list prefix
+
+        # Now try to decode the inner string
+        raw_bytes = rlp.decode(raw_bytes)
+
         return DecodedMethodCallData(raw_bytes)
 
     def decode_deployment_data(self, data: str) -> DecodedDeploymentData:


### PR DESCRIPTION
Fixes #DXP-368

# What

<!-- Describe the changes you made. -->

- Modified the `decode_method_call_data` method in `TransactionParser` to handle the decoding of method call data more robustly when arguments are passed.

# Why

<!-- Why are you making these changes? This should be related to the issue created, and the value we are adding with this PR -->

- To fix a bug related to incorrect decoding of method call data.

# Testing done

<!-- Describe the tests you ran to verify your changes. -->

- Tested the new decoding logic with various method call data inputs to ensure correct decoding.

# Decisions made

<!-- Describe any decisions made during the implementation of this PR. This should in general be in the code, but sometimes they are more related to the issue. For example: decisions on PR workflow -->

# Checks

- [x] I have tested this code
- [x] I have reviewed my own PR
- [x] I have created an issue for this PR
- [x] I have set a descriptive PR title compliant with [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)

# Reviewing tips

<!-- What can you tell the reviewer to make the review easier? -->

- Pay attention to the changes in the `decode_method_call_data` method, especially the handling of list prefixes and RLP decoding.

# User facing release notes

<!-- What should the user know about this change? Think of it going into public forums for end users to read -->

- Improved the decoding of method call data in transactions