### PR TITLE
feat: added unit tests when PR is approved

### DIFF
--- a/.github/workflows/unit-tests-pr-approved.yml
+++ b/.github/workflows/unit-tests-pr-approved.yml
@@ -1,31 +1,26 @@
-name: "Unit Tests"
+name: "Unit Tests - PR Approved"
 
 on:
-  pull_request:
+  pull_request_review:
     types:
-      - opened
-      - synchronize
-  push:
-    branches:
-      - main # so that test reports get uploaded to Codecov and SonarCloud
-  workflow_dispatch:
+      - submitted
 
 permissions:
   contents: read
 
 jobs:
   frontend-unit-tests:
-    if: (github.actor != 'dependabot[bot]' && github.actor != 'renovate[bot]')
-    name: Unit Tests
+    if: (github.event.review.state == 'approved' && github.actor != 'dependabot[bot]' && github.actor != 'renovate[bot]')
+    name: Unit Tests (Real LLMs)
     uses: ./.github/workflows/frontend-unit-tests.yml
     secrets:
       codecov_token: ${{ secrets.CODECOV_TOKEN }}
 
   backend-unit-tests:
-    if: (github.actor != 'dependabot[bot]' && github.actor != 'renovate[bot]')
+    if: (github.event.review.state == 'approved' && github.actor != 'dependabot[bot]' && github.actor != 'renovate[bot]')
     runs-on: ubuntu-latest
     env:
-      TEST_WITH_MOCK_LLMS: "true"  # Always use mocks for PR create/update
+      TEST_WITH_MOCK_LLMS: "false"  # Use real LLMs for approved PRs
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,0 +1,218 @@
+"""
+Global fixtures and configuration for unit tests
+"""
+import os
+import pytest
+from unittest.mock import Mock, MagicMock, patch, AsyncMock
+import json
+
+# Check if we should use mocks
+USE_MOCKS = os.getenv("TEST_WITH_MOCK_LLMS", "true").lower() == "true"
+
+
+@pytest.fixture(autouse=True)
+def mock_llm_providers():
+    """
+    Mock LLM provider calls specifically
+    """
+    if not USE_MOCKS:
+        yield
+        return
+    
+    patches = []
+    
+    # Mock OpenAI responses
+    try:
+        import openai
+        
+        # Mock chat completion response
+        mock_completion = Mock()
+        mock_completion.choices = [
+            Mock(
+                message=Mock(content="Mocked LLM response"),
+                finish_reason="stop"
+            )
+        ]
+        mock_completion.usage = Mock(total_tokens=100)
+        
+        mock_create = Mock(return_value=mock_completion)
+        patches.append(patch('openai.ChatCompletion.create', mock_create))
+    except ImportError:
+        pass
+    
+    # Mock Anthropic responses
+    try:
+        import anthropic
+        
+        mock_response = Mock()
+        mock_response.content = [Mock(text="Mocked Anthropic response")]
+        mock_response.usage = Mock(input_tokens=50, output_tokens=50)
+        
+        mock_client = Mock()
+        mock_client.messages.create = Mock(return_value=mock_response)
+        patches.append(patch('anthropic.Anthropic', Mock(return_value=mock_client)))
+    except ImportError:
+        pass
+    
+    # Start all patches
+    for p in patches:
+        p.start()
+    
+    yield
+    
+    # Stop all patches
+    for p in patches:
+        p.stop()
+
+
+@pytest.fixture(autouse=True)
+def mock_external_services():
+    """
+    Automatically mock all external services when TEST_WITH_MOCK_LLMS=true
+    Returns mock responses instead of throwing exceptions
+    """
+    if not USE_MOCKS:
+        # If mocks are disabled, don't patch anything
+        yield
+        return
+    
+    patches = []
+    
+    # Mock web requests with realistic responses
+    try:
+        import requests
+        
+        # Create mock response object
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.ok = True
+        mock_response.text = '{"success": true, "data": "mocked response"}'
+        mock_response.json.return_value = {"success": True, "data": "mocked response"}
+        mock_response.headers = {"content-type": "application/json"}
+        mock_response.raise_for_status = Mock()
+        
+        # Mock request methods to return the mock response
+        mock_get = Mock(return_value=mock_response)
+        mock_post = Mock(return_value=mock_response)
+        mock_put = Mock(return_value=mock_response)
+        mock_delete = Mock(return_value=mock_response)
+        
+        patches.extend([
+            patch('requests.get', mock_get),
+            patch('requests.post', mock_post),
+            patch('requests.put', mock_put),
+            patch('requests.delete', mock_delete),
+            patch('requests.Session.get', mock_get),
+            patch('requests.Session.post', mock_post),
+        ])
+    except ImportError:
+        pass
+    
+    # Mock urllib with realistic responses
+    try:
+        import urllib.request
+        
+        mock_response = Mock()
+        mock_response.read.return_value = b'{"success": true, "data": "mocked response"}'
+        mock_response.getcode.return_value = 200
+        mock_response.headers = {"content-type": "application/json"}
+        
+        mock_urlopen = Mock(return_value=mock_response)
+        patches.append(patch('urllib.request.urlopen', mock_urlopen))
+    except ImportError:
+        pass
+    
+    # Mock aiohttp with async responses
+    try:
+        import aiohttp
+        
+        # Create async mock response
+        mock_response = AsyncMock()
+        mock_response.status = 200
+        mock_response.text = AsyncMock(return_value='{"success": true, "data": "mocked response"}')
+        mock_response.json = AsyncMock(return_value={"success": True, "data": "mocked response"})
+        mock_response.headers = {"content-type": "application/json"}
+        
+        # Create async session mock
+        mock_session = AsyncMock()
+        mock_session.__aenter__.return_value = mock_session
+        mock_session.__aexit__.return_value = None
+        mock_session.get.return_value.__aenter__.return_value = mock_response
+        mock_session.post.return_value.__aenter__.return_value = mock_response
+        
+        # Mock the ClientSession class
+        mock_client_session = Mock(return_value=mock_session)
+        patches.append(patch('aiohttp.ClientSession', mock_client_session))
+    except ImportError:
+        pass
+    
+    # Start all patches
+    for p in patches:
+        p.start()
+    
+    yield
+    
+    # Stop all patches
+    for p in patches:
+        p.stop()
+
+
+@pytest.fixture(autouse=True)
+def mock_webdriver():
+    """
+    Mock WebDriver/Selenium to prevent real browser instances
+    Returns mock driver instances instead of throwing exceptions
+    """
+    if not USE_MOCKS:
+        yield
+        return
+    
+    patches = []
+    
+    # Mock selenium webdriver if present
+    try:
+        from selenium import webdriver
+        
+        # Create mock driver with common methods
+        mock_driver = Mock()
+        mock_driver.get = Mock()
+        mock_driver.quit = Mock()
+        mock_driver.close = Mock()
+        mock_driver.find_element = Mock()
+        mock_driver.find_elements = Mock()
+        mock_driver.execute_script = Mock(return_value={"success": True})
+        mock_driver.page_source = "<html><body>Mocked page</body></html>"
+        mock_driver.title = "Mocked Page"
+        mock_driver.current_url = "http://mocked.url"
+        
+        # Mock element for find_element operations
+        mock_element = Mock()
+        mock_element.text = "Mocked element text"
+        mock_element.get_attribute = Mock(return_value="mocked attribute")
+        mock_element.click = Mock()
+        mock_element.send_keys = Mock()
+        mock_element.is_displayed = Mock(return_value=True)
+        
+        mock_driver.find_element.return_value = mock_element
+        mock_driver.find_elements.return_value = [mock_element]
+        
+        # Create mock constructors
+        mock_chrome = Mock(return_value=mock_driver)
+        mock_firefox = Mock(return_value=mock_driver)
+        
+        patches.extend([
+            patch.object(webdriver, 'Chrome', mock_chrome),
+            patch.object(webdriver, 'Firefox', mock_firefox),
+        ])
+    except ImportError:
+        pass
+    
+    # Start patches
+    for p in patches:
+        p.start()
+    
+    yield
+    
+    # Stop patches
+    for p in patches:
+        p.stop()


