### PR TITLE
fix: clear votes dict when starting rotation

### DIFF
--- a/backend/consensus/base.py
+++ b/backend/consensus/base.py
@@ -1910,6 +1910,7 @@ class ProposingState(TransactionState):
 
         # Update the consensus data with the leader's vote and receipt
         context.consensus_data.votes = {}
+        context.votes = {}
         context.consensus_data.validators = []
         context.transactions_processor.set_transaction_result(
             context.transaction.hash, context.consensus_data.to_dict()


### PR DESCRIPTION
Fixes #DXP-644
# What

<!-- Describe the changes you made. -->

- Updated the `ProposingState` class in `backend/consensus/base.py` to initialize `context.votes` as an empty dictionary.

# Why

<!-- Why are you making these changes? This should be related to the issue created, and the value we are adding with this PR -->

- To fix a bug where `context.votes` was not initialized, so leader votes were still there when updating it.

# Testing done

<!-- Describe the tests you ran to verify your changes. -->

- Checked with UI.

# Decisions made

<!-- Describe any decisions made during the implementation of this PR. This should in general be in the code, but sometimes they are more related to the issue. For example: decisions on PR workflow -->

# Checks

- [x] I have tested this code
- [x] I have reviewed my own PR
- [x] I have created an issue for this PR
- [x] I have set a descriptive PR title compliant with [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)

# Reviewing tips

<!-- What can you tell the reviewer to make the review easier? -->

- Focus on the change.

# User facing release notes

<!-- What should the user know about this change? Think of it going into public forums for end users to read -->

Fixed an issue in the consensus mechanism where votes were not being initialized correctly.