### PR TITLE
fix: handle ClientDisconnected exception in WebSocket message forwarding

### DIFF
--- a/backend/protocol_rpc/websocket.py
+++ b/backend/protocol_rpc/websocket.py
@@ -22,8 +22,10 @@ async def _forward_messages(websocket: WebSocket, subscriber: Any) -> None:
             await websocket.send_text(event.message)
     except asyncio.CancelledError:  # Expected during shutdown/unsubscribe
         raise
-    except (WebSocketDisconnect, RuntimeError):
-        # Ignore send failures caused by abruptly closed sockets
+    except Exception:
+        # Ignore send failures caused by client disconnection.
+        # This covers WebSocketDisconnect, RuntimeError, ClientDisconnected (uvicorn),
+        # ConnectionClosedError (websockets), IncompleteReadError (asyncio), etc.
         pass
 
 


### PR DESCRIPTION
Fixes Sentry issue: https://genlayer-labs.sentry.io/issues/GENLAYER-STUDIO-F

## Summary

- Broadened exception handling in `_forward_messages` to catch all exceptions (except `CancelledError`) when forwarding messages to WebSocket clients
- This fixes the `ClientDisconnected` exception from uvicorn that was not being caught when clients disconnect abruptly without sending a close frame

## What

The WebSocket message forwarding function was only catching `WebSocketDisconnect` and `RuntimeError`, but uvicorn raises `ClientDisconnected` when a client disconnects without a close frame. This caused the exception to propagate up during cleanup, resulting in 14,411 error events affecting 1,992 users.

## Why

- The error was occurring frequently in production (14,411 occurrences)
- Root cause: When a client disconnects abruptly (browser tab closed, network loss, etc.), uvicorn raises `ClientDisconnected` which wraps lower-level exceptions like `ConnectionClosedError` and `IncompleteReadError`
- The previous code only caught `WebSocketDisconnect` and `RuntimeError`, missing these uvicorn/websockets-specific exceptions

## Testing done

- [x] DB/SQLAlchemy tests pass (25/25)
- [x] Pre-commit hooks pass

## Decisions made

- Catch `Exception` broadly (while re-raising `CancelledError`) rather than importing internal uvicorn exceptions, as any failure during message forwarding means the client is unreachable and we should silently exit the loop

## Checks

- [x] I have tested this code
- [x] I have reviewed my own PR
- [x] I have set a descriptive PR title compliant with conventional commits

## Reviewing tips

- The change is in `backend/protocol_rpc/websocket.py` line 25
- The broadened exception handling is appropriate here since the function's sole purpose is forwarding messages to a websocket client - any failure means the client is gone

## User facing release notes

- Fixed: WebSocket connection errors no longer cause server-side exceptions when clients disconnect unexpectedly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stability of WebSocket client disconnection handling by enhancing error resilience during message transmission failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->