### PR TITLE
feat: mock llm calls in integration tests

### DIFF
--- a/.github/workflows/backend_integration_tests_pr.yml
+++ b/.github/workflows/backend_integration_tests_pr.yml
@@ -51,6 +51,12 @@ jobs:
         run: |
           sed -i "s/<add_your_openai_api_key_here>/${OPENAIKEY}/g" .env
           sed -i "s/FINALITY_WINDOW =.*/FINALITY_WINDOW = 10/" .env
+          echo >> .env
+          if [[ "${{ needs.triggers.outputs.is_pull_request_review_approved }}" == "true" ]]; then
+            echo "TEST_WITH_MOCK_LLMS=false" >> .env
+          else
+            echo "TEST_WITH_MOCK_LLMS=true" >> .env
+          fi
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/backend/node/create_nodes/providers_schema.json
+++ b/backend/node/create_nodes/providers_schema.json
@@ -301,6 +301,9 @@
               "api_url": {
                 "type": ["string", "null"],
                 "$comment": "URL of the API endpoint. Leave empty to use the official OpenAI API endpoint."
+              },
+              "mock_response": {
+                "type": "object"
               }
             },
             "required": ["api_key_env_var", "api_url"]

--- a/backend/validators/__init__.py
+++ b/backend/validators/__init__.py
@@ -135,9 +135,12 @@ class Manager:
         current_validators: list[SingleValidatorSnapshot] = []
         for i in cur_validators_as_dict:
             val = domain.Validator.from_dict(i)
-            current_validators.append(
-                SingleValidatorSnapshot(val, {"studio_llm_id": f"node-{val.address}"})
-            )
+            host_data = {"studio_llm_id": f"node-{val.address}"}
+            if "mock_response" in val.llmprovider.plugin_config:
+                host_data["mock_response"] = val.llmprovider.plugin_config[
+                    "mock_response"
+                ]
+            current_validators.append(SingleValidatorSnapshot(val, host_data))
         return Snapshot(
             nodes=current_validators, genvm_config_path=self._genvm_config.new_path
         )

--- a/backend/validators/greyboxing.lua
+++ b/backend/validators/greyboxing.lua
@@ -1,12 +1,35 @@
 local lib = require("lib-greyboxing")
 local inspect = require("inspect")
 
+function get_mock_response_from_table(table, message)
+	for key, value in pairs(table) do
+		if string.find(message, key) then
+			return value
+		end
+	end
+	return "no match"
+end
+
 function just_in_backend(args, prompt, format)
 	local search_in = lib.select_backends_for(args, format)
 
 	lib.log{ args = args, prompt = prompt, format = format, search_in = search_in }
 
 	local handler = args.handler
+
+	if args.host_data and args.host_data.mock_response then
+		if args.payload then
+			if args.payload.principle then
+				result = get_mock_response_from_table(args.host_data.mock_response.eq_principle_prompt_comparative, prompt.user_message)
+			elseif args.payload.output then
+				result = get_mock_response_from_table(args.host_data.mock_response.eq_principle_prompt_non_comparative, prompt.user_message)
+			else
+				result = get_mock_response_from_table(args.host_data.mock_response.response, prompt.user_message)
+			end
+		end
+		lib.log{level = "debug", message = "executed with", type = type(result), res = result}
+		return result
+	end
 
 	local provider_id = args.host_data.studio_llm_id
 	local model = lib.get_first_from_table(greyboxing.available_backends[provider_id].models).key

--- a/tests/integration/icontracts/conftest.py
+++ b/tests/integration/icontracts/conftest.py
@@ -1,4 +1,6 @@
 import pytest
+import os
+from dotenv import load_dotenv
 
 from tests.common.request import payload, post_request_localhost
 from tests.common.response import has_success_status
@@ -6,14 +8,45 @@ from tests.common.response import has_success_status
 
 @pytest.fixture
 def setup_validators():
