### PR TITLE
feat: trigger workload release lane after image publish

### DIFF
--- a/.github/workflows/release-from-main.yml
+++ b/.github/workflows/release-from-main.yml
@@ -38,3 +38,60 @@ jobs:
     uses: ./.github/workflows/docker-build-and-push-all.yml
     needs: release
     secrets: inherit
+
+  trigger-workload-release-lane:
+    name: Trigger Workload Release Lane
+    runs-on: ubuntu-latest
+    needs: push-docker-images
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Get CI Bot Token
+        id: ci_bot_token
+        uses: tibdex/github-app-token@v2
+        with:
+          app_id: ${{ secrets.CI_BOT_APP_ID }}
+          private_key: ${{ secrets.CI_BOT_SECRET }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Resolve JSONRPC image digest
+        id: digest
+        run: |
+          set -euo pipefail
+          git fetch --tags --force
+          latest_tag=$(git describe --tags `git rev-list --tags --max-count=1`)
+          image_ref="yeagerai/simulator-jsonrpc:${latest_tag}"
+
+          digest=""
+          for attempt in {1..20}; do
+            digest="$(docker buildx imagetools inspect "$image_ref" --format '{{json .Manifest.Digest}}' 2>/dev/null | tr -d '\"' || true)"
+            if [[ "$digest" == sha256:* ]]; then
+              break
+            fi
+            echo "Digest not available yet for ${image_ref}; attempt ${attempt}/20"
+            sleep 15
+          done
+
+          if [[ ! "$digest" == sha256:* ]]; then
+            echo "Failed to resolve digest for ${image_ref}" >&2
+            exit 1
+          fi
+
+          image_digest_ref="yeagerai/simulator-jsonrpc@${digest}"
+          echo "latest_tag=${latest_tag}" >> "$GITHUB_OUTPUT"
+          echo "image=${image_digest_ref}" >> "$GITHUB_OUTPUT"
+          echo "Resolved digest reference: ${image_digest_ref}"
+
+      - name: Trigger workload release lane
+        run: |
+          set -euo pipefail
+          curl -sSfL -X POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${{ steps.ci_bot_token.outputs.token }}" \
+            https://api.github.com/repos/genlayerlabs/devexp-apps-workload/actions/workflows/release-jsonrpc-start.yml/dispatches \
+            -d "{\"ref\":\"main\",\"inputs\":{\"image\":\"${{ steps.digest.outputs.image }}\"}}"


### PR DESCRIPTION
## Summary
- add a post-image-publish job in release-from-main
- resolve immutable digest for latest simulator-jsonrpc tag
- dispatch devexp-apps-workload release lane automatically with GitHub App token

## Validation
- YAML parse of release-from-main workflow

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced release automation workflow with additional validation steps for improved deployment reliability and streamlined release orchestration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->