### PR TITLE
fix: merging removed index selection

### DIFF
--- a/backend/protocol_rpc/server.py
+++ b/backend/protocol_rpc/server.py
@@ -200,8 +200,8 @@ def restore_stuck_transactions():
         )
         if tx1_finalized:
             previous_contact_state = tx1_finalized["consensus_data"]["leader_receipt"][
-                "contract_state"
-            ]
+                0
+            ]["contract_state"]
             contract_processor.update_contract_state(
                 contract_address=tx1_finalized["to_address"],
                 accepted_state=previous_contact_state,
@@ -214,7 +214,7 @@ def restore_stuck_transactions():
             if tx1_accepted:
                 previous_contact_state = tx1_accepted["consensus_data"][
                     "leader_receipt"
-                ]["contract_state"]
+                ][0]["contract_state"]
                 contract_processor.update_contract_state(
                     contract_address=tx1_accepted["to_address"],
                     accepted_state=previous_contact_state,


### PR DESCRIPTION
Fixes #DXP-393
# What

<!-- Describe the changes you made. -->

Updated the indexing of `leader_receipt` to access the first element before retrieving `contract_state` in the `restore_stuck_transactions` function.

# Why

<!-- Why are you making these changes? This should be related to the issue created, and the value we are adding with this PR -->

To fix a bug where `contract_state` key could not be retrieved from a list.

# Testing done

<!-- Describe the tests you ran to verify your changes. -->

Tested in studio UI by having tx1 finalized and tx2 in a stuck state.

# Decisions made

<!-- Describe any decisions made during the implementation of this PR. This should in general be in the code, but sometimes they are more related to the issue. For example: decisions on PR workflow -->

# Checks

- [x] I have tested this code
- [x] I have reviewed my own PR
- [x] I have created an issue for this PR
- [x] I have set a descriptive PR title compliant with [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)

# Reviewing tips

<!-- What can you tell the reviewer to make the review easier? -->

Focus on the changes in the `restore_stuck_transactions` function to ensure the indexing change is correct and does not introduce any new issues.

# User facing release notes

<!-- What should the user know about this change? Think of it going into public forums for end users to read -->

Fixed an issue where the incorrect contract state was being accessed during transaction restoration.