### PR TITLE
feat: update studio version through release process

### DIFF
--- a/.github/workflows/release-from-main.yml
+++ b/.github/workflows/release-from-main.yml
@@ -28,7 +28,7 @@ jobs:
         with:
           node-version: "lts/*"
       - name: Install dependencies
-        run: npm install @semantic-release/github @semantic-release/release-notes-generator @semantic-release/commit-analyzer conventional-changelog-conventionalcommits
+        run: npm install @semantic-release/github @semantic-release/release-notes-generator @semantic-release/commit-analyzer @semantic-release/npm conventional-changelog-conventionalcommits
       - name: Release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "genlayer-simulator",
+  "name": "genlayer-studio",
   "version": "0.0.0",
   "private": true,
   "type": "module",

--- a/release.config.js
+++ b/release.config.js
@@ -32,7 +32,8 @@ module.exports = {
         [
             "@semantic-release/npm",
             {
-                "pkgRoot": "frontend"
+                "pkgRoot": "frontend",
+                "npmPublish": false
             }
         ],
         '@semantic-release/github',

--- a/release.config.js
+++ b/release.config.js
@@ -29,6 +29,12 @@ module.exports = {
                 },
             }
         ],
+        [
+            "@semantic-release/npm",
+            {
+                "pkgRoot": "frontend"
+            }
+        ],
         '@semantic-release/github',
     ]
 };


### PR DESCRIPTION
Fixes #DXP-81

# What

- Updated package name from `genlayer-simulator` to `genlayer-studio` in frontend
- Added `@semantic-release/npm` to the release workflow configuration
- Configured semantic-release to handle npm package versioning for frontend without publishing

# Why

- To properly version the frontend package using semantic-release
- To align package naming with the project's current branding

# Testing done

Not tested. It needs to be in main to test.

# Decisions made

# Checks

- [ ] I have tested this code
- [x] I have reviewed my own PR
- [x] I have created an issue for this PR
- [x] I have set a descriptive PR title compliant with [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)

# Reviewing tips

- Focus on the semantic-release configuration changes in `release.config.js`
- Check that the package name change is consistently applied

# User facing release notes

This change improves our release process by properly versioning the frontend package. The package has been renamed from genlayer-simulator to genlayer-studio to better reflect the project's branding.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated project name in the frontend metadata.
  * Enhanced release workflow to support npm package handling from the frontend directory.
  * Improved release process configuration for better integration with npm package management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->