### PR TITLE
fix: change webrequest to webdriver

### DIFF
--- a/.github/workflows/docker-build-and-push-all.yml
+++ b/.github/workflows/docker-build-and-push-all.yml
@@ -35,8 +35,8 @@ jobs:
     uses: ./.github/workflows/docker-build-and-push-image.yml
     with:
       docker_build_context: .
-      dockerfile: docker/Dockerfile.webrequest
-      dockerhub_repo: yeagerai/simulator-webrequest
+      dockerfile: docker/Dockerfile.webdriver
+      dockerhub_repo: yeagerai/simulator-webdriver
       dockerhub_username: ${{ vars.DOCKERHUB_USERNAME }}
     secrets:
       dockerhub_token: ${{ secrets.DOCKERHUB_TOKEN }}


### PR DESCRIPTION
Fixes #DXP-432
# What

<!-- Describe the changes you made. -->

- Changed the Dockerfile reference from `docker/Dockerfile.webrequest` to `docker/Dockerfile.webdriver`.
- Updated the Docker Hub repository from `yeagerai/simulator-webrequest` to `yeagerai/simulator-webdriver`.

# Why

<!-- Why are you making these changes? This should be related to the issue created, and the value we are adding with this PR -->

Push to DockerHub in Release to Main fails.
https://github.com/genlayerlabs/genlayer-studio/actions/workflows/release-from-main.yml

# Testing done

<!-- Describe the tests you ran to verify your changes. -->

Not tested

# Decisions made

<!-- Describe any decisions made during the implementation of this PR. This should in general be in the code, but sometimes they are more related to the issue. For example: decisions on PR workflow -->

I believe nginx dockerfile doesn't need to be uploaded .

# Checks

- [ ] I have tested this code
- [x] I have reviewed my own PR
- [x] I have created an issue for this PR
- [x] I have set a descriptive PR title compliant with [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)

# Reviewing tips

<!-- What can you tell the reviewer to make the review easier? -->

Focus on the changes in the Dockerfile and repository references to ensure they align with the intended project structure.

# User facing release notes

<!-- What should the user know about this change? Think of it going into public forums for end users to read -->

The Docker build and push process now uses the updated `webdriver` configuration.