### PR TITLE
fix: using SERVER_NAME instead of get_hostname for host

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -199,6 +199,7 @@ services:
       - GOOGLE_APPLICATION_CREDENTIALS=/etc/vector/gcp_credentials.json
       - VECTOR_LOG=info
       - GCP_PROJECT_ID=${GCP_PROJECT_ID}
+      - SERVER_NAME=${SERVER_NAME}
     volumes:
       - ./vector.yaml:/etc/vector/vector.yaml:ro
       - /var/run/docker.sock:/var/run/docker.sock:ro

--- a/vector.yaml
+++ b/vector.yaml
@@ -11,7 +11,7 @@ transforms:
       - docker_logs
     source: |
       # Add standard Loki labels
-      .labels = {"job": "docker", "instance": get_hostname!(), "container": .container_name}
+      .labels = {"job": "docker", "instance": "${SERVER_NAME}", "container": .container_name}
       # Convert timestamp to RFC3339
       .timestamp = format_timestamp!(.timestamp, format: "%+")
 


### PR DESCRIPTION
# What

- Replace `get_hostname!()` with `${SERVER_NAME}` in Vector logging configuration to show actual server hostname instead of random Docker container IDs
- Add `SERVER_NAME` environment variable to Vector service in `docker-compose.yml`

# Why

-  The host field in Google Cloud logs was showing random container IDs (e.g., eddfc10ceebf) instead of the actual server hostname, making log analysis difficult.

# Testing done

# Decisions made

- Updated `vector.yaml` to use `${SERVER_NAME}` for the instance label instead of `get_hostname!()`
- Added `SERVER_NAME` environment variable to the Vector service configuration

# Checks

- [ ] I have tested this code
- [ ] I have reviewed my own PR
- [ ] I have created an issue for this PR
- [ ] I have set a descriptive PR title compliant with [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)

# Reviewing tips

<!-- What can you tell the reviewer to make the review easier? -->

# User facing release notes

<!-- What should the user know about this change? Think of it going into public forums for end users to read -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for setting a server instance name via SERVER_NAME for the Vector service.
  * Log records now use SERVER_NAME for the instance label, enabling consistent, deployment-specific tagging.

* **Chores**
  * Updated docker-compose and Vector configuration to recognize and apply the SERVER_NAME environment variable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->