### PR TITLE
fix: close database session after initializing validators

### DIFF
--- a/backend/protocol_rpc/endpoint_generator.py
+++ b/backend/protocol_rpc/endpoint_generator.py
@@ -146,9 +146,6 @@ def setup_eth_method_handler(jsonrpc: JSONRPC):
                 method = request_json.get("method", "")
                 if method.startswith("eth_"):
                     site = jsonrpc.get_jsonrpc_site()
-                    print(site.view_funcs)
-                    print(method)
-                    print(method in site.view_funcs)
                     return None  # Use local implementation
                     # if method in site.view_funcs:
                     # else:

--- a/backend/protocol_rpc/server.py
+++ b/backend/protocol_rpc/server.py
@@ -79,12 +79,15 @@ async def create_app():
     transactions_parser = TransactionParser(consensus_service)
 
     initialize_validators_db_session = create_session()
-    await initialize_validators(
-        os.environ["VALIDATORS_CONFIG_JSON"],
-        ModifiableValidatorsRegistry(initialize_validators_db_session),
-        AccountsManager(initialize_validators_db_session),
-    )
-    initialize_validators_db_session.commit()
+    try:
+        await initialize_validators(
+            os.environ["VALIDATORS_CONFIG_JSON"],
+            ModifiableValidatorsRegistry(initialize_validators_db_session),
+            AccountsManager(initialize_validators_db_session),
+        )
+        initialize_validators_db_session.commit()
+    finally:
+        initialize_validators_db_session.close()
 
     validators_manager = validators.Manager(create_session())
     await validators_manager.restart()

--- a/backend/protocol_rpc/server.py
+++ b/backend/protocol_rpc/server.py
@@ -98,12 +98,12 @@ async def create_app():
             try:
                 await initialize_validators(
                     os.environ["VALIDATORS_CONFIG_JSON"],
-                    ModifiableValidatorsRegistry(initialize_validators_db_session),
-                    AccountsManager(initialize_validators_db_session),
+                    ModifiableValidatorsRegistry(session),
+                    AccountsManager(session),
                 )
-                initialize_validators_db_session.commit()
+                session.commit()
             finally:
-                initialize_validators_db_session.close()
+                session.close()
         else:
             print("VALIDATORS_CONFIG_JSON not set, skipping validator initialization")
 


### PR DESCRIPTION
The initialize_validators_db_session was not being closed after use, causing a connection leak that contributed to QueuePool exhaustion. This fix ensures the session is properly closed in a finally block.

Fixes issue where QueuePool limit of size 100 overflow 50 reached

<!-- This is a TEMPLATE, modify it to fit your needs. -->

Fixes #issue-number-here

# What

<!-- Describe the changes you made. -->

- changed thing a for b
- also did this other unrelated thing in my path

# Why

<!-- Why are you making these changes? This should be related to the issue created, and the value we are adding with this PR -->

- to fix a bug
- to add more value to the user

# Testing done

<!-- Describe the tests you ran to verify your changes. -->

- tested the new feature
- tested the bug fix

# Decisions made

<!-- Describe any decisions made during the implementation of this PR. This should in general be in the code, but sometimes they are more related to the issue. For example: decisions on PR workflow -->

# Checks

- [ ] I have tested this code
- [ ] I have reviewed my own PR
- [ ] I have created an issue for this PR
- [ ] I have set a descriptive PR title compliant with [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)

# Reviewing tips

<!-- What can you tell the reviewer to make the review easier? -->

# User facing release notes

<!-- What should the user know about this change? Think of it going into public forums for end users to read -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Validator initialization now runs in a dedicated session that is always closed, improving startup stability and preventing resource leaks.
  - Initialization commits more reliably and reads validator configuration from the environment; behavior unchanged when that configuration is absent.

- **Chores**
  - Removed extraneous debug logging to reduce console noise.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->