### PR TITLE
feat: removing the full path from the pub/sub topic

### DIFF
--- a/vector.yaml
+++ b/vector.yaml
@@ -36,6 +36,6 @@ sinks:
       - docker_logs_transform
     credentials_path: /etc/vector/gcp_credentials.json
     project: "${GCP_PROJECT_ID}"
-    topic: "projects/simulator-440803/topics/observability_logs"
+    topic: "observability_logs"
     encoding:
       codec: json


### PR DESCRIPTION
# What

- Updating `GCP Pub/Sub` sink configuration in `Vector`

# Why

- The Vector GCP Pub/Sub sink was generating 404 errors because it was constructing malformed URLs like /v1/projects//topics/projects/simulator-440803/topics/observability_logs:publish due to having both a project field and a full topic path in the topic field.

# Testing done

# Decisions made

# Checks

- [ ] I have tested this code
- [ ] I have reviewed my own PR
- [ ] I have created an issue for this PR
- [ ] I have set a descriptive PR title compliant with [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)

# Reviewing tips

# User facing release notes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Revised Pub/Sub topic reference in the logging pipeline configuration to use the topic name (observability_logs) instead of the full resource path. This aligns with current deployment settings and should not affect log forwarding behavior. No user action required. Monitoring and alerting remain unchanged. Applies to all environments. Release does not modify data schema or retention.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->