### PR TITLE
fix: hotfix genvm executuon timeout

### DIFF
--- a/backend/node/genvm/base.py
+++ b/backend/node/genvm/base.py
@@ -411,7 +411,7 @@ async def _run_genvm_host(
 ) -> ExecutionResult:
     tmpdir = Path(tempfile.mkdtemp())
     try:
-        timeout = 300  # seconds
+        timeout = 600  # seconds
         base_delay = 5  # seconds
         start_time = time.time()
         retry_count = 0


### PR DESCRIPTION
Increased the GenVM Execution timeout from 300s to 600s

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Increased operation timeout from 5 to 10 minutes to reduce premature VM timeout errors, improving reliability for longer-running tasks.
  * No changes required from users; behavior remains the same except for fewer VM_ERROR timeouts on extended operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->