### PR TITLE
Dxp 697 transactions stuck in activated

### DIFF
--- a/backend/validators/greyboxing.lua
+++ b/backend/validators/greyboxing.lua
@@ -11,7 +11,7 @@ llm.exec_prompt_template_transform = function(args)
 	}
 
 	my_data = my_data[args.template]
-	local my_template = M.rs.templates[my_data.template_id]
+	local my_template = lib.rs.templates[my_data.template_id]
 
 	args.template = nil
 	local vars = args

--- a/backend/validators/greyboxing.lua
+++ b/backend/validators/greyboxing.lua
@@ -11,7 +11,7 @@ llm.exec_prompt_template_transform = function(args)
 	}
 
 	my_data = my_data[args.template]
-	local my_template = lib.rs.templates[my_data.template_id]
+	local my_template = llm.rs.templates[my_data.template_id]
 
 	args.template = nil
 	local vars = args

--- a/backend/validators/greyboxing.lua
+++ b/backend/validators/greyboxing.lua
@@ -189,6 +189,8 @@ function ExecPromptTemplate(ctx, args, remaining_gen)
 	---@cast args LLMExecPromptTemplatePayload
 
 	local template = args.template -- workaround by kp2pml30 (Kira) GVM-86
+	print("ExecPromptTemplate", args.template)
+	print("args", args)
 	local mapped = llm.exec_prompt_template_transform(args)
 	args.template = template
 

--- a/tests/unit/consensus/test_helpers.py
+++ b/tests/unit/consensus/test_helpers.py
@@ -315,6 +315,13 @@ class TransactionsProcessorMock:
         self.commit(transaction)
         return appeal_validators_timeout
 
+    def get_activated_transactions_older_than(self, seconds: int) -> list[dict]:
+        """Get ACTIVATED transactions that have been stuck for more than the specified seconds.
+        Mock implementation that returns empty list to prevent interference with tests.
+        """
+        # Return empty list in tests to prevent the safety mechanism from interfering
+        return []
+
 
 class SnapshotMock:
     def __init__(self, transactions_processor: TransactionsProcessorMock):


### PR DESCRIPTION
Fixes DXP-697: Transactions stuck in ACTIVATED state

### What

- Introduce per-address head blocking in `ConsensusAlgorithm` to preserve ordering when a predecessor isn’t ready, via `blocked_heads`.
- Gate execution on predecessor readiness; skip and keep head blocked when prior tx isn’t finalized/decided.
- Add recovery sweep to re-queue stuck `ACTIVATED` transactions older than 300s back to `PENDING` when queues are idle and not blocked; clear stale blocked heads.
- In `PendingState`, reuse original validators after rollback when available; otherwise clear old consensus data and select new validators.
- Add `TransactionsProcessor.get_activated_transactions_older_than(seconds)` for recovery logic.
- Extend `greyboxing.lua` with `llm.exec_prompt_template_transform` for template-to-prompt/format mapping.
- Update unit test helpers to mock the new `get_activated_transactions_older_than` method to avoid test interference.

### Why

- Ensure strict per-address transaction ordering while avoiding deadlocks when predecessors are undecided.
- Recover orphaned `ACTIVATED` transactions that can become stuck due to intermittent failures or race conditions.
- Improve resilience of rollback flows when original validators are no longer available.

### Testing done

- Ran Python unit tests: `pytest` (updated helpers for recovery sweep compatibility).
- Exercised consensus loop locally to confirm:
  - Blocked head is retained until predecessor becomes ready.
  - Stuck `ACTIVATED` transactions older than threshold are reset to `PENDING` when queues are idle and not blocked.
  - Validators are reused or reselected as intended on rollback.

### Decisions made

- Use a 300s threshold for identifying stuck `ACTIVATED` transactions.
- Skip recovery for addresses with a blocked head or when the blocked head is the same transaction.
- Clear `consensus_data` when replacing validators post-rollback to avoid stale assignments.

### Checks

- [x] I have tested this code
- [x] I have reviewed my own PR
- [x] I have created an issue for this PR
- [x] I have set a descriptive PR title compliant with conventional commits

### Reviewing tips

- Focus on `backend/consensus/base.py` changes: queue gating, `blocked_heads`, and recovery paths.
- Validate edge cases around predecessor readiness and when to clear/retain blocked heads.
- Confirm `TransactionsProcessor.get_activated_transactions_older_than` is only used in runtime paths and is safely mocked in tests.
- Review `PendingState` validator reuse vs reselection logic for rolled-back transactions.

### User facing release notes

- Fixes an issue where transactions could remain stuck in `ACTIVATED`.
- Improves transaction ordering guarantees and automatic recovery of stalled transactions.
- No configuration changes required; behavior is enabled by default.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Added standardized template-based prompt handling for more consistent outputs.
* Bug Fixes
  * Prevented stalled transactions by preserving execution order and recovering older stuck items automatically.
  * Improved handling of rolled-back transactions when original validators are unavailable.
* Refactor
  * Optimized transaction queue processing to defer work until ready and reduce race conditions.
* Chores
  * Expanded logging and messages for better observability of blocking and recovery actions.
* Tests
  * Updated test helpers to support scenarios with aged activated transactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->