### PR TITLE
fix: incorrect rotation behavior on execution error

### DIFF
--- a/backend/consensus/utils.py
+++ b/backend/consensus/utils.py
@@ -2,16 +2,22 @@ from backend.consensus.types import ConsensusResult
 from backend.node.types import Vote
 
 
-def determine_consensus_from_votes(votes_list: list[str]) -> ConsensusResult:
+def determine_consensus_from_votes(
+    votes_list: list[str], leader_only: bool
+) -> ConsensusResult:
     """
     Determine consensus from a list of votes.
 
     Args:
         votes_list: List of vote strings
+        leader_only: Whether the transaction is leader-only
 
     Returns:
         ConsensusResult: The consensus result
     """
+    if leader_only:
+        return ConsensusResult.MAJORITY_AGREE
+
     agree_count = votes_list.count(Vote.AGREE.value)
     disagree_count = votes_list.count(Vote.DISAGREE.value)
     timeout_count = votes_list.count(Vote.TIMEOUT.value)

--- a/backend/database_handler/transactions_processor.py
+++ b/backend/database_handler/transactions_processor.py
@@ -308,7 +308,11 @@ class TransactionsProcessor:
                 len(transaction_data["consensus_history"]["consensus_results"]) - 1
             )
             last_round = transaction_data["consensus_history"]["consensus_results"][-1]
-            if "leader_result" in last_round and last_round["leader_result"]:
+            if (
+                "leader_result" in last_round
+                and last_round["leader_result"] is not None
+                and len(last_round["leader_result"]) > 1
+            ):
                 leader = last_round["leader_result"][1]
                 validator_votes_name.append(leader["vote"].upper())
                 vote_number = int(Vote.from_string(leader["vote"]))
@@ -336,7 +340,8 @@ class TransactionsProcessor:
             round_number = "0"
         last_round_result = int(
             determine_consensus_from_votes(
-                [vote.lower() for vote in validator_votes_name]
+                [vote.lower() for vote in validator_votes_name],
+                transaction_data["leader_only"],
             )
         )
 
@@ -542,7 +547,9 @@ class TransactionsProcessor:
             votes_temp = list(transaction_data["consensus_data"]["votes"].values())
         else:
             votes_temp = []
-        consensus_result = determine_consensus_from_votes(votes_temp)
+        consensus_result = determine_consensus_from_votes(
+            votes_temp, transaction_data["leader_only"]
+        )
         transaction_data["result"] = int(consensus_result)
         transaction_data["result_name"] = consensus_result.value
         return transaction_data

--- a/frontend/src/components/Simulator/TransactionItem.vue
+++ b/frontend/src/components/Simulator/TransactionItem.vue
@@ -419,44 +419,39 @@ function prettifyTxData(x: any): any {
             </div>
 
             <div
+              v-if="
+                (history?.leader_result && history.leader_result.length > 1) ||
+                (history?.validator_results &&
+                  history.validator_results.length > 0)
+              "
               class="divide-y overflow-hidden rounded border dark:border-gray-600"
             >
               <div
-                v-if="history?.leader_result"
+                v-if="
+                  history?.leader_result && history.leader_result.length > 1
+                "
                 class="flex flex-row items-center justify-between p-2 text-xs dark:border-gray-600"
               >
                 <div class="flex items-center gap-1">
                   <UserPen class="h-4 w-4" />
                   <span class="font-mono text-xs">{{
-                    history.leader_result[0].node_config.address
+                    history.leader_result[1].node_config.address
                   }}</span>
                 </div>
                 <div class="flex flex-row items-center gap-1 capitalize">
-                  <template v-if="history.leader_result.length === 1">
+                  <template v-if="history.leader_result[1].vote === 'agree'">
+                    <CheckCircleIcon class="h-4 w-4 text-green-500" />
+                    Agree
+                  </template>
+                  <template v-if="history.leader_result[1].vote === 'disagree'">
+                    <XCircleIcon class="h-4 w-4 text-red-500" />
+                    Disagree
+                  </template>
+                  <template v-if="history.leader_result[1].vote === 'timeout'">
                     <EllipsisHorizontalCircleIcon
                       class="h-4 w-4 text-yellow-500"
                     />
                     Timeout
-                  </template>
-                  <template v-else>
-                    <template v-if="history.leader_result[1].vote === 'agree'">
-                      <CheckCircleIcon class="h-4 w-4 text-green-500" />
-                      Agree
-                    </template>
-                    <template
-                      v-if="history.leader_result[1].vote === 'disagree'"
-                    >
-                      <XCircleIcon class="h-4 w-4 text-red-500" />
-                      Disagree
-                    </template>
-                    <template
-                      v-if="history.leader_result[1].vote === 'timeout'"
-                    >
-                      <EllipsisHorizontalCircleIcon
-                        class="h-4 w-4 text-yellow-500"
-                      />
-                      Timeout
-                    </template>
                   </template>
                 </div>
               </div>


### PR DESCRIPTION
Fixes #DXP-499
# What

<!-- Describe the changes you made. -->

- Updated the `PendingState` class in `backend/consensus/base.py` to handle leader-only transactions by setting the number of validators to 1. And modified the `ProposingState` class to no longer clear validators for leader-only transactions. So, we do not choose the 5 validators and then remove 4.
- Adjusted the `CommittingState` and `RevealingState` classes to account for leader-only transactions when emitting events.
- Updated the `determine_consensus_from_votes` function in `backend/consensus/utils.py` to handle leader-only transactions by returning a majority agree result. This way the transaction gets accepted and the contract gets deployed. If we did not do this then no votes means no majority which means undetermined state.
- Enhanced the `TransactionsProcessor` class in `backend/database_handler/transactions_processor.py` to correctly process leader-only transactions.
- Updated the `TransactionItem.vue` component in the frontend to correctly display the votes.

# Why

<!-- Why are you making these changes? This should be related to the issue created, and the value we are adding with this PR -->

- To fix a bug related to leader-only transactions not being handled correctly in the consensus process.

# Testing done

<!-- Describe the tests you ran to verify your changes. -->

- Tested in the local studio but running transactions.

# Decisions made

<!-- Describe any decisions made during the implementation of this PR. This should in general be in the code, but sometimes they are more related to the issue. For example: decisions on PR workflow -->

# Checks

- [x] I have tested this code
- [x] I have reviewed my own PR
- [x] I have created an issue for this PR
- [x] I have set a descriptive PR title compliant with [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)

# Reviewing tips

<!-- What can you tell the reviewer to make the review easier? -->

- Focus on the changes.

# User facing release notes

<!-- What should the user know about this change? Think of it going into public forums for end users to read -->

- Improved handling of leader-only transactions in the consensus process.
- Enhanced frontend display of transaction votes.