### PR TITLE
feat: use genlayerjs connect method in the studio

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -102,6 +102,7 @@ VALIDATORS_CONFIG_JSON = ''
 VITE_FINALITY_WINDOW = 1800 # in seconds
 VITE_FINALITY_WINDOW_APPEAL_FAILED_REDUCTION = 0.2 # 20% reduction per appeal failed
 VITE_MAX_ROTATIONS = 3
+VITE_NETWORK = 'localnet'
 
 # Set the compose profile to 'hardhat' to use the hardhat network
 COMPOSE_PROFILES = 'hardhat'

--- a/frontend/src/stores/accounts.ts
+++ b/frontend/src/stores/accounts.ts
@@ -3,7 +3,9 @@ import { computed, ref } from 'vue';
 import type { Address } from '@/types';
 import { createAccount, generatePrivateKey } from 'genlayer-js';
 import { useShortAddress } from '@/hooks';
-import { notify } from '@kyvg/vue3-notification';
+import { notify } from '@kyvg/vue3-notification'
+;import { useGenlayer } from '@/hooks';
+
 
 export interface AccountInfo {
   type: 'local' | 'metamask';
@@ -160,6 +162,13 @@ export const useAccountsStore = defineStore('accountsStore', () => {
   }
 
   function setCurrentAccount(account: AccountInfo | null) {
+    // Calling connect method here instead of relying on the UI button (shown only when
+    // no MetaMask account was previously connected). If the user deletes the network,
+    // that button won’t reappear; connecting on selection covers this edge case.
+    if (account?.type === 'metamask') {
+      const genlayer = useGenlayer();
+      genlayer.client?.value?.connect(import.meta.env.VITE_NETWORK);
+    }
     selectedAccount.value = account;
   }
 


### PR DESCRIPTION
### What
- Connect MetaMask inside `setCurrentAccount` to cover the “deleted network” edge case.
- The connect method also creates the Genlayer network if missing, switches to it, and installs the Genlayer wallet when needed.
- Update `.env.example` to document network-related configuration.

### Why
- Ensure MetaMask stays connected even if the user manually deletes the network and the UI connect button doesn’t reappear.
- Clarify required env configuration for smoother setup.

### Testing done
- Manually removed the Genlayer network in MetaMask; selecting a MetaMask account auto-connected and switched network.
- Switched MetaMask accounts and verified reconnection and network switching.
- Verified local account flow unaffected.

### Decisions made
- Triggering connect in `setCurrentAccount` instead of relying solely on the UI button, because the button only shows when no MetaMask account was previously connected; connecting on selection covers the edge case after a user removes the network.
- Known limitation: studionet and localnet currently share the same chainId, so `genlayer-js` cannot distinguish them when using a MetaMask account. This will be addressed separately when studionet and localnet have distinct chainIds.

### Reviewing tips
- Focus on the small change in `setCurrentAccount` and its inline comment rationale.
- Ensure `.env.example` aligns with current env usage (e.g., network configuration).

### User facing release notes
- MetaMask accounts now automatically connect and switch to the Genlayer network on selection, even if the user previously removed the network, reducing friction and avoiding broken states.
- Note: studionet and localnet currently share a chainId, which may affect MetaMask behavior. A future update will assign distinct chainIds.