### PR TITLE
ci: adding vector to studio compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -191,6 +191,24 @@ services:
       traefik.http.routers.hardhat.entrypoints: websecure
       traefik.http.routers.hardhat.tls: true
 
+  vector:
+    profiles: ["studio"]
+    image: timberio/vector:latest-alpine
+    container_name: vector
+    environment:
+      - GOOGLE_APPLICATION_CREDENTIALS=/etc/vector/gcp_credentials.json
+      - VECTOR_LOG=info
+      - GCP_PROJECT_ID=simulator-440803
+    volumes:
+      - ./vector.yaml:/etc/vector/vector.yaml:ro
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+      - ./gcp_credentials.json:/etc/vector/gcp_credentials.json:ro
+      - /var/log:/var/log:ro  # Mount the host's /var/log directory
+    network_mode: host
+    restart: unless-stopped
+    labels:
+      org.label-schema.group: "monitoring"
+
 volumes:
   hardhat_artifacts:
   hardhat_cache:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -198,7 +198,7 @@ services:
     environment:
       - GOOGLE_APPLICATION_CREDENTIALS=/etc/vector/gcp_credentials.json
       - VECTOR_LOG=info
-      - GCP_PROJECT_ID=simulator-440803
+      - GCP_PROJECT_ID=${GCP_PROJECT_ID}
     volumes:
       - ./vector.yaml:/etc/vector/vector.yaml:ro
       - /var/run/docker.sock:/var/run/docker.sock:ro

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -193,7 +193,7 @@ services:
 
   vector:
     profiles: ["studio"]
-    image: timberio/vector:latest-alpine
+    image: timberio/vector:0.42.0-alpine
     container_name: vector
     environment:
       - GOOGLE_APPLICATION_CREDENTIALS=/etc/vector/gcp_credentials.json
@@ -204,7 +204,7 @@ services:
       - /var/run/docker.sock:/var/run/docker.sock:ro
       - ./gcp_credentials.json:/etc/vector/gcp_credentials.json:ro
       - /var/log:/var/log:ro  # Mount the host's /var/log directory
-    network_mode: host
+    # network_mode: host
     restart: unless-stopped
     labels:
       org.label-schema.group: "monitoring"

--- a/vector.yaml
+++ b/vector.yaml
@@ -3,7 +3,7 @@ sources:
     type: docker_logs
     exclude_containers: 
       - vector
-  
+
 transforms:
   docker_logs_transform:
     type: remap
@@ -14,7 +14,7 @@ transforms:
       .labels = {"job": "docker", "instance": get_hostname!(), "container": .container_name}
       # Convert timestamp to RFC3339
       .timestamp = format_timestamp!(.timestamp, format: "%+")
-      
+
 sinks:
   gcp_logs:
     type: gcp_stackdriver_logs

--- a/vector.yaml
+++ b/vector.yaml
@@ -29,3 +29,13 @@ sinks:
       verify_certificate: true
     request:
       retry_attempts: 3
+
+  gcp_pubsub:
+    type: gcp_pubsub
+    inputs:
+      - docker_logs_transform
+    credentials_path: /etc/vector/gcp_credentials.json
+    project: "${GCP_PROJECT_ID}"
+    topic: "projects/simulator-440803/topics/observability_logs"
+    encoding:
+      codec: json

--- a/vector.yaml
+++ b/vector.yaml
@@ -1,7 +1,7 @@
 sources:
   docker_logs:
     type: docker_logs
-    exclude_containers: 
+    exclude_containers:
       - vector
 
 transforms:

--- a/vector.yaml
+++ b/vector.yaml
@@ -1,0 +1,31 @@
+sources:
+  docker_logs:
+    type: docker_logs
+    exclude_containers: 
+      - vector
+  
+transforms:
+  docker_logs_transform:
+    type: remap
+    inputs:
+      - docker_logs
+    source: |
+      # Add standard Loki labels
+      .labels = {"job": "docker", "instance": get_hostname!(), "container": .container_name}
+      # Convert timestamp to RFC3339
+      .timestamp = format_timestamp!(.timestamp, format: "%+")
+      
+sinks:
+  gcp_logs:
+    type: gcp_stackdriver_logs
+    inputs:
+      - docker_logs_transform
+    credentials_path: /etc/vector/gcp_credentials.json
+    log_id: "genlayer-logs"
+    project_id: "${GCP_PROJECT_ID}"
+    resource:
+      type: "generic_node"
+    tls:
+      verify_certificate: true
+    request:
+      retry_attempts: 3


### PR DESCRIPTION
# What

Adding Vector to Studio.

- changed docker-compose.yml
- added vector.yml

# Why

To collect logs from Studio and send to GCP Logs

# Testing done

We'll test when deploying.

# Decisions made

We need to see the logs from Studio

# Checks

- [ ] I have tested this code
- [ ] I have reviewed my own PR
- [ ] I have created an issue for this PR
- [ ] I have set a descriptive PR title compliant with [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)

# Reviewing tips

# User facing release notes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional "studio" logging service that collects Docker and host logs (excluding its own) and forwards them to Google Cloud (Logs and Pub/Sub) with TLS and retry protection.
  * Logs are enriched with labels (job, instance, container) and normalized to RFC3339 timestamps.
  * Service restarts unless stopped and is labeled under monitoring.
  * Added persistent volumes for deployments and database storage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->