### PR TITLE
feat: fees parameters frontend

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -101,7 +101,10 @@ VALIDATORS_CONFIG_JSON = ''
 # Consensus mechanism
 VITE_FINALITY_WINDOW = 1800 # in seconds
 VITE_FINALITY_WINDOW_APPEAL_FAILED_REDUCTION = 0.2 # 20% reduction per appeal failed
-VITE_MAX_ROTATIONS = 3
+VITE_LEADER_TIMEOUT_FEE = 300
+VITE_VALIDATORS_TIMEOUT_FEE = 300
+VITE_APPEAL_ROUNDS_FEE = 3
+VITE_ROTATIONS_FEE = 2
 
 # Set the compose profile to 'hardhat' to use the hardhat network
 COMPOSE_PROFILES = 'hardhat'

--- a/frontend/src/components/Simulator/ConstructorParameters.vue
+++ b/frontend/src/components/Simulator/ConstructorParameters.vue
@@ -5,10 +5,11 @@ import PageSection from '@/components/Simulator/PageSection.vue';
 import { ArrowUpTrayIcon } from '@heroicons/vue/16/solid';
 import ContractParams from './ContractParams.vue';
 import { type ArgData, unfoldArgsData } from './ContractParams';
+import type { FeesDistribution } from '@/types';
 
 const props = defineProps<{
   leaderOnly: boolean;
-  consensusMaxRotations: number;
+  feesDistribution: FeesDistribution;
 }>();
 
 const { contract, contractSchemaQuery, deployContract, isDeploying } =
@@ -25,7 +26,7 @@ const emit = defineEmits(['deployed-contract']);
 const handleDeployContract = async () => {
   const args = calldataArguments.value;
   const newArgs = unfoldArgsData(args);
-  await deployContract(newArgs, props.leaderOnly, props.consensusMaxRotations);
+  await deployContract(newArgs, props.leaderOnly, props.feesDistribution);
 
   emit('deployed-contract');
 };

--- a/frontend/src/components/Simulator/ContractMethodItem.vue
+++ b/frontend/src/components/Simulator/ContractMethodItem.vue
@@ -9,6 +9,7 @@ import { ChevronDownIcon } from '@heroicons/vue/16/solid';
 import { useEventTracking, useContractQueries } from '@/hooks';
 import { unfoldArgsData, type ArgData } from './ContractParams';
 import ContractParams from './ContractParams.vue';
+import type { FeesDistribution } from '@/types';
 
 const { callWriteMethod, callReadMethod, contract } = useContractQueries();
 const { trackEvent } = useEventTracking();
@@ -18,7 +19,7 @@ const props = defineProps<{
   method: ContractMethod;
   methodType: 'read' | 'write';
   leaderOnly: boolean;
-  consensusMaxRotations?: number;
+  feesDistribution: FeesDistribution;
 }>();
 
 const isExpanded = ref(false);
