### PR TITLE
feat: fees mechanism on/off

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -101,7 +101,10 @@ VALIDATORS_CONFIG_JSON = ''
 # Consensus mechanism
 VITE_FINALITY_WINDOW = 1800 # in seconds
 VITE_FINALITY_WINDOW_APPEAL_FAILED_REDUCTION = 0.2 # 20% reduction per appeal failed
-VITE_MAX_ROTATIONS = 3
+VITE_LEADER_TIMEOUT_FEE = 300
+VITE_VALIDATORS_TIMEOUT_FEE = 300
+VITE_APPEAL_ROUNDS_FEE = 3
+VITE_ROTATIONS_FEE = 2
 
 # Set the compose profile to 'hardhat' to use the hardhat network
 COMPOSE_PROFILES = 'hardhat'

--- a/.env.example
+++ b/.env.example
@@ -105,6 +105,7 @@ VITE_LEADER_TIMEOUT_FEE = 300
 VITE_VALIDATORS_TIMEOUT_FEE = 300
 VITE_APPEAL_ROUNDS_FEE = 3
 VITE_ROTATIONS_FEE = 2
+VITE_FEES_ENABLED = 'true'
 
 # Set the compose profile to 'hardhat' to use the hardhat network
 COMPOSE_PROFILES = 'hardhat'

--- a/frontend/src/components/Simulator/ConstructorParameters.vue
+++ b/frontend/src/components/Simulator/ConstructorParameters.vue
@@ -5,10 +5,11 @@ import PageSection from '@/components/Simulator/PageSection.vue';
 import { ArrowUpTrayIcon } from '@heroicons/vue/16/solid';
 import ContractParams from './ContractParams.vue';
 import { type ArgData, unfoldArgsData } from './ContractParams';
+import type { FeesDistribution } from '@/types';
 
 const props = defineProps<{
   leaderOnly: boolean;
-  consensusMaxRotations: number;
+  feesDistribution: FeesDistribution;
 }>();
 
 const { contract, contractSchemaQuery, deployContract, isDeploying } =
@@ -25,7 +26,7 @@ const emit = defineEmits(['deployed-contract']);
 const handleDeployContract = async () => {
   const args = calldataArguments.value;
   const newArgs = unfoldArgsData(args);
-  await deployContract(newArgs, props.leaderOnly, props.consensusMaxRotations);
+  await deployContract(newArgs, props.leaderOnly, props.feesDistribution);
 
   emit('deployed-contract');
 };

--- a/frontend/src/components/Simulator/ConstructorParameters.vue
+++ b/frontend/src/components/Simulator/ConstructorParameters.vue
@@ -9,7 +9,7 @@ import type { FeesDistribution } from '@/types';
 
 const props = defineProps<{
   leaderOnly: boolean;
-  feesDistribution: FeesDistribution;
+  feesDistribution?: FeesDistribution;
 }>();
 
 const { contract, contractSchemaQuery, deployContract, isDeploying } =

--- a/frontend/src/components/Simulator/ContractMethodItem.vue
+++ b/frontend/src/components/Simulator/ContractMethodItem.vue
@@ -19,7 +19,7 @@ const props = defineProps<{
   method: ContractMethod;
   methodType: 'read' | 'write';
   leaderOnly: boolean;
-  feesDistribution: FeesDistribution;
+  feesDistribution?: FeesDistribution;
 }>();
 
 const isExpanded = ref(false);

--- a/frontend/src/components/Simulator/ContractMethodItem.vue
+++ b/frontend/src/components/Simulator/ContractMethodItem.vue
@@ -9,6 +9,7 @@ import { ChevronDownIcon } from '@heroicons/vue/16/solid';
 import { useEventTracking, useContractQueries } from '@/hooks';
 import { unfoldArgsData, type ArgData } from './ContractParams';
 import ContractParams from './ContractParams.vue';
+import type { FeesDistribution } from '@/types';
 
 const { callWriteMethod, callReadMethod, contract } = useContractQueries();
 const { trackEvent } = useEventTracking();
@@ -18,7 +19,7 @@ const props = defineProps<{
   method: ContractMethod;
   methodType: 'read' | 'write';
   leaderOnly: boolean;
-  consensusMaxRotations?: number;
+  feesDistribution: FeesDistribution;
 }>();
 
 const isExpanded = ref(false);
