### PR TITLE
chore: upgrade webdriver images with mem leak fixes

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -157,7 +157,7 @@ services:
       traefik.http.routers.jsonrpc-health.service: jsonrpc
 
   webdriver:
-    image: yeagerai/genlayer-genvm-webdriver:0.0.7
+    image: yeagerai/genlayer-genvm-webdriver:0.0.8
     shm_size: 2gb
     environment:
       - PORT=${WEBDRIVERPORT:-4444}


### PR DESCRIPTION
upgraded webdriver image to 0.0.8 with potential memory leak and stability fixes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal service component to the latest version for improved stability and performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->