### PR TITLE
fix: Create getTransactionStatus endpoint for lighter data retrieval

### DIFF
--- a/backend/database_handler/transactions_processor.py
+++ b/backend/database_handler/transactions_processor.py
@@ -1088,3 +1088,12 @@ class TransactionsProcessor:
             .count()
         )
         return count
+
+    def get_transaction_status(self, transaction_hash: str) -> str | None:
+        transaction = (
+            self.session.query(Transactions).filter_by(hash=transaction_hash).first()
+        )
+        if not transaction:
+            return None
+        transaction_status = transaction.status
+        return transaction_status.value

--- a/backend/protocol_rpc/endpoints.py
+++ b/backend/protocol_rpc/endpoints.py
@@ -733,6 +733,12 @@ def get_transaction_by_hash(
     return transactions_processor.get_transaction_by_hash(transaction_hash)
 
 
+def get_transaction_status(
+    transactions_processor: TransactionsProcessor, transaction_hash: str
+) -> str | None:
+    return transactions_processor.get_transaction_status(transaction_hash)
+
+
 async def eth_call(
     session: Session,
     accounts_manager: AccountsManager,
@@ -1426,4 +1432,8 @@ def register_all_rpc_endpoints(
     register_rpc_endpoint(
         partial(dev_get_pool_status, sqlalchemy_db),
         method_name="dev_getPoolStatus",
+    )
+    register_rpc_endpoint(
+        partial(get_transaction_status, transactions_processor),
+        method_name="gen_getTransactionStatus",
     )


### PR DESCRIPTION
Fixes #DXP-652
# What

<!-- Describe the changes you made. -->

- Added a new function `get_transaction_status` in `TransactionsProcessor` to retrieve the status of a transaction by its hash.
- Registered a new RPC endpoint `gen_getTransactionStatus` in `endpoints.py` to expose the transaction status retrieval functionality.

# Why

<!-- Why are you making these changes? This should be related to the issue created, and the value we are adding with this PR -->

To provide a way to query the status of transactions.

# Testing done

<!-- Describe the tests you ran to verify your changes. -->

- Verified the new `get_transaction_status` function returns correct transaction statuses.
- Tested the `gen_getTransactionStatus` RPC endpoint to ensure it correctly interfaces with the backend logic.

# Decisions made

<!-- Describe any decisions made during the implementation of this PR. This should in general be in the code, but sometimes they are more related to the issue. For example: decisions on PR workflow -->

# Checks

- [x] I have tested this code
- [x] I have reviewed my own PR
- [x] I have created an issue for this PR
- [x] I have set a descriptive PR title compliant with [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)

# Reviewing tips

<!-- What can you tell the reviewer to make the review easier? -->

# User facing release notes

<!-- What should the user know about this change? Think of it going into public forums for end users to read -->

Introduced a new RPC endpoint `gen_getTransactionStatus` to allow users to query the status of transactions by their hash.