### PR TITLE
fix: guard against null consensus_data in appeal processing

### DIFF
--- a/backend/database_handler/transactions_processor.py
+++ b/backend/database_handler/transactions_processor.py
@@ -1389,6 +1389,12 @@ class TransactionsProcessor:
         count = 0
         for tx in stuck_transactions:
             tx.status = TransactionStatus.PENDING
+            # Reset appeal flags if consensus_data is missing (can't process appeal without it)
+            if tx.consensus_data is None:
+                tx.appealed = False
+                tx.appeal_undetermined = False
+                tx.appeal_validators_timeout = False
+                tx.appeal_leader_timeout = False
             count += 1
 
         if count > 0:


### PR DESCRIPTION
## Summary
- Adds null guards in `PendingState.handle()` for transactions with `appealed=true` or `appeal_undetermined=true` but missing `consensus_data`
- Updates `reset_stuck_transactions()` to reset appeal flags when `consensus_data` is null

## Problem
Transactions with `appealed=true` but `consensus_data=null` cause infinite error loops:
```
AttributeError: 'NoneType' object has no attribute 'validators'
```

Workers repeatedly claim the transaction, crash trying to access `consensus_data.validators`, release it, and another worker picks it up.

## Root Cause
This can happen when:
1. Transaction is appealed
2. Worker starts processing but crashes/times out (or validators change and `consensus_data` gets cleared)
3. `reset_stuck_transactions()` resets status to PENDING
4. But appeal flags remain set while `consensus_data` is null

## Fix
1. **Runtime guard**: If `consensus_data` is null but appeal flags are set, reset the flags and process as fresh transaction
2. **Prevention**: `reset_stuck_transactions()` now clears appeal flags when `consensus_data` is missing

## Test plan
- [ ] Deploy to staging and verify stuck transaction `0x6e9a9b0e...` gets processed
- [ ] Monitor worker logs for any new null consensus_data errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved robustness of appeal handling by guarding against missing/corrupted consensus data
  * Ensured appeal-related flags are reset when recovering stuck transactions
  * Prevented invalid validator computations and spurious event emission for malformed transactions

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->