### PR TITLE
fix: parse_transaction leader_receipts handling can be accessed for o…

### DIFF
--- a/backend/database_handler/transactions_processor.py
+++ b/backend/database_handler/transactions_processor.py
@@ -40,7 +40,9 @@ class TransactionsProcessor:
     def _parse_transaction_data(transaction_data: Transactions) -> dict:
         if transaction_data.consensus_data:
             leader_receipts = transaction_data.consensus_data.get("leader_receipt", [])
-            if len(leader_receipts) > 0:
+            if isinstance(leader_receipts, dict):
+                result = leader_receipts.get("result", {})
+            elif isinstance(leader_receipts, list) and len(leader_receipts) > 0:
                 result = leader_receipts[0].get("result", {})
             else:
                 result = {}


### PR DESCRIPTION
Fixes #DXP-399

# What

<!-- Describe the changes you made. -->

- Modified the `_parse_transaction_data` method in `TransactionsProcessor` to handle `leader_receipts` when it is a dictionary for old tx or a list for new tx.

# Why

<!-- Why are you making these changes? This should be related to the issue created, and the value we are adding with this PR -->

- To fix a bug where `leader_receipts` could be a dictionary.

# Testing done

<!-- Describe the tests you ran to verify your changes. -->

- None

# Decisions made

<!-- Describe any decisions made during the implementation of this PR. This should in general be in the code, but sometimes they are more related to the issue. For example: decisions on PR workflow -->

# Checks

- [x] I have tested this code
- [x] I have reviewed my own PR
- [x] I have created an issue for this PR
- [x] I have set a descriptive PR title compliant with [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)

# Reviewing tips

<!-- What can you tell the reviewer to make the review easier? -->

- Focus on the changes.

# User facing release notes

<!-- What should the user know about this change? Think of it going into public forums for end users to read -->

- Improved the robustness of transaction data parsing by handling different data structures for `leader_receipts` to be backward compatible.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of transaction data to support both list and dictionary formats for leader receipts, ensuring more robust and reliable transaction processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->