### PR TITLE
feat(rpc): add gen_getContractCode endpoint; store accounts data a…

### DIFF
--- a/backend/database_handler/accounts_manager.py
+++ b/backend/database_handler/accounts_manager.py
@@ -42,7 +42,7 @@ class AccountsManager:
             return existing_account
 
         # If account doesn't exist, create it
-        account = CurrentState(id=address, data="{}", balance=0)
+        account = CurrentState(id=address, data={}, balance=0)
         self.session.add(account)
         self.session.commit()
         return account

--- a/backend/database_handler/contract_snapshot.py
+++ b/backend/database_handler/contract_snapshot.py
@@ -1,7 +1,8 @@
 # database_handler/contract_snapshot.py
 from .models import CurrentState
 from sqlalchemy.orm import Session
-from typing import Optional
+from typing import Optional, Dict
+import base64
 
 
 class ContractSnapshot:
@@ -14,7 +15,7 @@ class ContractSnapshot:
     contract_address: str
     contract_code: str
     balance: int
-    states: dict[str, dict[str, str]]
+    states: Dict[str, Dict[str, str]]
 
     def __init__(self, contract_address: str | None, session: Session):
         if contract_address is not None:
@@ -65,3 +66,45 @@ class ContractSnapshot:
             raise Exception(f"Contract {self.contract_address} not found")
 
         return result
+
+    def get_deployed_code_b64(self) -> Optional[str]:
+        """Return base64-encoded deployed contract code extracted from self.states.
+
+        Returns None if the contract code is not present or cannot be decoded.
+        """
+        return ContractSnapshot.extract_deployed_code_b64_from_state(self.states)
+
+    @staticmethod
+    def extract_deployed_code_b64_from_state(state: dict) -> Optional[str]:
+        """Given a state mapping, extract the deployed contract code as base64.
+
+        This reads the code slot key, fetches the stored blob, validates and
+        slices out the code payload, and returns it base64-encoded. Returns None
+        if missing/invalid.
+        """
+        # Import here to avoid circular dependencies at module import time
+        from backend.node.genvm.origin.base_host import get_code_slot
+
+        if not isinstance(state, dict):
+            return None
+
+        accepted = state.get("accepted") or {}
+
+        try:
+            code_slot_b64 = base64.b64encode(get_code_slot()).decode("ascii")
+            stored = accepted.get(code_slot_b64)
+            if not stored:
+                return None
+
+            raw = base64.b64decode(stored, validate=True)
+            if len(raw) < 4:
+                return None
+
+            code_len = int.from_bytes(raw[0:4], byteorder="little", signed=False)
+            if len(raw) < 4 + code_len:
+                return None
+
+            code_bytes = raw[4 : 4 + code_len]
+            return base64.b64encode(code_bytes).decode("ascii")
+        except Exception:
+            return None

--- a/backend/protocol_rpc/endpoints.py
+++ b/backend/protocol_rpc/endpoints.py
@@ -438,6 +438,12 @@ def get_contract_code(
         )
     contract_account = accounts_manager.get_account_or_fail(contract_address)
 
+    # Legacy compatibility note:
+    # Historically, some rows in `current_state` were inserted with `data` as a
+    # JSON string (e.g., "{}") instead of a JSONB object. To avoid `.get` errors
+    # and keep backward compatibility, normalize string-valued `data` by parsing
+    # it into a dict. If parsing fails or the result is empty, treat it as an
+    # undeployed contract and return the standard error.
     data = contract_account.get("data") or {}
     if isinstance(data, str):
         try:

--- a/backend/protocol_rpc/endpoints.py
+++ b/backend/protocol_rpc/endpoints.py
@@ -428,9 +428,7 @@ async def get_contract_schema_for_code(
     return json.loads(schema)
 
 
-def get_contract_code(
-    accounts_manager: AccountsManager, contract_address: str
-) -> str:
+def get_contract_code(accounts_manager: AccountsManager, contract_address: str) -> str:
     if not accounts_manager.is_valid_address(contract_address):
         raise InvalidAddressError(
             contract_address,

--- a/backend/protocol_rpc/endpoints.py
+++ b/backend/protocol_rpc/endpoints.py
@@ -466,7 +466,10 @@ def get_contract_code(
             "Contract not deployed.",
         )
 
-    raw = base64.b64decode(stored)
+    try:
+        raw = base64.b64decode(stored, validate=True)
+    except Exception:
+        raise InvalidAddressError(contract_address, "Contract not deployed.")
     if len(raw) < 4:
         raise InvalidAddressError(
             contract_address,
@@ -474,6 +477,8 @@ def get_contract_code(
         )
 
     code_len = int.from_bytes(raw[0:4], byteorder="little", signed=False)
+    if len(raw) < 4 + code_len:
+        raise InvalidAddressError(contract_address, "Contract not deployed.")
     code_bytes = raw[4 : 4 + code_len]
     return base64.b64encode(code_bytes).decode("ascii")
 


### PR DESCRIPTION
### What
- Add RPC endpoint `gen_getContractCode` to return contract code from `current_state.data.state.accepted[BASE64(get_code_slot())]`.
- Register the endpoint in `register_all_rpc_endpoints`.
- Update `AccountsManager.create_new_account_with_address` to initialize `data` as `{}` (JSONB object) instead of `"{}"` (string), avoiding str/dict mismatches.

### Why
- Align code retrieval with the canonical storage layout used by GenVM.
- Eliminate errors when `data` is a string (e.g., "'str' object has no attribute 'get'").
- Provide a simple, reliable way for clients to fetch contract code for tooling (schema generation, debugging, etc.).

### Testing done
- Called `gen_getContractCode` for a deployed contract; received Base64-encoded code and decoded to bytes with `b64ToArray`.
- Verified returned code works with `gen_getContractSchemaForCode` after converting to 0x-hex.
- Verified undeployed/empty state returns JSON-RPC error “Contract not deployed.”.
- Created a new account and confirmed `current_state.data` is a JSONB object (`{}`), not `"{}"`.

### Decisions made
- Server strips the 4-byte little-endian length prefix stored in the code slot and returns only raw code bytes (Base64).
- No backfill migration included; legacy rows with `"{}"` remain. Optional DB update can be handled in a separate PR if needed.

### Checks
- [x] I have tested this code
- [x] I have reviewed my own PR
- [ ] I have created an issue for this PR
- [x] I have set a descriptive PR title compliant with conventional commits

### Reviewing tips
- Focus on `backend/protocol_rpc/endpoints.py` (new `get_contract_code` and registration) and `backend/database_handler/accounts_manager.py` (data initialization).
- Confirm `get_code_slot` is used and the value is looked up under `data.state.accepted[BASE64(slot)]`.
- Check that only Base64 code bytes are returned (no length prefix).

### User facing release notes
- New JSON-RPC method `gen_getContractCode(address)` returns the contract’s code as Base64.
- New accounts now store `data` as a JSON object, improving compatibility and preventing errors in downstream reads.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an RPC endpoint to retrieve a contract’s deployed code by address, returning the code as base64 for wallets, explorers, and dev tools.

* **Bug Fixes**
  * Default account state for new addresses now initializes as an empty object to avoid inconsistencies.
  * Normalized legacy contract state formats to reliably detect and extract deployed code.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->