### PR TITLE
feat: configurable Chain ID

### DIFF
--- a/backend/node/base.py
+++ b/backend/node/base.py
@@ -19,7 +19,18 @@ from backend.protocol_rpc.message_handler.base import MessageHandler
 
 from .types import Address
 
-SIMULATOR_CHAIN_ID: typing.Final[int] = int(os.getenv("HARDHAT_CHAIN_ID", "61999"))
+
+def _parse_chain_id() -> int:
+    raw = os.getenv("HARDHAT_CHAIN_ID", "61999")
+    try:
+        return int(raw)
+    except ValueError as exc:
+        raise ValueError(
+            f"HARDHAT_CHAIN_ID must be decimal digits, got '{raw}'"
+        ) from exc
+
+
+SIMULATOR_CHAIN_ID: typing.Final[int] = _parse_chain_id()
 
 
 class _SnapshotView(genvmbase.StateProxy):

--- a/backend/node/base.py
+++ b/backend/node/base.py
@@ -19,7 +19,7 @@ from backend.protocol_rpc.message_handler.base import MessageHandler
 
 from .types import Address
 
-SIMULATOR_CHAIN_ID: typing.Final[int] = 61999
+SIMULATOR_CHAIN_ID: typing.Final[int] = int(os.getenv("HARDHAT_CHAIN_ID", "61999"))
 
 
 class _SnapshotView(genvmbase.StateProxy):
@@ -325,6 +325,7 @@ class Node:
             config_path=config_path,
             host_data=host_data,
         )
+        print("bla", SIMULATOR_CHAIN_ID)
 
         if res is None:
             res = genvmbase.ExecutionResult(

--- a/backend/node/base.py
+++ b/backend/node/base.py
@@ -325,7 +325,6 @@ class Node:
             config_path=config_path,
             host_data=host_data,
         )
-        print("bla", SIMULATOR_CHAIN_ID)
 
         if res is None:
             res = genvmbase.ExecutionResult(

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -173,6 +173,8 @@ services:
       dockerfile: docker/Dockerfile.hardhat
     ports:
       - "${HARDHAT_PORT:-8545}:8545"
+    env_file:
+      - .env
     volumes:
       - ./hardhat:/app/hardhat_src
       - hardhat_artifacts:/app/artifacts

--- a/hardhat/hardhat.config.js
+++ b/hardhat/hardhat.config.js
@@ -31,7 +31,7 @@ module.exports = {
           order: "fifo"
         }
       },
-      chainId: 61_999,
+      chainId: parseInt(process.env.HARDHAT_CHAIN_ID || "61999"),
       gasPrice: 0,
       initialBaseFeePerGas: 0,
       blockGasLimit: 20000000000,
@@ -45,7 +45,7 @@ module.exports = {
           order: "fifo"
         }
       },
-      chainId: 61_999,
+      chainId: parseInt(process.env.HARDHAT_CHAIN_ID || "61999"),
       gasPrice: 0,
       initialBaseFeePerGas: 0,
       blockGasLimit: 20000000000,


### PR DESCRIPTION
Fixes #DXP-332

# What

- Changed the `SIMULATOR_CHAIN_ID` to be dynamically set using an environment variable `HARDHAT_CHAIN_ID` with a default value of `61999`.
- Updated the `docker-compose.yml` to include an `env_file` for hardhat.
- Modified `hardhat.config.js` to use `process.env.HARDHAT_CHAIN_ID` for setting the `chainId`.

# Why

- To provide more flexibility in different environments.

# Testing done

- Verified that the backend correctly reads the `HARDHAT_CHAIN_ID` from the environment.
- Confirmed that the `hardhat` configuration uses the environment variable for `chainId`.

# Decisions made

# Checks

- [x] I have tested this code
- [x] I have reviewed my own PR
- [x] I have created an issue for this PR
- [x] I have set a descriptive PR title compliant with [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)

# Reviewing tips

- Focus on the changes related to environment variable usage and ensure they align with the project's configuration management practices.

# User facing release notes

- The `SIMULATOR_CHAIN_ID` and `hardhat` `chainId` can now be configured via the `HARDHAT_CHAIN_ID` environment variable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for configuring the chain ID dynamically via an environment variable, allowing for greater flexibility at runtime.

- **Chores**
  - Updated container configuration to load environment variables from a `.env` file for improved environment management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->