### PR TITLE
fix: Enhance log parsing to support additional formats

### DIFF
--- a/vector.yaml
+++ b/vector.yaml
@@ -50,26 +50,33 @@ transforms:
       } else {
       # Parse severity from various log formats
       # Plain format: "INFO | message" or "ERROR    | message" (with any amount of spacing)
-      plain_parsed = parse_regex(.message, r'^(?P<level>INFO|ERROR|WARNING|WARN|DEBUG|CRITICAL|TRACE|NOTICE|SEVERE)\s*\|') ?? {}
-      # Loguru format with ANSI codes: [1mLEVEL[0m | message
+      plain_parsed = parse_regex(.message, r'^(?P<level>INFO|ERROR|WARNING|WARN|DEBUG|CRITICAL|TRACE|NOTICE|SEVERE|SUCCESS)\s*\|') ?? {}
+      # True ANSI escape with bold: \u001b[1mLEVEL\u001b[0m | message (THIS IS WHAT YOUR LOGS USE!)
+      ansi_bold_parsed = parse_regex(.message, r'^\u001b\[1m(?P<level>INFO|ERROR|WARNING|WARN|DEBUG|CRITICAL|TRACE|NOTICE|SEVERE|SUCCESS)\s*\u001b\[0m\s*\|') ?? {}
+      # True ANSI escape with colors: \u001b[32mLEVEL\u001b[0m (green), \u001b[31mERROR\u001b[0m (red), etc
+      ansi_color_parsed = parse_regex(.message, r'^\u001b\[\d+m(?P<level>INFO|ERROR|WARNING|WARN|DEBUG|CRITICAL|TRACE|NOTICE|SEVERE|SUCCESS)\s*\u001b\[0m') ?? {}
+      # Combined ANSI color + bold: \u001b[31m\u001b[1mERROR\u001b[0m
+      ansi_combined_parsed = parse_regex(.message, r'^\u001b\[\d+m\u001b\[1m(?P<level>INFO|ERROR|WARNING|WARN|DEBUG|CRITICAL|TRACE|NOTICE|SEVERE|SUCCESS)\s*\u001b\[0m') ?? {}
+      # Fallback patterns for other formats
       ansi_parsed = parse_regex(.message, r'^\[1m(?P<level>\w+)\s*\[0m\s*\|\s*(?P<msg>.*)') ?? {}
-      # Colored ANSI: [33m[1mWARNING[0m | message
       ansi_colored_parsed = parse_regex(.message, r'^\[\d+m\[1m(?P<level>\w+)\s*\[0m\s*\|\s*(?P<msg>.*)') ?? {}
-      # True ANSI escape: ESC[1mLEVEL ESC[0m | message
-      ansi_esc_parsed = parse_regex(.message, r'^\x1b\[1m(?P<level>\w+)\s*\x1b\[0m\s*\|\s*(?P<msg>.*)') ?? {}
-      # XML format: <level>LEVEL</level> | message
       xml_parsed = parse_regex(.message, r'^<level>(?P<level>\w+)\s*</level>\s*\|\s*(?P<msg>.*)') ?? {}
 
-      if exists(plain_parsed.level) {
+      if exists(ansi_bold_parsed.level) {
+        # ANSI bold format detected (\u001b[1mLEVEL\u001b[0m | message) - YOUR PRODUCTION LOGS!
+        .severity = strip_whitespace(upcase!(ansi_bold_parsed.level))
+      } else if exists(ansi_color_parsed.level) {
+        # ANSI color format detected (\u001b[32mLEVEL\u001b[0m)
+        .severity = strip_whitespace(upcase!(ansi_color_parsed.level))
+      } else if exists(ansi_combined_parsed.level) {
+        # Combined ANSI color+bold format detected
+        .severity = strip_whitespace(upcase!(ansi_combined_parsed.level))
+      } else if exists(plain_parsed.level) {
         # Plain format detected (INFO     | message)
         .severity = strip_whitespace(upcase!(plain_parsed.level))
-        # Don't change the message, just set severity
       } else if exists(ansi_colored_parsed.level) {
         # Colored ANSI format detected ([33m[1m....[0m)
         .severity = strip_whitespace(upcase!(ansi_colored_parsed.level))
-      } else if exists(ansi_esc_parsed.level) {
-        # True ANSI escape format detected (ESC[1m...ESC[0m)
-        .severity = strip_whitespace(upcase!(ansi_esc_parsed.level))
       } else if exists(ansi_parsed.level) {
         # ANSI format detected ([1m...[0m)
         .severity = strip_whitespace(upcase!(ansi_parsed.level))


### PR DESCRIPTION
<!-- This is a TEMPLATE, modify it to fit your needs. -->

# What

<!-- Describe the changes you made. -->

Enhance log parsing to support additional formats including plain, ANSI, and XML

# Why

<!-- Why are you making these changes? This should be related to the issue created, and the value we are adding with this PR -->

Vector was not parsing 

-  message: "INFO     | BEGIN (implicit)"
- message: "eth_blockNumber (5)"
- message: "ERROR    | jsonrpc error | exc=flask_jsonrpc.exceptions.JSONRPCError | tb=File 
  "/usr/local/lib/python3.12/dist-packages/flask_jsonrpc/site.py", line 128, in handle_dispatch_except
  
<img width="1119" height="322" alt="Screenshot 2025-09-09 at 16 45 00" src="https://github.com/user-attachments/assets/6238c383-9056-4010-ab5c-6c3165740e4f" />

# Checks

- [x] I have tested this code
- [x] I have reviewed my own PR
- [ ] I have created an issue for this PR
- [x] I have set a descriptive PR title compliant with [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)

# Reviewing tips

Deploy to Deploy dKOL Studio to Development environment and watch the logs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Broader severity detection across plain, ANSI (bold/colored/combined), and XML inputs with ordered fallbacks; recognizes TRACE, NOTICE, SEVERE and remaps them (TRACE→DEBUG, NOTICE→INFO, SEVERE→ERROR). Adds numeric severity mapping for GCP, enforces uppercase severities, and supplies a default RFC3339 timestamp when missing. Adds a debug_console output to emit diagnostic JSON to stdout.

* **Bug Fixes**
  * Parsed variants no longer overwrite the original message; only severity is updated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->