-    result = post_request_localhost(
-        payload("sim_createRandomValidators", 5, 8, 12, ["openai"], ["gpt-4o"])
-    ).json()
-    assert has_success_status(result)
+    def _setup(mock_response=None):
+        if mock_llms():
+            for _ in range(5):
+                result = post_request_localhost(
+                    payload(
+                        "sim_createValidator",
+                        8,
+                        "openai",
+                        "gpt-4o",
+                        {"temperature": 0.75, "max_tokens": 500},
+                        "openai-compatible",
+                        {
+                            "api_key_env_var": "OPENAIKEY",
+                            "api_url": "https://api.openai.com",
+                            "mock_response": mock_response,
+                        },
+                    )
+                ).json()
+                assert has_success_status(result)
+        else:
+            result = post_request_localhost(
+                payload("sim_createRandomValidators", 5, 8, 12, ["openai"], ["gpt-4o"])
+            ).json()
+            assert has_success_status(result)
 
-    yield
+    yield _setup
 
     delete_validators_result = post_request_localhost(
         payload("sim_deleteAllValidators")
     ).json()
     assert has_success_status(delete_validators_result)
+
+
+def mock_llms():
+    env_var = os.getenv("TEST_WITH_MOCK_LLMS", "false")  # default no mocking
+    if env_var == "true":
+        return True
+    return False
+
+
+def pytest_configure(config):
+    load_dotenv(override=True)

--- a/tests/integration/icontracts/conftest.py
+++ b/tests/integration/icontracts/conftest.py
@@ -22,7 +22,7 @@ def setup_validators():
                         {
                             "api_key_env_var": "OPENAIKEY",
                             "api_url": "https://api.openai.com",
-                            "mock_response": mock_response,
+                            "mock_response": mock_response if mock_response else {},
                         },
                     )
                 ).json()

--- a/tests/integration/icontracts/tests/test_football_prediction_market.py
+++ b/tests/integration/icontracts/tests/test_football_prediction_market.py
@@ -1,12 +1,29 @@
 # tests/e2e/test_storage.py
 from gltest import get_contract_factory
 from gltest.assertions import tx_execution_succeeded
+import json
 
 
 def test_football_prediction_market(setup_validators):
+    team_1 = "Georgia"
+    team_2 = "Portugal"
+    score = "2:0"
+    winner = 1
+    mock_response = {
+        "response": {
+            f"Team 1: {team_1}\nTeam 2: {team_2}": json.dumps(
+                {
+                    "score": score,
+                    "winner": winner,
+                }
+            ),
+        }
+    }
+    setup_validators(mock_response)
+
     # Deploy Contract
     factory = get_contract_factory("PredictionMarket")
-    contract = factory.deploy(args=["2024-06-26", "Georgia", "Portugal"])
+    contract = factory.deploy(args=["2024-06-26", team_1, team_2])
 
     ########################################
     ############# RESOLVE match ############
@@ -21,6 +38,6 @@ def test_football_prediction_market(setup_validators):
     # Get Updated State
     contract_state_2 = contract.get_resolution_data(args=[])
 
-    assert contract_state_2["winner"] == 1
-    assert contract_state_2["score"] == "2:0"
+    assert contract_state_2["winner"] == winner
+    assert contract_state_2["score"] == score
     assert contract_state_2["has_resolved"] == True

--- a/tests/integration/icontracts/tests/test_intelligent_oracle_factory_pattern.py
+++ b/tests/integration/icontracts/tests/test_intelligent_oracle_factory_pattern.py
@@ -2,6 +2,7 @@ import time
 
 from gltest import get_contract_factory
 from gltest.assertions import tx_execution_succeeded
+import json
 
 
 def wait_for_contract_deployment(intelligent_oracle_contract, max_retries=10, delay=5):
