### PR TITLE
feat: implement sim_studio_version method

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,6 @@
 # Items that don't need to be in a Docker image.
 # Anything not used by the build system should go here.
-.git
+# .git  # Allowed for version detection during build
 .dockerignore
 .gitignore
 .github/

--- a/.github/workflows/release-from-main.yml
+++ b/.github/workflows/release-from-main.yml
@@ -28,7 +28,7 @@ jobs:
         with:
           node-version: "lts/*"
       - name: Install dependencies
-        run: npm install @semantic-release/github @semantic-release/release-notes-generator @semantic-release/commit-analyzer @semantic-release/npm conventional-changelog-conventionalcommits
+        run: npm install @semantic-release/github @semantic-release/release-notes-generator @semantic-release/commit-analyzer conventional-changelog-conventionalcommits
       - name: Release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/backend/protocol_rpc/endpoints.py
+++ b/backend/protocol_rpc/endpoints.py
@@ -1044,6 +1044,27 @@ def delete_all_snapshots(
     return {"deleted_count": deleted_count}
 
 
+def get_simulator_version() -> str:
+    """Get the current version of the simulator."""
+    try:
+        with open("/app/version.txt", "r") as f:
+            # Read first line which contains the studio version
+            return f.readline().strip()
+    except (FileNotFoundError, IOError):
+        return "0.0.0"
+
+
+def get_genvm_version() -> str:
+    """Get the current version of the GenVM."""
+    try:
+        with open("/app/version.txt", "r") as f:
+            # Skip first line (studio version) and read second line (genvm version)
+            f.readline()
+            return f.readline().strip()
+    except (FileNotFoundError, IOError):
+        return "0.0.0"
+
+
 def register_all_rpc_endpoints(
     jsonrpc: JSONRPC,
     msg_handler: MessageHandler,
@@ -1253,3 +1274,5 @@ def register_all_rpc_endpoints(
         partial(delete_all_snapshots, snapshot_manager),
         method_name="sim_deleteAllSnapshots",
     )
+    register_rpc_endpoint(get_simulator_version, method_name="gen_protocolVersion")
+    register_rpc_endpoint(get_genvm_version, method_name="sim_genvmVersion")

--- a/docker/Dockerfile.backend
+++ b/docker/Dockerfile.backend
@@ -1,7 +1,6 @@
 FROM ubuntu:24.04 AS base
 
 ARG TARGETPLATFORM
-
 ARG GENVM_TAG=v0.1.3
 
 ARG path=/app
@@ -10,7 +9,7 @@ WORKDIR $path
 SHELL ["/bin/bash", "-x", "-c"]
 RUN apt-get update -y \
     && DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC apt-get install -y --no-install-recommends \
-        curl unzip xz-utils ca-certificates python3.12 libssl3 \
+        curl unzip xz-utils ca-certificates python3.12 libssl3 git \
     && mkdir -p "$HOME/.config/pip/" \
     && printf "[global]\nbreak-system-packages = true\n" >> "$HOME/.config/pip/pip.conf" \
     && update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.12 2 \
@@ -18,6 +17,11 @@ RUN apt-get update -y \
     && python3.12 -m pip --version \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
+
+# Capture git version using mount (temporary access, no git data in final image, the final image is stored on DockerHub)
+RUN --mount=type=bind,source=.git,target=.git,readonly \
+    git describe --tags --always 2>/dev/null | sed 's/^v//' | sed 's/-.*//' > /app/version.txt || echo "0.0.0" > /app/version.txt && \
+    echo "${GENVM_TAG#v}" >> /app/version.txt
 
 ADD backend/protocol_rpc/requirements.txt backend/protocol_rpc/requirements.txt
 RUN --mount=type=cache,target=/root/.cache/pip \
@@ -28,6 +32,7 @@ RUN groupadd -r backend-group \
     && mkdir -p /home/backend-user/.cache/huggingface \
     && chown -R backend-user:backend-group /home/backend-user \
     && chown -R backend-user:backend-group $path \
+    && chown backend-user:backend-group /app/version.txt \
     && mkdir -p /genvm
 
 ENV PYTHONPATH "${PYTHONPATH}:/${path}"

--- a/frontend/src/components/Simulator/settings/VersionSection.vue
+++ b/frontend/src/components/Simulator/settings/VersionSection.vue
@@ -1,0 +1,31 @@
+<script setup lang="ts">
+import { ref, onMounted } from 'vue';
+import { useRpcClient } from '@/hooks';
+import PageSection from '@/components/Simulator/PageSection.vue';
+
+const rpcClient = useRpcClient();
+const studioVersion = ref('');
+const genvmVersion = ref('');
+
+onMounted(async () => {
+  try {
+    studioVersion.value = await rpcClient.getStudioVersion();
+    genvmVersion.value = await rpcClient.getGenVMVersion();
+  } catch (error) {
+    console.error('Error fetching versions:', error);
+  }
+});
+</script>
+
+<template>
+  <PageSection>
+    <template #title>Version</template>
+
+    <div class="p-1">
+      <div class="text-sm">
+        <div>Studio: {{ studioVersion || '0.0.0' }}</div>
+        <div>GenVM: {{ genvmVersion || '0.0.0' }}</div>
+      </div>
+    </div>
+  </PageSection>
+</template>

--- a/frontend/src/services/IJsonRpcService.ts
+++ b/frontend/src/services/IJsonRpcService.ts
@@ -33,4 +33,6 @@ export interface IJsonRpcService {
   getTransactionCount(address: GetTransactionCountRequest): Promise<number>;
   setFinalityWindowTime(time: number): Promise<any>;
   getFinalityWindowTime(): Promise<number>;
+  getStudioVersion(): Promise<string>;
+  getGenVMVersion(): Promise<string>;
 }

--- a/frontend/src/services/JsonRpcService.ts
+++ b/frontend/src/services/JsonRpcService.ts
@@ -202,4 +202,22 @@ export class JsonRpcService implements IJsonRpcService {
       'Error getting finality window time',
     );
   }
+
+  async getStudioVersion(): Promise<string> {
+    const result = await this.callRpcMethod<string>(
+      'gen_protocolVersion',
+      [],
+      'Error getting studio version',
+    );
+    return result as string;
+  }
+
+  async getGenVMVersion(): Promise<string> {
+    const result = await this.callRpcMethod<string>(
+      'sim_genvmVersion',
+      [],
+      'Error getting GenVM version',
+    );
+    return result as string;
+  }
 }

