### PR TITLE
fix: move GenVM precompile from build-time to container startup

### DIFF
--- a/docker/Dockerfile.consensus-worker
+++ b/docker/Dockerfile.consensus-worker
@@ -90,7 +90,7 @@ RUN cd /genvm \
     && echo "GenVM installed successfully:" \
     && ls -la \
     && chown -R worker-user:worker-group /genvm \
-    && su - worker-user -c "/genvm/bin/post-install.py"
+    && su - worker-user -c "/genvm/bin/post-install.py --precompile false"
 
 # Set GenVM environment variables (GENVM_TAG is already set as ENV earlier)
 ENV GENVMROOT=/genvm
@@ -99,18 +99,18 @@ ENV PATH="/genvm/bin:${PATH}"
 # Copy necessary files
 COPY ../.env .
 COPY backend $path/backend
+COPY docker/consensus-worker-entrypoint.sh /entrypoint.sh
 
 # Change ownership of app files
 RUN chown -R worker-user:worker-group $path
 
-# Health check
-HEALTHCHECK --interval=30s --timeout=10s --retries=3 --start-period=40s \
+# Health check (start-period accounts for first-boot precompile ~60s)
+HEALTHCHECK --interval=30s --timeout=10s --retries=3 --start-period=120s \
     CMD curl -f http://localhost:${WORKER_PORT:-4001}/health || exit 1
 
 # Switch to non-root user
 USER worker-user
 
-# Run the consensus worker service with proper logging configuration
+# Precompile GenVM for host CPU on startup, then start worker
 WORKDIR /app
-# Use run_worker.py to configure uvicorn logging (filters health check access logs)
-CMD ["python3", "-m", "backend.consensus.run_worker"]
+ENTRYPOINT ["/entrypoint.sh"]

--- a/docker/consensus-worker-entrypoint.sh
+++ b/docker/consensus-worker-entrypoint.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+set -e
+
+CACHE_MARKER="/genvm/.cache/pc/.precompiled-${GENVM_TAG}"
+
+if [ -f "$CACHE_MARKER" ]; then
+    echo "GenVM ${GENVM_TAG} already precompiled for this host, skipping."
+else
+    echo "Precompiling GenVM ${GENVM_TAG} for host CPU..."
+    /genvm/bin/post-install.py --default-steps false --precompile true
+    touch "$CACHE_MARKER"
+    echo "Precompilation complete."
+fi
+
+exec python3 -m backend.consensus.run_worker


### PR DESCRIPTION
## Summary
- Skip WASM AOT precompilation during `docker build` (`--precompile false`)
- Run precompile on container startup via entrypoint script for the actual host CPU
- Version-aware marker file skips re-precompile on pod restarts (with shared volume)

## Problem
GenVM's `post-install.py` runs `genvm precompile` during Docker build on GitHub Actions `ubuntu-latest` runners. This AOT-compiles WASM modules (softfloat, cpython, py-genlayer) for the build machine's CPU. When the build runner has AVX-512 but the target k8s nodes don't, every contract deploy fails:

```
compilation setting "has_avx512bitalg" is enabled, but not available on the host
```

This breaks studio-dev (no AVX-512 on nodes) while prod works (has AVX-512).

## Fix
1. **Build time**: `post-install.py --precompile false` — download and install GenVM without precompiling
2. **Startup**: Entrypoint runs `post-install.py --default-steps false --precompile true` — compiles for the actual host CPU
3. **Caching**: Marker file `/genvm/.cache/pc/.precompiled-${GENVM_TAG}` prevents re-precompile on restart (when volume is persisted)
4. **Probes**: Bumped `start-period` to 120s to account for first-boot precompile (~30-60s)

## Test plan
- [ ] Docker image builds successfully (CI)
- [ ] Deploy to studio-dev, verify worker starts and precompiles on first boot
- [ ] Deploy a contract via genlayer_py — should succeed (no more AVX-512 error)
- [ ] Restart pod — verify precompile is skipped via marker file (with emptyDir, will re-precompile)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized consensus worker initialization with precompilation caching for faster startup times on subsequent runs.
  * Extended health check timeout to accommodate initial setup requirements and improve deployment reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->