@@ -19,6 +20,83 @@ def wait_for_contract_deployment(intelligent_oracle_contract, max_retries=10, de
 
 
 def test_intelligent_oracle_factory_pattern(setup_validators):
+    markets_data = [
+        {
+            "prediction_market_id": "marathon2024",
+            "title": "Marathon Winner Prediction",
+            "description": "Predict the male winner of a major marathon event.",
+            "potential_outcomes": ["Bekele Fikre", "Tafa Mitku", "Chebii Douglas"],
+            "rules": [
+                "The outcome is based on the official race results announced by the marathon organizers."
+            ],
+            "data_source_domains": ["thepostrace.com"],
+            "resolution_urls": [],
+            "earliest_resolution_date": "2024-01-01T00:00:00+00:00",
+            "outcome": "Tafa Mitku",
+            "evidence_urls": "https://thepostrace.com/en/blog/marathon-de-madrid-2024-results-and-rankings/?srsltid=AfmBOor1uG6O3_4oJ447hkah_ilOYuy0XXMvl8j70EApe1Z7Bzd94XJl",
+        },
+        {
+            "prediction_market_id": "election2024",
+            "title": "Election Prediction",
+            "description": "Predict the winner of the 2024 US presidential election.",
+            "potential_outcomes": ["Kamala Harris", "Donald Trump"],
+            "rules": ["The outcome is based on official election results."],
+            "data_source_domains": ["bbc.com"],
+            "resolution_urls": [],
+            "earliest_resolution_date": "2024-01-01T00:00:00+00:00",
+            "outcome": "Donald Trump",
+            "evidence_urls": "https://www.bbc.com/news/election/2024/us/results",
+        },
+    ]
+
+    reasoning_single_source_marathon = "The HTML content contains the results of the Madrid Marathon 2024, which occurred on April 28, 2024. Mitku Tafa won and matches the name 'Tafa Mitku' in the list of potential outcomes."
+    reasoning_all_sources_marathon = "The URL indicates that the Madrid Marathon 2024 has occurred on April 28, 2024, and Mitku Tafa was the winner. The name matches one of the potential outcomes. There are no conflicting sources."
+    reasoning_single_source_election = "The URL is a valid news page. The election has occurred, and Donald Trump is reported to have won with 312 votes. The rule specifies that the outcome is based on official election results."
+    reasoning_all_sources_election = "The only data source provided is from BBC News. It reports that Donald Trump won the 2024 US presidential election with 312 votes. The rule specifies that the outcome is based on official election results. There are no other sources contradicting this information."
+
+    mock_response = {
+        "response": {
+            f"outcomes.\n\n### Inputs\n<title>\n{markets_data[0]['title']}": json.dumps(
+                {
+                    "valid_source": "true",
+                    "event_has_occurred": "true",
+                    "reasoning": reasoning_single_source_marathon,
+                    "outcome": markets_data[0]["outcome"],
+                }
+            ),
+            f"inputs\n\n    ### Inputs\n    <title>\n    {markets_data[0]['title']}\n": json.dumps(
+                {
+                    "relevant_sources": [markets_data[0]["evidence_urls"]],
+                    "reasoning": reasoning_all_sources_marathon,
+                    "outcome": markets_data[0]["outcome"],
+                }
+            ),
+            f"outcomes.\n\n### Inputs\n<title>\n{markets_data[1]['title']}": json.dumps(
+                {
+                    "valid_source": "true",
+                    "event_has_occurred": "true",
+                    "reasoning": reasoning_single_source_election,
+                    "outcome": markets_data[1]["outcome"],
+                }
+            ),
+            f"inputs\n\n    ### Inputs\n    <title>\n    {markets_data[1]['title']}\n": json.dumps(
+                {
+                    "relevant_sources": [markets_data[1]["evidence_urls"]],
+                    "reasoning": reasoning_all_sources_election,
+                    "outcome": markets_data[1]["outcome"],
+                }
+            ),
+        },
+        "eq_principle_prompt_comparative": {
+            reasoning_single_source_marathon: True,
+            reasoning_all_sources_marathon: True,
+            reasoning_single_source_election: True,
+            reasoning_all_sources_election: True,
+        },
+    }
+
+    setup_validators(mock_response)
+
     # Get the intelligent oracle factory
     intelligent_oracle_factory = get_contract_factory("IntelligentOracle")
 

--- a/tests/integration/icontracts/tests/test_llm_erc20.py
+++ b/tests/integration/icontracts/tests/test_llm_erc20.py
@@ -1,6 +1,7 @@
 # tests/e2e/test_storage.py
 from gltest import get_contract_factory, default_account, create_account
 from gltest.assertions import tx_execution_succeeded
+import json
 
 TOKEN_TOTAL_SUPPLY = 1000
 TRANSFER_AMOUNT = 100
@@ -10,6 +11,23 @@ def test_llm_erc20(setup_validators):
     # Account Setup
     from_account_a = default_account
     from_account_b = create_account()
+
+    mock_response = {
+        "response": {
+            "The balance of the sender": json.dumps(
+                {
+                    "transaction_success": True,
+                    "transaction_error": "",
+                    "updated_balances": {
+                        from_account_a.address: TOKEN_TOTAL_SUPPLY - TRANSFER_AMOUNT,
+                        from_account_b.address: TRANSFER_AMOUNT,
+                    },
+                }
+            )
+        },
+        "eq_principle_prompt_non_comparative": {"The balance of the sender": True},
+    }
+    setup_validators(mock_response)
 
     # Deploy Contract
     factory = get_contract_factory("LlmErc20")

--- a/tests/integration/icontracts/tests/test_log_indexer.py
+++ b/tests/integration/icontracts/tests/test_log_indexer.py
@@ -9,6 +9,7 @@ from tests.common.response import assert_dict_struct
 
 
 def test_log_indexer(setup_validators):
+    setup_validators()
     # Deploy Contract
     factory = get_contract_factory("LogIndexer")
     contract = factory.deploy(args=[])

--- a/tests/integration/icontracts/tests/test_multi_file_contract.py
+++ b/tests/integration/icontracts/tests/test_multi_file_contract.py
@@ -3,6 +3,7 @@ from gltest.assertions import tx_execution_succeeded
 
 
 def test_deploy(setup_validators):
+    setup_validators()
     factory = get_contract_factory("MultiFileContract")
     contract = factory.deploy(args=[])
 

--- a/tests/integration/icontracts/tests/test_multi_read_erc20.py
+++ b/tests/integration/icontracts/tests/test_multi_read_erc20.py
@@ -15,6 +15,7 @@ def test_multi_read_erc20(setup_validators):
 
     This test demonstrates the integration contract to contract reads
     """
+    setup_validators()
     TOKEN_TOTAL_SUPPLY = 1000
     from_account_doge = create_account()
     from_account_shiba = create_account()

--- a/tests/integration/icontracts/tests/test_multi_tenant_storage.py
+++ b/tests/integration/icontracts/tests/test_multi_tenant_storage.py
@@ -15,6 +15,7 @@ def test_multi_tenant_storage(setup_validators):
 
     This test demonstrates contract-to-contract interactions and multi-tenant data management.
     """
+    setup_validators()
     user_account_a = create_account()
     user_account_b = create_account()
 

--- a/tests/integration/icontracts/tests/test_read_erc20.py
+++ b/tests/integration/icontracts/tests/test_read_erc20.py
@@ -11,6 +11,7 @@ def test_read_erc20(setup_validators):
 
     It's like a linked list, but with contracts.
     """
+    setup_validators()
     TOKEN_TOTAL_SUPPLY = 1000
 
     # LLM ERC20

--- a/tests/integration/icontracts/tests/test_storage.py
+++ b/tests/integration/icontracts/tests/test_storage.py
@@ -14,6 +14,7 @@ UPDATED_STATE = "b"
 
 
 def test_storage(setup_validators):
+    setup_validators()
     factory = get_contract_factory("Storage")
     contract = factory.deploy(args=[INITIAL_STATE])
 

--- a/tests/integration/icontracts/tests/test_user_storage.py
+++ b/tests/integration/icontracts/tests/test_user_storage.py
@@ -15,6 +15,7 @@ UPDATED_STATE_USER_B = "user_b_updated_state"
 
 
 def test_user_storage(setup_validators):
+    setup_validators()
     # Account Setup
     from_account_a = default_account
     from_account_b = create_account()

--- a/tests/integration/icontracts/tests/test_wizard_of_coin.py
+++ b/tests/integration/icontracts/tests/test_wizard_of_coin.py
@@ -1,9 +1,25 @@
 # tests/e2e/test_wizard_of_coin.py
 from gltest import get_contract_factory
 from gltest.assertions import tx_execution_succeeded
+import json
 
 
 def test_wizard_of_coin(setup_validators):
+    mock_response = {
+        "response": {
+            "wizard": json.dumps(
+                {
+                    "reasoning": "I am a grumpy wizard and I never give away my coins!",
+                    "give_coin": False,
+                }
+            ),
+        },
+        "eq_principle_prompt_comparative": {
+            "The value of give_coin has to match": True
+        },
+    }
+    setup_validators(mock_response)
+
     factory = get_contract_factory("WizardOfCoin")
     contract = factory.deploy(args=[True])
 


### PR DESCRIPTION
Fixes #DXP-65

# What

<!-- Describe the changes you made. -->

- Updated the `.github/workflows/backend_integration_tests_pr.yml` to conditionally set `TEST_WITH_MOCK_LLMS` in the `.env` file based on whether a pull request review is approved or not.
- Added a `mock_response` field to the `providers_schema.json` to support mock responses in testing.
- Modified the `Manager` class in `backend/validators/__init__.py` to include `mock_response` in the `host_data` if available.
- Implemented a new function `get_mock_response_from_table` in `backend/validators/greyboxing.lua` to retrieve mock responses based on message content. It will select the right response based on a matching string. This function is needed to respond differently when there are multiple prompts or multiple equivalence principles.
- Enhanced the `setup_validators` fixture in `tests/integration/icontracts/conftest.py` to support mock responses.
- Updated various test files to utilize the `setup_validators` fixture with mock responses for more controlled testing scenarios.

# Why

<!-- Why are you making these changes? This should be related to the issue created, and the value we are adding with this PR -->

To ensure that integration tests can simulate different scenarios without relying on external API calls.

# Testing done

<!-- Describe the tests you ran to verify your changes. -->

- Verified that the `.env` file is correctly updated with `TEST_WITH_MOCK_LLMS` during workflow runs.
- Ran integration tests with mock responses to ensure they pass and behave as expected.

# Decisions made

<!-- Describe any decisions made during the implementation of this PR. This should in general be in the code, but sometimes they are more related to the issue. For example: decisions on PR workflow -->

- Chose to conditionally set `TEST_WITH_MOCK_LLMS` based on PR review status.
- Decided to not make a mock provider in the provider_schema used to validate. Instead I adapted the openai one.
- Decided to use a hardcoded input string instead of using AST python package to decode the contract class code. In s simple contract, this string can be empty. It is used to differentiate what response to pick when a contract function uses multiple gl.exec_prompt and multiple gl.eq_principle_. Or when you want to test the contract with different input arguments of the contract function like in the intelligent oracle test. It is basically a string that will be present in prompt.user_message of the lua script which contains the whole prompt with filled in f-strings/function calls/data member calls/principle, criteria, input, task/leader_answer, validator_answer.
- Future improvements:
   - Set responses specifically for each leader/validator. Now all 5 contain the same response. Overwrite the vrf get_validators_for_transaction function to know who will be the leader.
   - Change lua script's if statement check for eq_principles in a dynamic way when a user can make their own eq_principle somehow.

# Checks

- [x] I have tested this code
- [x] I have reviewed my own PR
- [x] I have created an issue for this PR
- [x] I have set a descriptive PR title compliant with [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)

# Reviewing tips

<!-- What can you tell the reviewer to make the review easier? -->

- Focus on the changes in the testing framework and how mock responses are integrated.
- Review the logic in `greyboxing.lua` for handling mock responses to ensure it aligns with expected behavior.

# User facing release notes

<!-- What should the user know about this change? Think of it going into public forums for end users to read -->

Improved testing framework with support for mocking llm calls.