--- a/frontend/src/views/Simulator/SettingsView.vue
+++ b/frontend/src/views/Simulator/SettingsView.vue
@@ -4,6 +4,7 @@ import MainTitle from '@/components/Simulator/MainTitle.vue';
 import ProviderSection from '@/components/Simulator/settings/ProviderSection.vue';
 import ConsensusSection from '@/components/Simulator/settings/ConsensusSection.vue';
 import SimulatorSection from '@/components/Simulator/settings/SimulatorSection.vue';
+import VersionSection from '@/components/Simulator/settings/VersionSection.vue';
 
 const { canUpdateProviders } = useConfig();
 </script>
@@ -15,5 +16,7 @@ const { canUpdateProviders } = useConfig();
     <SimulatorSection />
     <ConsensusSection />
     <ProviderSection v-if="canUpdateProviders" />
+    <div class="flex-grow"></div>
+    <VersionSection />
   </div>
 </template>

--- a/release.config.js
+++ b/release.config.js
@@ -29,13 +29,6 @@ module.exports = {
                 },
             }
         ],
-        [
-            "@semantic-release/npm",
-            {
-                "pkgRoot": "frontend",
-                "npmPublish": false
-            }
-        ],
         '@semantic-release/github',
     ]
 };


### PR DESCRIPTION
Fixes #DXP-478

# What

<!-- Describe the changes you made. -->

- Removed try of npm update version in package.json during release CI workflow.
- Added functions `get_simulator_version` and `get_genvm_version` to `endpoints.py` for retrieving version information.
- Updated `Dockerfile.backend` to include git for version detection and added logic to capture version information and write it in a file. The DockerHub image should contain the version file (not tested).
- Introduced a new `VersionSection.vue` component in the frontend to display version information in the settings tab at the bottom.
- Updated `SettingsView.vue` to include the new `VersionSection`.
- Modified `IJsonRpcService.ts` and `JsonRpcService.ts` to include methods for fetching studio and GenVM versions.
- Frontend UI:
   <img width="383" height="193" alt="Screenshot 2025-07-17 at 19 16 46" src="https://github.com/user-attachments/assets/bcfa6512-34f9-4cd9-a8cc-33159886fc3e" />
   <img width="383" height="193" alt="Screenshot 2025-07-17 at 19 16 42" src="https://github.com/user-attachments/assets/8b093824-45e2-498e-88ec-2e42bcb85dc9" />

# Why

<!-- Why are you making these changes? This should be related to the issue created, and the value we are adding with this PR -->

To provide users with visibility into the current version of the simulator and GenVM, enhancing transparency and debugging capabilities.

# Testing done

<!-- Describe the tests you ran to verify your changes. -->

- Verified that the version information is correctly captured in the Docker build process.
- Tested the frontend to ensure the version information is displayed correctly in the `VersionSection`.
- Confirmed that the RPC endpoints return the expected version data.

# Decisions made

<!-- Describe any decisions made during the implementation of this PR. This should in general be in the code, but sometimes they are more related to the issue. For example: decisions on PR workflow -->

- Decided to use git for studio version detection during the Docker build process to ensure accurate versioning. Reasoning about implementation options:
   - Copy .git + remove in dockerfile: Still leaves .git in Docker layers creating security risk
   - Build args with shell commands: Docker-compose doesn't execute $(git describe...), treats as literal string
   - Mount .git at runtime: Running containers get git access creating security risk
   - Version file commits: Creates dirty git history with automated commits
   - Package.json during release CI updates: Requires commits to update version, creates dirty history
   - Force push to main when creating a release: main branch is shared between devs
   - Separate branch for version text file: branches do not know which version they are on
   - Git notes: Still requires .git access in Dockerfile, doesn't solve core problem
   - Git hooks: Local only, not shared via repository, each dev needs setup. Hosting might not call git command after clone
   - Wrapper scripts: Requires ./start.sh instead of docker compose up
   - Manual version files: Violates "no hardcoded versions" requirement
   - Environment variables: Requires setting GIT_VERSION=... before docker-compose
   - Hardcoded versions: Static versions become outdated, manual maintenance required
   - Multi-stage builds: Could work but pre-stage takes too long to build.
   - Git directory mounting: Temporary git access during build only, no git data in final image, fast build time -> Final Solution

# Checks

- [x] I have tested this code
- [x] I have reviewed my own PR
- [x] I have created an issue for this PR
- [x] I have set a descriptive PR title compliant with [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)

# Reviewing tips

<!-- What can you tell the reviewer to make the review easier? -->

- Focus on the new version retrieval logic in `endpoints.py` and the integration in the frontend components.
- Ensure that the Dockerfile changes do not introduce any unintended side effects or security issues. Adding git is only done at the build phase so DockerHub should not contain git information.

# User facing release notes

<!-- What should the user know about this change? Think of it going into public forums for end users to read -->

Added version display for the studio and GenVM in the settings section of the application.