### PR TITLE
fix: encode newCodeHash as bytes in upgrade signature

### DIFF
--- a/frontend/src/hooks/useContractQueries.ts
+++ b/frontend/src/hooks/useContractQueries.ts
@@ -338,7 +338,7 @@ export function useContractQueries() {
           concat([
             toBytes(contractAddress as `0x${string}`),
             toBytes(nonceBytes),
-            newCodeHash,
+            toBytes(newCodeHash),
           ]),
         );
 


### PR DESCRIPTION
Fixes DXP-735

# What

- Wrap `newCodeHash` in `toBytes()` when constructing the upgrade message hash in `useContractQueries.ts`

# Why

When passing a hex string directly to viem's `concat()` function, it was being treated as a **literal UTF-8 string** (converting each character to ASCII bytes) instead of as **hex-encoded bytes**.

For example:
- `concat([hexString])` → `307836653733...` (ASCII encoding of "0x6e73fa...")
- `concat([toBytes(hexString)])` → `6e73fa02...` (actual hex bytes)

This caused the signature verification on the backend to fail because the frontend was signing a different message than what the backend expected to verify.

# Testing done

- Verified via Node.js REPL that the message hash now matches between frontend and backend
- Confirmed the encoding difference using test values

# Decisions made

- Used `toBytes()` wrapper consistently for all three components in the concat array (address, nonce, and code hash)

# Checks

- [x] I have tested this code
- [x] I have reviewed my own PR
- [x] I have set a descriptive PR title compliant with conventional commits

# Reviewing tips

- The fix is a single character change: wrapping `newCodeHash` in `toBytes()`
- The root cause was viem's `concat` treating hex strings as literal strings when mixed with Uint8Array

# User facing release notes

- Fixed contract upgrade signature verification in hosted Studio

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved data handling issue in contract upgrade process for improved reliability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->