@@ -101,7 +102,7 @@ const handleCallWriteMethod = async () => {
     await callWriteMethod({
       method: props.name,
       leaderOnly: props.leaderOnly,
-      consensusMaxRotations: props.consensusMaxRotations,
+      feesDistribution: props.feesDistribution,
       args: unfoldArgsData({
         args: calldataArguments.value.args,
         kwargs: calldataArguments.value.kwargs,

--- a/frontend/src/components/Simulator/ContractWriteMethods.vue
+++ b/frontend/src/components/Simulator/ContractWriteMethods.vue
@@ -5,9 +5,11 @@ import PageSection from '@/components/Simulator/PageSection.vue';
 import ContractMethodItem from '@/components/Simulator/ContractMethodItem.vue';
 import EmptyListPlaceholder from '@/components/Simulator/EmptyListPlaceholder.vue';
 import type { ContractSchema } from 'genlayer-js/types';
+import type { FeesDistribution } from '@/types';
+
 const props = defineProps<{
   leaderOnly: boolean;
-  consensusMaxRotations: number;
+  feesDistribution: FeesDistribution;
 }>();
 
 const { contractAbiQuery } = useContractQueries();
@@ -42,7 +44,7 @@ const writeMethods = computed(() => {
         :method="method[1]"
         methodType="write"
         :leaderOnly="props.leaderOnly"
-        :consensusMaxRotations="consensusMaxRotations"
+        :feesDistribution="props.feesDistribution"
       />
 
       <EmptyListPlaceholder v-if="writeMethods.length === 0">

--- a/frontend/src/components/Simulator/settings/ConsensusInputSection.vue
+++ b/frontend/src/components/Simulator/settings/ConsensusInputSection.vue
@@ -1,0 +1,54 @@
+<script setup lang="ts">
+import NumberInput from '@/components/global/inputs/NumberInput.vue';
+import type { ConsensusInput } from '@/types/store';
+
+interface Props {
+  title: string;
+  inputs: ConsensusInput[];
+}
+
+defineProps<Props>();
+
+const isInputValid = (value: number) => {
+  return !isNaN(value) && Number.isInteger(value) && value >= 0;
+};
+
+const handleValueUpdate = (value: number, setter: (value: number) => void) => {
+  if (isInputValid(value)) {
+    setter(value);
+  }
+};
+</script>
+
+<template>
+  <div>
+    <div class="mb-1 text-xs font-semibold opacity-50">{{ title }}</div>
+    <div
+      class="overflow-hidden rounded-md border border-gray-300 bg-slate-100 dark:border-gray-800 dark:bg-gray-700"
+    >
+      <div
+        v-for="input in inputs"
+        :key="input.id"
+        class="flex items-center justify-between px-2 py-1.5"
+      >
+        <div class="truncate text-sm font-medium">{{ input.label }}</div>
+        <NumberInput
+          :id="input.id"
+          :name="input.id"
+          :min="0"
+          :step="1"
+          :model-value="input.value"
+          @update:model-value="
+            (val) => handleValueUpdate(Number(val), input.setter)
+          "
+          required
+          :testId="input.testId"
+          :invalid="!isInputValid(input.value)"
+          :disabled="false"
+          class="h-6 w-20"
+          tiny
+        />
+      </div>
+    </div>
+  </div>
+</template>

--- a/frontend/src/components/Simulator/settings/ConsensusSection.vue
+++ b/frontend/src/components/Simulator/settings/ConsensusSection.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, computed } from 'vue';
+import { computed } from 'vue';
 import PageSection from '@/components/Simulator/PageSection.vue';
 import FieldError from '@/components/global/fields/FieldError.vue';
 import NumberInput from '@/components/global/inputs/NumberInput.vue';
@@ -8,23 +8,40 @@ import { useConsensusStore } from '@/stores';
 const consensusStore = useConsensusStore();
 const maxRotations = computed({
   get: () => consensusStore.maxRotations,
-  set: (newTime) => {
-    if (isMaxRotationsValid(newTime)) {
-      consensusStore.setMaxRotations(newTime);
-    }
+  set: (newRotations) => {
+    consensusStore.setMaxRotations(Number(newRotations));
   },
 });
 
-function isMaxRotationsValid(value: number) {
-  return Number.isInteger(value) && value >= 0;
-}
+const isMaxRotationsValid = computed(() => {
+  return (
+    !isNaN(maxRotations.value) &&
+    Number.isInteger(maxRotations.value) &&
+    maxRotations.value >= 0
+  );
+});
+
+const maxAppealRound = computed({
+  get: () => consensusStore.maxAppealRound,
+  set: (newAppealRound) => {
+    consensusStore.setMaxAppealRound(Number(newAppealRound));
+  },
+});
+
+const isMaxAppealRoundValid = computed(() => {
+  return (
+    !isNaN(maxAppealRound.value) &&
+    Number.isInteger(maxAppealRound.value) &&
+    maxAppealRound.value >= 0
+  );
+});
 </script>
 
 <template>
   <PageSection>
     <template #title>Consensus</template>
 
-    <div class="p-2">
+    <div class="p-1">
       <div class="flex flex-wrap items-center gap-2">
         <label for="maxRotations" class="text-xs">Max Rotations</label>
         <NumberInput
@@ -35,6 +52,7 @@ function isMaxRotationsValid(value: number) {
           v-model.number="maxRotations"
           required
           testId="input-maxRotations"
+          :invalid="!isMaxRotationsValid"
           :disabled="false"
           class="h-6 w-12"
           tiny
@@ -42,6 +60,29 @@ function isMaxRotationsValid(value: number) {
       </div>
 
       <FieldError v-if="!isMaxRotationsValid"
+        >Please enter a positive integer.</FieldError
+      >
+    </div>
+
+    <div class="p-1">
+      <div class="flex flex-wrap items-center gap-2">
+        <label for="maxAppealRound" class="text-xs">Max Appeal Rounds</label>
+        <NumberInput
+          id="maxAppealRound"
+          name="maxAppealRound"
+          :min="0"
+          :step="1"
+          v-model.number="maxAppealRound"
+          required
+          testId="input-maxAppealRound"
+          :invalid="!isMaxAppealRoundValid"
+          :disabled="false"
+          class="h-6 w-12"
+          tiny
+        />
+      </div>
+
+      <FieldError v-if="!isMaxAppealRoundValid"
         >Please enter a positive integer.</FieldError
       >
     </div>

--- a/frontend/src/hooks/useContractQueries.ts
+++ b/frontend/src/hooks/useContractQueries.ts
@@ -1,6 +1,6 @@
 import { watch, ref, computed } from 'vue';
 import { useQuery, useQueryClient } from '@tanstack/vue-query';
-import type { TransactionItem } from '@/types';
+import type { TransactionItem, FeesDistribution } from '@/types';
 import {
   useContractsStore,
   useTransactionsStore,
@@ -100,7 +100,7 @@ export function useContractQueries() {
       kwargs: { [key: string]: CalldataEncodable };
     },
     leaderOnly: boolean,
-    consensusMaxRotations: number,
+    feesDistribution: FeesDistribution,
   ) {
     isDeploying.value = true;
 
@@ -116,7 +116,7 @@ export function useContractQueries() {
         code: code_bytes as any as string, // FIXME: code should accept both bytes and string in genlayer-js
         args: args.args,
         leaderOnly,
-        consensusMaxRotations,
+        feesDistribution: feesDistribution,
       });
 
       const tx: TransactionItem = {
@@ -209,7 +209,7 @@ export function useContractQueries() {
     method,
     args,
     leaderOnly,
-    consensusMaxRotations,
+    feesDistribution,
   }: {
     method: string;
     args: {
@@ -217,7 +217,7 @@ export function useContractQueries() {
       kwargs: { [key: string]: CalldataEncodable };
     };
     leaderOnly: boolean;
-    consensusMaxRotations?: number;
+    feesDistribution: FeesDistribution;
   }) {
     try {
       if (!accountsStore.selectedAccount) {
@@ -230,7 +230,7 @@ export function useContractQueries() {
         args: args.args,
         value: BigInt(0),
         leaderOnly,
-        consensusMaxRotations,
+        feesDistribution: feesDistribution,
       });
 
       transactionsStore.addTransaction({

--- a/frontend/src/stores/consensus.ts
+++ b/frontend/src/stores/consensus.ts
@@ -8,6 +8,7 @@ export const useConsensusStore = defineStore('consensusStore', () => {
   const finalityWindow = ref(Number(import.meta.env.VITE_FINALITY_WINDOW));
   const isLoading = ref<boolean>(true); // Needed for the delay between creating the variable and fetching the initial value
   const maxRotations = ref(Number(import.meta.env.VITE_MAX_ROTATIONS));
+  const maxAppealRound = ref(Number(import.meta.env.VITE_MAX_APPEALS));
 
   if (!webSocketClient.connected) webSocketClient.connect();
 
@@ -39,6 +40,11 @@ export const useConsensusStore = defineStore('consensusStore', () => {
     maxRotations.value = rotations;
   }
 
+  function setMaxAppealRound(appealRound: number) {
+    maxAppealRound.value = appealRound;
+    console.log('maxAppealRound', maxAppealRound.value);
+  }
+
   return {
     finalityWindow,
     setFinalityWindowTime,
@@ -46,5 +52,7 @@ export const useConsensusStore = defineStore('consensusStore', () => {
     isLoading,
     maxRotations,
     setMaxRotations,
+    maxAppealRound,
+    setMaxAppealRound,
   };
 });

--- a/frontend/src/stores/consensus.ts
+++ b/frontend/src/stores/consensus.ts
@@ -32,20 +32,24 @@ export const useConsensusStore = defineStore('consensusStore', () => {
     ),
   );
   const defaultRotationFee = Number(import.meta.env.VITE_ROTATIONS_FEE);
-  const storedRotationsFee = localStorage.getItem(
-    'consensusStore.rotationsFee',
-  );
   const rotationsFee = ref<number[]>(
-    storedRotationsFee ? JSON.parse(storedRotationsFee) : [],
+    ((): number[] => {
+      try {
+        const stored = localStorage.getItem('consensusStore.rotationsFee');
+        if (stored) {
+          return JSON.parse(stored);
+        }
+      } catch (error) {
+        console.warn(
+          'Failed to parse stored rotationsFee, using default:',
+          error,
+        );
+      }
+      // Initialize based on current appealRoundFee
+      const rounds = appealRoundFee.value;
+      return rounds > 0 ? Array(rounds).fill(defaultRotationFee) : [];
+    })(),
   );
-
-  if (!storedRotationsFee && appealRoundFee.value > 0) {
-    rotationsFee.value = Array(appealRoundFee.value).fill(defaultRotationFee);
-    localStorage.setItem(
-      'consensusStore.rotationsFee',
-      JSON.stringify(rotationsFee.value),
-    );
-  }
 
   if (!webSocketClient.connected) webSocketClient.connect();
 

--- a/frontend/src/stores/consensus.ts
+++ b/frontend/src/stores/consensus.ts
@@ -46,7 +46,7 @@ export const useConsensusStore = defineStore('consensusStore', () => {
         );
       }
       // Initialize based on current appealRoundFee
-      const rounds = appealRoundFee.value;
+      const rounds = appealRoundFee.value + 1;
       return rounds > 0 ? Array(rounds).fill(defaultRotationFee) : [];
     })(),
   );
@@ -91,22 +91,22 @@ export const useConsensusStore = defineStore('consensusStore', () => {
     appealRoundFee.value = fee;
     localStorage.setItem('consensusStore.appealRoundFee', fee.toString());
 
-    // When appeal rounds change, adjust rotations fee array
-    if (fee > 0) {
-      const currentRotations = rotationsFee.value;
-      if (fee > currentRotations.length) {
-        // Add new rounds with default fee
-        rotationsFee.value = [
-          ...currentRotations,
-          ...Array(fee - currentRotations.length).fill(defaultRotationFee),
-        ];
-      } else if (fee < currentRotations.length) {
-        // Remove excess rounds
-        rotationsFee.value = currentRotations.slice(0, fee);
-      }
-    } else {
-      // If fee is 0, clear the array
-      rotationsFee.value = [];
+    // Increment fee for rotation calculations
+    const rotationCount = fee + 1;
+    const currentRotations = rotationsFee.value;
+
+    // Adjust rotations fee array based on new count
+    if (rotationCount > currentRotations.length) {
+      // Add new rounds with default fee
+      rotationsFee.value = [
+        ...currentRotations,
+        ...Array(rotationCount - currentRotations.length).fill(
+          defaultRotationFee,
+        ),
+      ];
+    } else if (rotationCount < currentRotations.length) {
+      // Remove excess rounds
+      rotationsFee.value = currentRotations.slice(0, rotationCount);
     }
 
     localStorage.setItem(

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -45,6 +45,13 @@ export interface NewProviderDataModel {
   plugin_config: Record<string, any>;
 }
 
+export interface FeesDistribution {
+  leaderTimeoutFee: number;
+  validatorsTimeoutFee: number;
+  appealRounds: number;
+  rotations: number[];
+}
+
 export type Address = `0x${string}`;
 
 export interface SchemaProperty {

--- a/frontend/src/types/store.ts
+++ b/frontend/src/types/store.ts
@@ -46,3 +46,11 @@ export interface UIState {
   mode: UIMode;
   showTutorial: boolean;
 }
+
+export interface ConsensusInput {
+  value: number;
+  label: string;
+  id: string;
+  testId: string;
+  setter: (value: number) => void;
+}

--- a/frontend/src/views/Simulator/RunDebugView.vue
+++ b/frontend/src/views/Simulator/RunDebugView.vue
@@ -12,6 +12,7 @@ import {
   useConsensusStore,
   useUIStore,
 } from '@/stores';
+import type { FeesDistribution } from '@/types';
 
 import ContractInfo from '@/components/Simulator/ContractInfo.vue';
 import BooleanField from '@/components/global/fields/BooleanField.vue';
@@ -51,7 +52,12 @@ function isFinalityWindowValid(value: number) {
   return Number.isInteger(value) && value >= 0;
 }
 
-const consensusMaxRotations = computed(() => consensusStore.maxRotations);
+const feesDistribution = computed<FeesDistribution>(() => ({
+  leaderTimeoutFee: consensusStore.leaderTimeoutFee,
+  validatorsTimeoutFee: consensusStore.validatorsTimeoutFee,
+  appealRounds: consensusStore.appealRoundFee,
+  rotations: consensusStore.rotationsFee,
+}));
 </script>
 
 <template>
@@ -106,7 +112,7 @@ const consensusMaxRotations = computed(() => consensusStore.maxRotations);
           v-if="isDeploymentOpen"
           @deployedContract="isDeploymentOpen = false"
           :leaderOnly="leaderOnly"
-          :consensusMaxRotations="consensusMaxRotations"
+          :feesDistribution="feesDistribution"
         />
 
         <ContractReadMethods
@@ -118,7 +124,7 @@ const consensusMaxRotations = computed(() => consensusStore.maxRotations);
           v-if="isDeployed"
           id="tutorial-write-methods"
           :leaderOnly="leaderOnly"
-          :consensusMaxRotations="consensusMaxRotations"
+          :feesDistribution="feesDistribution"
         />
         <TransactionsList
           id="tutorial-tx-response"

--- a/frontend/src/views/Simulator/RunDebugView.vue
+++ b/frontend/src/views/Simulator/RunDebugView.vue
@@ -84,7 +84,7 @@ const consensusMaxRotations = computed(() => consensusStore.maxRotations);
               required
               testId="input-finalityWindow"
               :disabled="false"
-              class="w-20"
+              class="h-6 w-20"
               tiny
             />
           </div>


### PR DESCRIPTION
Fixes #DXP-443

# What

<!-- Describe the changes you made. -->

- Replaced `consensusMaxRotations` with `feesDistribution` in various components.
- Introduced new fees configuration in the `.env.example` file, including `VITE_LEADER_TIMEOUT_FEE`, `VITE_VALIDATORS_TIMEOUT_FEE`, `VITE_APPEAL_ROUNDS_FEE`, and `VITE_ROTATIONS_FEE`.
- Added `ConsensusInputSection` component to manage consensus input settings.
- Updated `useConsensusStore` to handle new fee-related state and logic.
- Frontend look: 
   - Red border=invalid value
   - Blue border=selected input
   - The number of rotations per round fields is equal to the value set in appeal rounds
   - Layout follows the provider section
<img width="331" height="738" alt="Screenshot 2025-07-22 at 18 30 13" src="https://github.com/user-attachments/assets/94ba16b5-c7e6-41f9-88fc-2b3cc5deda24" />
<img width="331" height="738" alt="Screenshot 2025-07-22 at 18 30 04" src="https://github.com/user-attachments/assets/2f59a7f7-1150-46fb-90c1-0fe50ae828b7" />

# Why

<!-- Why are you making these changes? This should be related to the issue created, and the value we are adding with this PR -->

To add fees.

# Testing done

<!-- Describe the tests you ran to verify your changes. -->

Verified that the new fee settings are correctly loaded and stored in local storage.

# Decisions made

<!-- Describe any decisions made during the implementation of this PR. This should in general be in the code, but sometimes they are more related to the issue. For example: decisions on PR workflow -->

Decided to store fee settings in local storage for persistence across sessions.

# Checks

- [x] I have tested this code
- [x] I have reviewed my own PR
- [x] I have created an issue for this PR
- [x] I have set a descriptive PR title compliant with [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)

# Reviewing tips

<!-- What can you tell the reviewer to make the review easier? -->

Focus on the changes.

# Depends on
Implementation of DXP-445. That is why tests are failing.

# User facing release notes

<!-- What should the user know about this change? Think of it going into public forums for end users to read -->

Introduced a fee structure for the consensus mechanism.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


## Summary by CodeRabbit

* **New Features**
  * Introduced separate configuration options for leader timeout fee, validators timeout fee, appeal rounds fee, and rotations fee.
  * Added a new component for grouped consensus fee inputs, allowing users to configure multiple fee parameters with validation.
  * Enhanced consensus settings UI with modular input sections and explanatory information.

* **Refactor**
  * Replaced the previous single "max rotations" parameter with a structured fees distribution object throughout the simulator.
  * Updated contract deployment and write methods to use the new fees distribution structure.
  * Refactored consensus store to manage multiple fee states and persist them with localStorage.

* **Bug Fixes**
  * Improved input validation for consensus fee parameters to ensure non-negative integer values.

* **Chores**
  * Updated environment variable documentation to reflect new fee-related configuration keys.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->