@@ -101,7 +102,7 @@ const handleCallWriteMethod = async () => {
     await callWriteMethod({
       method: props.name,
       leaderOnly: props.leaderOnly,
-      consensusMaxRotations: props.consensusMaxRotations,
+      feesDistribution: props.feesDistribution,
       args: unfoldArgsData({
         args: calldataArguments.value.args,
         kwargs: calldataArguments.value.kwargs,

--- a/frontend/src/components/Simulator/ContractWriteMethods.vue
+++ b/frontend/src/components/Simulator/ContractWriteMethods.vue
@@ -5,9 +5,11 @@ import PageSection from '@/components/Simulator/PageSection.vue';
 import ContractMethodItem from '@/components/Simulator/ContractMethodItem.vue';
 import EmptyListPlaceholder from '@/components/Simulator/EmptyListPlaceholder.vue';
 import type { ContractSchema } from 'genlayer-js/types';
+import type { FeesDistribution } from '@/types';
+
 const props = defineProps<{
   leaderOnly: boolean;
-  consensusMaxRotations: number;
+  feesDistribution: FeesDistribution;
 }>();
 
 const { contractAbiQuery } = useContractQueries();
@@ -42,7 +44,7 @@ const writeMethods = computed(() => {
         :method="method[1]"
         methodType="write"
         :leaderOnly="props.leaderOnly"
-        :consensusMaxRotations="consensusMaxRotations"
+        :feesDistribution="props.feesDistribution"
       />
 
       <EmptyListPlaceholder v-if="writeMethods.length === 0">

--- a/frontend/src/components/Simulator/ContractWriteMethods.vue
+++ b/frontend/src/components/Simulator/ContractWriteMethods.vue
@@ -9,7 +9,7 @@ import type { FeesDistribution } from '@/types';
 
 const props = defineProps<{
   leaderOnly: boolean;
-  feesDistribution: FeesDistribution;
+  feesDistribution?: FeesDistribution;
 }>();
 
 const { contractAbiQuery } = useContractQueries();

--- a/frontend/src/components/Simulator/settings/ConsensusInputSection.vue
+++ b/frontend/src/components/Simulator/settings/ConsensusInputSection.vue
@@ -1,0 +1,54 @@
+<script setup lang="ts">
+import NumberInput from '@/components/global/inputs/NumberInput.vue';
+import type { ConsensusInput } from '@/types/store';
+
+interface Props {
+  title: string;
+  inputs: ConsensusInput[];
+}
+
+defineProps<Props>();
+
+const isInputValid = (value: number) => {
+  return !isNaN(value) && Number.isInteger(value) && value >= 0;
+};
+
+const handleValueUpdate = (value: number, setter: (value: number) => void) => {
+  if (isInputValid(value)) {
+    setter(value);
+  }
+};
+</script>
+
+<template>
+  <div>
+    <div class="mb-1 text-xs font-semibold opacity-50">{{ title }}</div>
+    <div
+      class="overflow-hidden rounded-md border border-gray-300 bg-slate-100 dark:border-gray-800 dark:bg-gray-700"
+    >
+      <div
+        v-for="input in inputs"
+        :key="input.id"
+        class="flex items-center justify-between px-2 py-1.5"
+      >
+        <div class="truncate text-sm font-medium">{{ input.label }}</div>
+        <NumberInput
+          :id="input.id"
+          :name="input.id"
+          :min="0"
+          :step="1"
+          :model-value="input.value"
+          @update:model-value="
+            (val) => handleValueUpdate(Number(val), input.setter)
+          "
+          required
+          :testId="input.testId"
+          :invalid="!isInputValid(input.value)"
+          :disabled="false"
+          class="h-6 w-20"
+          tiny
+        />
+      </div>
+    </div>
+  </div>
+</template>

--- a/frontend/src/components/Simulator/settings/ConsensusSection.vue
+++ b/frontend/src/components/Simulator/settings/ConsensusSection.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, computed } from 'vue';
+import { computed } from 'vue';
 import PageSection from '@/components/Simulator/PageSection.vue';
 import FieldError from '@/components/global/fields/FieldError.vue';
 import NumberInput from '@/components/global/inputs/NumberInput.vue';
@@ -8,23 +8,40 @@ import { useConsensusStore } from '@/stores';
 const consensusStore = useConsensusStore();
 const maxRotations = computed({
   get: () => consensusStore.maxRotations,
-  set: (newTime) => {
-    if (isMaxRotationsValid(newTime)) {
-      consensusStore.setMaxRotations(newTime);
-    }
+  set: (newRotations) => {
+    consensusStore.setMaxRotations(Number(newRotations));
   },
 });
 
-function isMaxRotationsValid(value: number) {
-  return Number.isInteger(value) && value >= 0;
-}
+const isMaxRotationsValid = computed(() => {
+  return (
+    !isNaN(maxRotations.value) &&
+    Number.isInteger(maxRotations.value) &&
+    maxRotations.value >= 0
+  );
+});
+
+const maxAppealRound = computed({
+  get: () => consensusStore.maxAppealRound,
+  set: (newAppealRound) => {
+    consensusStore.setMaxAppealRound(Number(newAppealRound));
+  },
+});
+
+const isMaxAppealRoundValid = computed(() => {
+  return (
+    !isNaN(maxAppealRound.value) &&
+    Number.isInteger(maxAppealRound.value) &&
+    maxAppealRound.value >= 0
+  );
+});
 </script>
 
 <template>
   <PageSection>
     <template #title>Consensus</template>
 
-    <div class="p-2">
+    <div class="p-1">
       <div class="flex flex-wrap items-center gap-2">
         <label for="maxRotations" class="text-xs">Max Rotations</label>
         <NumberInput
@@ -35,6 +52,7 @@ function isMaxRotationsValid(value: number) {
           v-model.number="maxRotations"
           required
           testId="input-maxRotations"
+          :invalid="!isMaxRotationsValid"
           :disabled="false"
           class="h-6 w-12"
           tiny
@@ -42,6 +60,29 @@ function isMaxRotationsValid(value: number) {
       </div>
 
       <FieldError v-if="!isMaxRotationsValid"
+        >Please enter a positive integer.</FieldError
+      >
+    </div>
+
+    <div class="p-1">
+      <div class="flex flex-wrap items-center gap-2">
+        <label for="maxAppealRound" class="text-xs">Max Appeal Rounds</label>
+        <NumberInput
+          id="maxAppealRound"
+          name="maxAppealRound"
+          :min="0"
+          :step="1"
+          v-model.number="maxAppealRound"
+          required
+          testId="input-maxAppealRound"
+          :invalid="!isMaxAppealRoundValid"
+          :disabled="false"
+          class="h-6 w-12"
+          tiny
+        />
+      </div>
+
+      <FieldError v-if="!isMaxAppealRoundValid"
         >Please enter a positive integer.</FieldError
       >
     </div>

--- a/frontend/src/components/Simulator/settings/ConsensusSection.vue
+++ b/frontend/src/components/Simulator/settings/ConsensusSection.vue
@@ -3,10 +3,16 @@ import { computed } from 'vue';
 import PageSection from '@/components/Simulator/PageSection.vue';
 import { useConsensusStore } from '@/stores';
 import MoreInfo from '@/components/global/MoreInfo.vue';
+import BooleanField from '@/components/global/fields/BooleanField.vue';
 import ConsensusInputSection from './ConsensusInputSection.vue';
 import type { ConsensusInput } from '@/types/store';
 
 const consensusStore = useConsensusStore();
+
+const feesEnabled = computed({
+  get: () => consensusStore.feesEnabled,
+  set: (value) => consensusStore.setFeesEnabled(value),
+});
 
 const createConsensusInput = (
   storeValue: number,
@@ -69,21 +75,30 @@ const rotationInputs = computed(() =>
     </template>
 
     <div class="space-y-2">
-      <ConsensusInputSection
-        title="Time Units Allocation"
-        :inputs="timeUnitsInputs"
+      <BooleanField
+        v-model="feesEnabled"
+        name="feesEnabled"
+        label="Enable Fees"
+        data-testid="toggle-fees"
       />
 
-      <ConsensusInputSection
-        title="Appeal Configuration"
-        :inputs="appealInputs"
-      />
+      <template v-if="feesEnabled">
+        <ConsensusInputSection
+          title="Time Units Allocation"
+          :inputs="timeUnitsInputs"
+        />
 
-      <ConsensusInputSection
-        v-if="rotationInputs.length > 0"
-        title="Rotations Per Round"
-        :inputs="rotationInputs"
-      />
+        <ConsensusInputSection
+          title="Appeal Configuration"
+          :inputs="appealInputs"
+        />
+
+        <ConsensusInputSection
+          v-if="rotationInputs.length > 0"
+          title="Rotations Per Round"
+          :inputs="rotationInputs"
+        />
+      </template>
     </div>
   </PageSection>
 </template>

--- a/frontend/src/hooks/useContractQueries.ts
+++ b/frontend/src/hooks/useContractQueries.ts
@@ -1,6 +1,6 @@
 import { watch, ref, computed } from 'vue';
 import { useQuery, useQueryClient } from '@tanstack/vue-query';
-import type { TransactionItem } from '@/types';
+import type { TransactionItem, FeesDistribution } from '@/types';
 import {
   useContractsStore,
   useTransactionsStore,
@@ -100,7 +100,7 @@ export function useContractQueries() {
       kwargs: { [key: string]: CalldataEncodable };
     },
     leaderOnly: boolean,
-    consensusMaxRotations: number,
+    feesDistribution: FeesDistribution,
   ) {
     isDeploying.value = true;
 
@@ -116,7 +116,7 @@ export function useContractQueries() {
         code: code_bytes as any as string, // FIXME: code should accept both bytes and string in genlayer-js
         args: args.args,
         leaderOnly,
-        consensusMaxRotations,
+        feesDistribution: feesDistribution,
       });
 
       const tx: TransactionItem = {
@@ -209,7 +209,7 @@ export function useContractQueries() {
     method,
     args,
     leaderOnly,
-    consensusMaxRotations,
+    feesDistribution,
   }: {
     method: string;
     args: {
@@ -217,7 +217,7 @@ export function useContractQueries() {
       kwargs: { [key: string]: CalldataEncodable };
     };
     leaderOnly: boolean;
-    consensusMaxRotations?: number;
+    feesDistribution: FeesDistribution;
   }) {
     try {
       if (!accountsStore.selectedAccount) {
@@ -230,7 +230,7 @@ export function useContractQueries() {
         args: args.args,
         value: BigInt(0),
         leaderOnly,
-        consensusMaxRotations,
+        feesDistribution: feesDistribution,
       });
 
       transactionsStore.addTransaction({

--- a/frontend/src/hooks/useContractQueries.ts
+++ b/frontend/src/hooks/useContractQueries.ts
@@ -112,13 +112,11 @@ export function useContractQueries() {
       const code = contract.value?.content ?? '';
       const code_bytes = new TextEncoder().encode(code);
 
-      console.log('feesDistribution', feesDistribution);
-
       const result = await genlayerClient.value?.deployContract({
         code: code_bytes as any as string, // FIXME: code should accept both bytes and string in genlayer-js
         args: args.args,
         leaderOnly,
-        // feesDistribution: feesDistribution,
+        feesDistribution: feesDistribution,
       });
 
       const tx: TransactionItem = {
@@ -226,15 +224,13 @@ export function useContractQueries() {
         throw new Error('Error writing to contract');
       }
 
-      console.log('feesDistribution', feesDistribution);
-
       const result = await genlayerClient.value?.writeContract({
         address: address.value as Address,
         functionName: method,
         args: args.args,
         value: BigInt(0),
         leaderOnly,
-        // feesDistribution: feesDistribution,
+        feesDistribution: feesDistribution,
       });
 
       transactionsStore.addTransaction({

--- a/frontend/src/hooks/useContractQueries.ts
+++ b/frontend/src/hooks/useContractQueries.ts
@@ -100,7 +100,7 @@ export function useContractQueries() {
       kwargs: { [key: string]: CalldataEncodable };
     },
     leaderOnly: boolean,
-    feesDistribution: FeesDistribution,
+    feesDistribution?: FeesDistribution,
   ) {
     isDeploying.value = true;
 
@@ -112,11 +112,13 @@ export function useContractQueries() {
       const code = contract.value?.content ?? '';
       const code_bytes = new TextEncoder().encode(code);
 
+      console.log('feesDistribution', feesDistribution);
+
       const result = await genlayerClient.value?.deployContract({
         code: code_bytes as any as string, // FIXME: code should accept both bytes and string in genlayer-js
         args: args.args,
         leaderOnly,
-        feesDistribution: feesDistribution,
+        // feesDistribution: feesDistribution,
       });
 
       const tx: TransactionItem = {
@@ -217,12 +219,14 @@ export function useContractQueries() {
       kwargs: { [key: string]: CalldataEncodable };
     };
     leaderOnly: boolean;
-    feesDistribution: FeesDistribution;
+    feesDistribution?: FeesDistribution;
   }) {
     try {
       if (!accountsStore.selectedAccount) {
         throw new Error('Error writing to contract');
       }
+
+      console.log('feesDistribution', feesDistribution);
 
       const result = await genlayerClient.value?.writeContract({
         address: address.value as Address,
@@ -230,7 +234,7 @@ export function useContractQueries() {
         args: args.args,
         value: BigInt(0),
         leaderOnly,
-        feesDistribution: feesDistribution,
+        // feesDistribution: feesDistribution,
       });
 
       transactionsStore.addTransaction({

--- a/frontend/src/stores/consensus.ts
+++ b/frontend/src/stores/consensus.ts
@@ -8,6 +8,7 @@ export const useConsensusStore = defineStore('consensusStore', () => {
   const finalityWindow = ref(Number(import.meta.env.VITE_FINALITY_WINDOW));
   const isLoading = ref<boolean>(true); // Needed for the delay between creating the variable and fetching the initial value
   const maxRotations = ref(Number(import.meta.env.VITE_MAX_ROTATIONS));
+  const maxAppealRound = ref(Number(import.meta.env.VITE_MAX_APPEALS));
 
   if (!webSocketClient.connected) webSocketClient.connect();
 
@@ -39,6 +40,11 @@ export const useConsensusStore = defineStore('consensusStore', () => {
     maxRotations.value = rotations;
   }
 
+  function setMaxAppealRound(appealRound: number) {
+    maxAppealRound.value = appealRound;
+    console.log('maxAppealRound', maxAppealRound.value);
+  }
+
   return {
     finalityWindow,
     setFinalityWindowTime,
@@ -46,5 +52,7 @@ export const useConsensusStore = defineStore('consensusStore', () => {
     isLoading,
     maxRotations,
     setMaxRotations,
+    maxAppealRound,
+    setMaxAppealRound,
   };
 });

--- a/frontend/src/stores/consensus.ts
+++ b/frontend/src/stores/consensus.ts
@@ -32,20 +32,24 @@ export const useConsensusStore = defineStore('consensusStore', () => {
     ),
   );
   const defaultRotationFee = Number(import.meta.env.VITE_ROTATIONS_FEE);
-  const storedRotationsFee = localStorage.getItem(
-    'consensusStore.rotationsFee',
-  );
   const rotationsFee = ref<number[]>(
-    storedRotationsFee ? JSON.parse(storedRotationsFee) : [],
+    ((): number[] => {
+      try {
+        const stored = localStorage.getItem('consensusStore.rotationsFee');
+        if (stored) {
+          return JSON.parse(stored);
+        }
+      } catch (error) {
+        console.warn(
+          'Failed to parse stored rotationsFee, using default:',
+          error,
+        );
+      }
+      // Initialize based on current appealRoundFee
+      const rounds = appealRoundFee.value;
+      return rounds > 0 ? Array(rounds).fill(defaultRotationFee) : [];
+    })(),
   );
-
-  if (!storedRotationsFee && appealRoundFee.value > 0) {
-    rotationsFee.value = Array(appealRoundFee.value).fill(defaultRotationFee);
-    localStorage.setItem(
-      'consensusStore.rotationsFee',
-      JSON.stringify(rotationsFee.value),
-    );
-  }
 
   if (!webSocketClient.connected) webSocketClient.connect();
 

--- a/frontend/src/stores/consensus.ts
+++ b/frontend/src/stores/consensus.ts
@@ -8,11 +8,23 @@ const getStoredValue = (key: string, defaultValue: number): number => {
   return stored ? Number(stored) : defaultValue;
 };
 
+// Helper function to get stored boolean value or default
+const getStoredBooleanValue = (key: string, defaultValue: boolean): boolean => {
+  const stored = localStorage.getItem(`consensusStore.${key}`);
+  return stored ? stored === 'true' : defaultValue;
+};
+
 export const useConsensusStore = defineStore('consensusStore', () => {
   const rpcClient = useRpcClient();
   const webSocketClient = useWebSocketClient();
   const finalityWindow = ref(Number(import.meta.env.VITE_FINALITY_WINDOW));
   const isLoading = ref<boolean>(true); // Needed for the delay between creating the variable and fetching the initial value
+  const feesEnabled = ref(
+    getStoredBooleanValue(
+      'feesEnabled',
+      import.meta.env.VITE_FEES_ENABLED !== 'false',
+    ),
+  );
   const leaderTimeoutFee = ref(
     getStoredValue(
       'leaderTimeoutFee',
@@ -125,6 +137,11 @@ export const useConsensusStore = defineStore('consensusStore', () => {
     );
   }
 
+  function setFeesEnabled(enabled: boolean) {
+    feesEnabled.value = enabled;
+    localStorage.setItem('consensusStore.feesEnabled', enabled.toString());
+  }
+
   return {
     finalityWindow,
     setFinalityWindowTime,
@@ -138,5 +155,7 @@ export const useConsensusStore = defineStore('consensusStore', () => {
     setAppealRoundFee,
     rotationsFee,
     setRotationsFee,
+    feesEnabled,
+    setFeesEnabled,
   };
 });

--- a/frontend/src/stores/consensus.ts
+++ b/frontend/src/stores/consensus.ts
@@ -58,7 +58,10 @@ export const useConsensusStore = defineStore('consensusStore', () => {
         );
       }
       // Initialize based on current appealRoundFee
-      const rounds = appealRoundFee.value;
+      const rounds = getStoredValue(
+        'appealRoundFee',
+        Number(import.meta.env.VITE_APPEAL_ROUNDS_FEE),
+      );
       return rounds > 0 ? Array(rounds).fill(defaultRotationFee) : [];
     })(),
   );

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -45,6 +45,13 @@ export interface NewProviderDataModel {
   plugin_config: Record<string, any>;
 }
 
+export interface FeesDistribution {
+  leaderTimeoutFee: number;
+  validatorsTimeoutFee: number;
+  appealRounds: number;
+  rotations: number[];
+}
+
 export type Address = `0x${string}`;
 
 export interface SchemaProperty {

--- a/frontend/src/types/store.ts
+++ b/frontend/src/types/store.ts
@@ -46,3 +46,11 @@ export interface UIState {
   mode: UIMode;
   showTutorial: boolean;
 }
+
+export interface ConsensusInput {
+  value: number;
+  label: string;
+  id: string;
+  testId: string;
+  setter: (value: number) => void;
+}

--- a/frontend/src/views/Simulator/RunDebugView.vue
+++ b/frontend/src/views/Simulator/RunDebugView.vue
@@ -52,12 +52,16 @@ function isFinalityWindowValid(value: number) {
   return Number.isInteger(value) && value >= 0;
 }
 
-const feesDistribution = computed<FeesDistribution>(() => ({
-  leaderTimeoutFee: consensusStore.leaderTimeoutFee,
-  validatorsTimeoutFee: consensusStore.validatorsTimeoutFee,
-  appealRounds: consensusStore.appealRoundFee,
-  rotations: consensusStore.rotationsFee,
-}));
+const feesDistribution = computed<FeesDistribution | undefined>(() => {
+  if (!consensusStore.feesEnabled) return undefined;
+
+  return {
+    leaderTimeoutFee: consensusStore.leaderTimeoutFee,
+    validatorsTimeoutFee: consensusStore.validatorsTimeoutFee,
+    appealRounds: consensusStore.appealRoundFee,
+    rotations: consensusStore.rotationsFee,
+  };
+});
 </script>
 
 <template>

--- a/frontend/src/views/Simulator/RunDebugView.vue
+++ b/frontend/src/views/Simulator/RunDebugView.vue
@@ -12,6 +12,7 @@ import {
   useConsensusStore,
   useUIStore,
 } from '@/stores';
+import type { FeesDistribution } from '@/types';
 
 import ContractInfo from '@/components/Simulator/ContractInfo.vue';
 import BooleanField from '@/components/global/fields/BooleanField.vue';
@@ -51,7 +52,12 @@ function isFinalityWindowValid(value: number) {
   return Number.isInteger(value) && value >= 0;
 }
 
-const consensusMaxRotations = computed(() => consensusStore.maxRotations);
+const feesDistribution = computed<FeesDistribution>(() => ({
+  leaderTimeoutFee: consensusStore.leaderTimeoutFee,
+  validatorsTimeoutFee: consensusStore.validatorsTimeoutFee,
+  appealRounds: consensusStore.appealRoundFee,
+  rotations: consensusStore.rotationsFee,
+}));
 </script>
 
 <template>
@@ -106,7 +112,7 @@ const consensusMaxRotations = computed(() => consensusStore.maxRotations);
           v-if="isDeploymentOpen"
           @deployedContract="isDeploymentOpen = false"
           :leaderOnly="leaderOnly"
-          :consensusMaxRotations="consensusMaxRotations"
+          :feesDistribution="feesDistribution"
         />
 
         <ContractReadMethods
@@ -118,7 +124,7 @@ const consensusMaxRotations = computed(() => consensusStore.maxRotations);
           v-if="isDeployed"
           id="tutorial-write-methods"
           :leaderOnly="leaderOnly"
-          :consensusMaxRotations="consensusMaxRotations"
+          :feesDistribution="feesDistribution"
         />
         <TransactionsList
           id="tutorial-tx-response"

--- a/frontend/src/views/Simulator/RunDebugView.vue
+++ b/frontend/src/views/Simulator/RunDebugView.vue
@@ -84,7 +84,7 @@ const consensusMaxRotations = computed(() => consensusStore.maxRotations);
               required
               testId="input-finalityWindow"
               :disabled="false"
-              class="w-20"
+              class="h-6 w-20"
               tiny
             />
           </div>


### PR DESCRIPTION
Fixes #DXP-444

# What

<!-- Describe the changes you made. -->

- Added an on/off toggle button for fees in the simulator settings.
- When the toggle is off, the application sends `undefined` for fees to deploy and write method and hides the fee fields.
- Introduced a new `feesEnabled` state in the `consensusStore` to manage the toggle state.
- Updated the `feesDistribution` prop to be optional in several components.
- Modified the `useContractQueries` hook to handle the optional `feesDistribution`.

# Why

<!-- Why are you making these changes? This should be related to the issue created, and the value we are adding with this PR -->

To provide users with the ability to enable or disable fees dynamically.

# Testing done

<!-- Describe the tests you ran to verify your changes. -->

- Tested the toggle button to ensure it correctly updates the state and UI.
- Verified that when fees are disabled, `undefined` is sent and fee fields are hidden.
- Checked that existing functionality remains unaffected when fees are enabled.

# Decisions made

<!-- Describe any decisions made during the implementation of this PR. This should in general be in the code, but sometimes they are more related to the issue. For example: decisions on PR workflow -->

# Checks

- [x] I have tested this code
- [x] I have reviewed my own PR
- [x] I have created an issue for this PR
- [x] I have set a descriptive PR title compliant with [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)

# Reviewing tips

<!-- What can you tell the reviewer to make the review easier? -->

Focus on the changes.

# Depends on
This PR contains code from PR #1265.
Tests are failing because it depends on genlayer-js DXP-445.

# User facing release notes

<!-- What should the user know about this change? Think of it going into public forums for end users to read -->

- Introduced a new toggle feature to enable or disable fees in the simulator settings.
- When fees are disabled, related fields are hidden, and no fees are applied.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced granular fee configuration options for consensus mechanisms, including leader timeout, validators timeout, appeal rounds, and rotations per round.
  * Added a global toggle to enable or disable fees in the consensus settings.
  * Added new input sections for configuring multiple fee categories in the consensus settings UI.

* **Improvements**
  * Enhanced consensus settings UI for better modularity and clarity.
  * Fee-related settings are now persisted across sessions.

* **Refactor**
  * Replaced the previous single "Max Rotations" parameter with a comprehensive fee distribution structure throughout the simulator interface.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->