### PR TITLE
feat: create local profile for db

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -104,7 +104,7 @@ VITE_FINALITY_WINDOW_APPEAL_FAILED_REDUCTION = 0.2 # 20% reduction per appeal fa
 VITE_MAX_ROTATIONS = 3
 
 # Set the compose profile to 'hardhat' to use the hardhat network
-COMPOSE_PROFILES = 'hardhat'
+COMPOSE_PROFILES = 'hardhat, local'
 
 # Hardhat chain ID
 HARDHAT_CHAIN_ID = 61999

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -132,6 +132,7 @@ services:
         max-file: "3"
 
   postgres:
+    profiles: ["local"]
     image: postgres:16-alpine
     ports:
       - "${DBPORT}:5432"
@@ -152,9 +153,9 @@ services:
       options:
         max-size: "10m"
         max-file: "3"
-    # If you want your db to persist in dev
+    # Database data - use 'docker compose down -v' to wipe
     volumes:
-     - "./data/postgres:/var/lib/postgresql/data"
+      - postgres_data:/var/lib/postgresql/data
 
   database-migration:
     build:
@@ -194,3 +195,4 @@ volumes:
   hardhat_deployments:
   ignition_deployments:
   hardhat_snapshots:
+  postgres_data:


### PR DESCRIPTION
Fixes #DXP-515

# What

<!-- Describe the changes you made. -->

- Updated the `.env.example` file to include `local` in the `COMPOSE_PROFILES` setting, allowing for a local development environment alongside `hardhat`.
- Modified the `docker-compose.yml` to add a `local` profile for the `postgres` service, enabling for the use of an optional database.
- Changed the volume mapping for `postgres` to use a named volume `postgres_data` for persistent data storage or cleaning when using `-v`.

# Why

<!-- Why are you making these changes? This should be related to the issue created, and the value we are adding with this PR -->

- To enhance the development setup by allowing a local profile for the database and to make it possible to clean it.

# Testing done

<!-- Describe the tests you ran to verify your changes. -->

# Decisions made

<!-- Describe any decisions made during the implementation of this PR. This should in general be in the code, but sometimes they are more related to the issue. For example: decisions on PR workflow -->

# Checks

- [x] I have tested this code
- [x] I have reviewed my own PR
- [x] I have created an issue for this PR
- [x] I have set a descriptive PR title compliant with [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)

# Reviewing tips

<!-- What can you tell the reviewer to make the review easier? -->

# User facing release notes

<!-- What should the user know about this change? Think of it going into public forums for end users to read -->

Added support for a local development profile in the Docker setup, allowing for easier database management and persistence.