### PR TITLE
feat(release): dispatch workloads lane with worker digest

### DIFF
--- a/.github/workflows/release-from-main.yml
+++ b/.github/workflows/release-from-main.yml
@@ -87,6 +87,36 @@ jobs:
           echo "image=${image_digest_ref}" >> "$GITHUB_OUTPUT"
           echo "Resolved digest reference: ${image_digest_ref}"
 
+      - name: Resolve Consensus Worker image digest
+        id: worker_digest
+        run: |
+          set -euo pipefail
+          latest_tag='${{ steps.digest.outputs.latest_tag }}'
+          if [[ -z "$latest_tag" ]]; then
+            echo "Missing latest_tag output from digest step" >&2
+            exit 1
+          fi
+          image_ref="yeagerai/simulator-consensus-worker:${latest_tag}"
+
+          digest=""
+          for attempt in {1..20}; do
+            digest="$(docker buildx imagetools inspect "$image_ref" --format '{{json .Manifest.Digest}}' 2>/dev/null | tr -d '\"' || true)"
+            if [[ "$digest" == sha256:* ]]; then
+              break
+            fi
+            echo "Digest not available yet for ${image_ref}; attempt ${attempt}/20"
+            sleep 15
+          done
+
+          if [[ ! "$digest" == sha256:* ]]; then
+            echo "Failed to resolve digest for ${image_ref}" >&2
+            exit 1
+          fi
+
+          image_digest_ref="yeagerai/simulator-consensus-worker@${digest}"
+          echo "image=${image_digest_ref}" >> "$GITHUB_OUTPUT"
+          echo "Resolved digest reference: ${image_digest_ref}"
+
       - name: Trigger workload release lane
         run: |
           set -euo pipefail
@@ -94,4 +124,4 @@ jobs:
             -H "Accept: application/vnd.github+json" \
             -H "Authorization: Bearer ${{ steps.ci_bot_token.outputs.token }}" \
             https://api.github.com/repos/genlayerlabs/devexp-apps-workload/actions/workflows/release-jsonrpc-start.yml/dispatches \
-            -d "{\"ref\":\"main\",\"inputs\":{\"image\":\"${{ steps.digest.outputs.image }}\"}}"
+            -d "{\"ref\":\"main\",\"inputs\":{\"image\":\"${{ steps.digest.outputs.image }}\",\"consensus_worker_image\":\"${{ steps.worker_digest.outputs.image }}\"}}"


### PR DESCRIPTION
The workloads progressive release lane now promotes a backend bundle (jsonrpc + consensus-worker) and the start workflow requires both digests.

This updates `release-from-main.yml` to:
- Resolve `yeagerai/simulator-jsonrpc:<tag>` digest
- Resolve `yeagerai/simulator-consensus-worker:<tag>` digest
- Dispatch `devexp-apps-workload` `release-jsonrpc-start.yml` with both inputs: `image` and `consensus_worker_image`.

Companion PR in workloads: genlayerlabs/devexp-apps-workload#22.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Enhanced release automation with improved image validation and verification of critical system components
  * Strengthened error handling in the deployment workflow to ensure more reliable and consistent release processes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->