### PR TITLE
fix: rename entrypoint to match dockerignore and fix cache path

### DIFF
--- a/docker/Dockerfile.consensus-worker
+++ b/docker/Dockerfile.consensus-worker
@@ -99,7 +99,7 @@ ENV PATH="/genvm/bin:${PATH}"
 # Copy necessary files
 COPY ../.env .
 COPY backend $path/backend
-COPY docker/consensus-worker-entrypoint.sh /entrypoint.sh
+COPY docker/entrypoint-consensus-worker.sh /entrypoint.sh
 
 # Change ownership of app files
 RUN chown -R worker-user:worker-group $path

--- a/docker/entrypoint-consensus-worker.sh
+++ b/docker/entrypoint-consensus-worker.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-CACHE_MARKER="/genvm/.cache/pc/.precompiled-${GENVM_TAG}"
+CACHE_MARKER="/genvm/executor/${GENVM_TAG}/.cache/pc/.precompiled"
 
 if [ -f "$CACHE_MARKER" ]; then
     echo "GenVM ${GENVM_TAG} already precompiled for this host, skipping."


### PR DESCRIPTION
## Summary
- Renames `docker/consensus-worker-entrypoint.sh` to `docker/entrypoint-consensus-worker.sh` to match `.dockerignore` exception pattern (`!docker/entrypoint-*.sh`)
- Fixes cache marker path from `/genvm/.cache/pc/` to `/genvm/executor/${GENVM_TAG}/.cache/pc/` (actual GenVM cache location)

Follows up on #1428. The v0.97.2-precompile-fix build failed because `.dockerignore` excluded the entrypoint file.

## Test plan
- Verify Docker image builds successfully with `COPY docker/entrypoint-consensus-worker.sh /entrypoint.sh`
- Verify entrypoint uses correct cache path on startup