### PR TITLE
fix: remove webdriver publishing

### DIFF
--- a/.github/workflows/docker-build-and-push-all.yml
+++ b/.github/workflows/docker-build-and-push-all.yml
@@ -31,16 +31,6 @@ jobs:
     secrets:
       dockerhub_token: ${{ secrets.DOCKERHUB_TOKEN }}
 
-  webdriver:
-    uses: ./.github/workflows/docker-build-and-push-image.yml
-    with:
-      docker_build_context: .
-      dockerfile: docker/Dockerfile.webdriver
-      dockerhub_repo: yeagerai/simulator-webdriver
-      dockerhub_username: ${{ vars.DOCKERHUB_USERNAME }}
-    secrets:
-      dockerhub_token: ${{ secrets.DOCKERHUB_TOKEN }}
-
   database-migration:
     uses: ./.github/workflows/docker-build-and-push-image.yml
     with:


### PR DESCRIPTION
Fixes #DXP-448
# What

<!-- Describe the changes you made. -->

Removed the `webdriver` job from the `.github/workflows/docker-build-and-push-all.yml` file.

# Why

<!-- Why are you making these changes? This should be related to the issue created, and the value we are adding with this PR -->

We do not need to push it. Genvm does that.

# Testing done

<!-- Describe the tests you ran to verify your changes. -->


# Decisions made

<!-- Describe any decisions made during the implementation of this PR. This should in general be in the code, but sometimes they are more related to the issue. For example: decisions on PR workflow -->


# Checks

- [x] I have tested this code
- [x] I have reviewed my own PR
- [x] I have created an issue for this PR
- [x] I have set a descriptive PR title compliant with [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)

# Reviewing tips

<!-- What can you tell the reviewer to make the review easier? -->

Focus on the impact of removing the `webdriver` job on the all projects.

# User facing release notes

<!-- What should the user know about this change? Think of it going into public forums for end users to read -->

Removed an unnecessary job from CI/CD pipeline.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed the workflow job responsible for building and pushing the Docker image for the simulator-webdriver. No other workflow functionality was changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->