### PR DESCRIPTION
Fixes https://linear.app/genlayer-labs/issue/DXP-691/configure-github-actions-and-workflows-part1

## Summary
This PR configures GitHub Actions to run unit tests with mocked external services (LLMs and web requests) during PR creation/updates, and with real services when PRs are approved.

## Changes

### GitHub Actions Workflows
- **Added `TEST_WITH_MOCK_LLMS` environment variable** to `unit-tests-pr.yml` (set to `"true"`)
- **Created `unit-tests-pr-approved.yml`** workflow that triggers on PR approval (with `TEST_WITH_MOCK_LLMS="false"`)

### Test Infrastructure
- **Created `tests/unit/conftest.py`** with comprehensive mocking fixtures:
  - Mocks HTTP libraries (requests, urllib, aiohttp)
  - Mocks Selenium WebDriver
  - Mocks LLM providers (OpenAI, Anthropic)
  - Returns realistic mock responses instead of throwing exceptions
  - Automatically applied to all unit tests via `autouse=True`

## How It Works

1. **When a PR is created or updated:**
   - `unit-tests-pr.yml` runs with `TEST_WITH_MOCK_LLMS="true"`
   - All external services return mock responses
   - Tests run quickly without API keys

2. **When a PR is approved:**
   - `unit-tests-pr-approved.yml` runs with `TEST_WITH_MOCK_LLMS="false"`
   - Real LLMs and web services are used for validation
   - Ensures code works with actual external services

## Benefits
- ✅ Faster CI/CD pipeline for PR iterations
- ✅ No API keys needed during development
- ✅ Reliable tests (no external service failures)
- ✅ Real validation before merge

## Testing
The mocking has been verified to:
- Return valid HTTP 200 responses with JSON data
- Provide mock WebDriver instances with common methods
- Properly toggle between mocked and real services based on environment variable

## Related Issue
Closes DXP-691 (Part 1)