### PR TITLE
feat: mock response to a custom made eq principle

### DIFF
--- a/tests/integration/icontracts/contracts/company_naming.py
+++ b/tests/integration/icontracts/contracts/company_naming.py
@@ -1,0 +1,91 @@
+# { "Depends": "py-genlayer:test" }
+
+import json
+from genlayer import *
+
+MAX_SCORE_DIFFERENCE = 3
+
+
+class CompanyNaming(gl.Contract):
+    scores: TreeMap[str, u256]
+
+    def __init__(self):
+        pass
+
+    @gl.public.write
+    def score_alignment(self, company_name: str, description: str) -> int:
+        """Score how well a company name aligns with its description."""
+
+        task = f"""
+You are an expert business analyst specializing in brand alignment. Your task is to analyze how well a company name aligns with its description and provide a score from 0 to 10.
+
+Scoring criteria:
+1. Relevance (0-2 points)
+- Does the name reflect the company's industry or purpose?
+
+2. Memorability (0-2 points)
+- Is the name distinctive and easy to remember?
+
+3. Description Match (0-4 points)
+- How well does the name capture the key elements in the description?
+- Does it reflect the company's unique value proposition?
+
+4. Brand Potential (0-2 points)
+- Does the combination of name and description create a cohesive brand identity?
+
+Company Name: {company_name}
+Description: {description}
+
+Output format - Respond using ONLY the following format:
+{{
+"analysis": str detailed analysis of name-description alignment,
+"score": int between 0-10 being the overall alignment score>
+}}
+It is mandatory that you respond only using the JSON format above,
+nothing else. Don't include any other words or characters,
+your output must be only JSON without any formatting prefix or suffix.
+This result should be perfectly parseable by a JSON parser without errors.
+"""
+
+        def leader_fn():
+            result = gl.nondet.exec_prompt(task)
+            result = _extract_json_from_string(result)
+            result = json.loads(result)
+            return result
+
+        def validator_fn(
+            leaders_res: gl.vm.Result,
+        ) -> bool:
+            leaders_res = gl.vm.unpack_result(leaders_res)
+            validators_res = gl.vm.spawn_sandbox(leader_fn)
+            validators_res = gl.vm.unpack_result(validators_res)
+            result = (
+                abs(validators_res["score"] - leaders_res["score"])
+                <= MAX_SCORE_DIFFERENCE
+            )
+            return result
+
+        analysis = gl.vm.run_nondet(leader_fn, validator_fn)
+
+        # Store the result
+        score = analysis["score"]
+        self.scores[company_name] = score
+
+        return score
+
+    @gl.public.view
+    def get_score(self, company_name: str) -> int:
+        """Retrieve a previously computed score."""
+        if company_name in self.scores:
+            return self.scores[company_name]
+        else:
+            return 0
+
+
+def _extract_json_from_string(s: str) -> str:
+    start_index = s.find("{")
+    end_index = s.rfind("}")
+    if start_index != -1 and end_index != -1 and start_index < end_index:
+        return s[start_index : end_index + 1]
+    else:
+        return ""

--- a/tests/integration/icontracts/tests/test_company_naming.py
+++ b/tests/integration/icontracts/tests/test_company_naming.py
@@ -1,0 +1,35 @@
+# tests/e2e/test_company_naming.py
+from gltest import get_contract_factory
+from gltest.assertions import tx_execution_succeeded
+import json
+
+
+def test_company_naming(setup_validators):
+    mock_response = {
+        "response": {
+            "expert business analyst": json.dumps(
+                {
+                    "analysis": "The company name 'GenLayer' aligns reasonably well with its description. For relevance, it scores 2 points because 'Gen' could imply generation or general, aligning with the creation and management role of the digital court and jurisdiction, while 'Layer' suggests a foundational or infrastructural role, relevant to the concept of a trust layer. In terms of memorability, it scores 2 points as 'GenLayer' is distinctive and easy to remember. For description match, it scores 3 points. The name captures the essence of a foundational layer but does not fully convey the complexity of the decentralized digital court or intelligent contracts. Lastly, for brand potential, it scores 2 points. The name and description together create a cohesive and futuristic brand identity, suggesting innovation in digital governance and contract enforcement.",
+                    "score": 9,
+                }
+            ),
+        },
+    }
+
+    setup_validators(mock_response)
+
+    factory = get_contract_factory("CompanyNaming")
+    contract = factory.deploy(args=[])
+
+    company_name = "GenLayer"
+    description = "Al-native trust layer and synthetic jurisdiction on-chain. Validators running diverse language models act as a decentralized digital court, resolving disputes and enforcing contracts. Intelligent Contracts interpret language, process unstructured data, and pull live web inputs, enabling autonomous systems to transact, govern, and settle decisions at machine speed."
+    transaction_response_call_1 = contract.score_alignment(
+        args=[company_name, description]
+    )
+    assert tx_execution_succeeded(transaction_response_call_1)
+
+    score = contract.get_score(args=[company_name])
+
+    assert (
+        score != 0
+    )  # it means there was een agreement. The score is determined by the LLM so we cannot hardcode it to a specific value.


### PR DESCRIPTION
Fixes #DXP-406

# What

<!-- Describe the changes you made. -->

- Added a new contract `CompanyNaming` in `tests/integration/icontracts/contracts/company_naming.py` to score company names based on their alignment with descriptions.
- Implemented a test for the `CompanyNaming` contract in `tests/integration/icontracts/tests/test_company_naming.py`.

# Why

<!-- Why are you making these changes? This should be related to the issue created, and the value we are adding with this PR -->

To test the mocking behaviour when using a custom equivalence principle.

# Testing done

<!-- Describe the tests you ran to verify your changes. -->

Ran the added testcase with and without mocking.

# Decisions made

<!-- Describe any decisions made during the implementation of this PR. This should in general be in the code, but sometimes they are more related to the issue. For example: decisions on PR workflow -->

`backend/validators/greyboxing.lua` file does not need any adaptation to work. The leader and validator functions are using exec_prompt which is already supported by the mocking implementation. Both function will always use exec_prompt or get webpage data or do some code calculations. We can influence the leader and validator outputs obtained by calculations with the responses we set, so no need to filter in the lua file like with did with `args.template == "EqComparative"` (not that we can do that because the template value does not exist).

# Checks

- [x] I have tested this code
- [x] I have reviewed my own PR
- [x] I have created an issue for this PR
- [x] I have set a descriptive PR title compliant with [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)

# Reviewing tips

<!-- What can you tell the reviewer to make the review easier? -->

See code changes and decisions made.

# User facing release notes

<!-- What should the user know about this change? Think of it going into public forums for end users to read -->

Introduced a new test to check the mocking behaviour of the custom equivalence.