### PR TITLE
fix: stop GenVM permit starvation crash loop

### DIFF
--- a/backend/node/base.py
+++ b/backend/node/base.py
@@ -623,6 +623,7 @@ class Node:
             calldata,
             readonly=True,
             is_init=False,
+            is_sync=True,
             transaction_datetime=(
                 transaction_datetime
                 if transaction_datetime is not None
@@ -698,7 +699,7 @@ class Node:
             extra_args=["--debug-mode"],
             host_data='{"node_address":"0x", "tx_id":"0x"}',
             capture_output=True,
-            is_sync=False,
+            is_sync=True,
             logger=self.logger,
             timeout=30,
             manager_uri=self.manager.url,
@@ -735,6 +736,7 @@ class Node:
         *,
         readonly: bool,
         is_init: bool,
+        is_sync: bool = False,
         transaction_hash: str | None = None,
         transaction_datetime: datetime.datetime | None,
         state_status: str | None = None,
@@ -820,7 +822,7 @@ class Node:
                 capture_output=True,
                 host_data=json.dumps(host_data),
                 extra_args=["--debug-mode"],
-                is_sync=False,
+                is_sync=is_sync,
                 manager_uri=self.manager.url,
                 timeout=timeout,
                 code=code,

--- a/backend/protocol_rpc/fastapi_server.py
+++ b/backend/protocol_rpc/fastapi_server.py
@@ -20,7 +20,7 @@ from backend.protocol_rpc.dependencies import (
     websocket_broadcast,
 )
 from backend.protocol_rpc.fastapi_rpc_router import FastAPIRPCRouter
-from backend.protocol_rpc.health import health_router, create_readiness_check_with_state
+from backend.protocol_rpc.health import health_router
 from backend.protocol_rpc.rpc_endpoint_manager import JSONRPCResponse
 from backend.protocol_rpc.websocket import GLOBAL_CHANNEL, websocket_handler
 
@@ -71,15 +71,6 @@ app.add_middleware(
 
 # Include health check endpoints
 app.include_router(health_router)
-
-
-@app.get("/ready")
-async def readiness_check_with_app_state(
-    rpc_router: FastAPIRPCRouter | None = Depends(get_rpc_router_optional),
-):
-    """Enhanced readiness check with access to application state."""
-    readiness_func = create_readiness_check_with_state(rpc_router)
-    return await readiness_func()
 
 
 # JSON-RPC endpoint (supports single and batch requests)

--- a/tests/integration/rpc/test_jsonrpc_endpoint.py
+++ b/tests/integration/rpc/test_jsonrpc_endpoint.py
@@ -112,6 +112,7 @@ async def test_create_readiness_check_handles_router_instance(jsonrpc_test_app):
     readiness_func = create_readiness_check_with_state(app.state.rpc_router)
     payload = await readiness_func()
 
+    assert isinstance(payload, dict)
     assert payload["rpc_router_initialized"] is True
     assert payload["status"] == "ready"
 
@@ -121,5 +122,9 @@ async def test_create_readiness_check_handles_missing_router():
     readiness_func = create_readiness_check_with_state(None)
     payload = await readiness_func()
 
-    assert payload["rpc_router_initialized"] is False
-    assert payload["status"] == "not_ready"
+    import json
+
+    assert payload.status_code == 503
+    body = json.loads(payload.body.decode())
+    assert body["rpc_router_initialized"] is False
+    assert body["status"] == "not_ready"


### PR DESCRIPTION
## Summary

Fixes the jsonrpc pod crash loop on Rally TestNet (134 restarts in 17h, exit code 137) caused by GenVM semaphore permit exhaustion under heavy contract execution load.

**Root cause:** All gen_call (read-only) requests used `is_sync=False`, consuming 2 semaphore permits each. With 13 max permits, only 6 concurrent GenVM processes could run. Heavy contracts held permits for minutes → new requests blocked at semaphore → Python socket timeout → `record_genvm_execution_failure()` incremented → `/health` returned 503 → K8s liveness probe killed the pod → restart cycle.

### Changes

1. **Gate liveness failure counting on manager /status probe** (`health.py`)
   - `record_genvm_execution_failure()` now checks `_health_cache.genvm_healthy` (polled every 10s)
   - If manager is alive (just busy), failures reset the counter instead of incrementing
   - Only counts toward liveness when the manager process is actually unreachable

2. **Use `is_sync=True` for read-only gen_call** (`base.py`)
   - `get_contract_data()` and `get_contract_data_for_schema()` now pass `is_sync=True`
   - Halves permit usage from 2→1 per read-only request (~doubles capacity: 6→13 concurrent)
   - Consensus path unchanged (`is_sync=False`)

3. **Permit-aware readiness endpoint** (`health.py`, `fastapi_server.py`)
   - `/ready` now returns HTTP 503 when not-ready (standard K8s behavior)
   - Background health checker parses GenVM `/status` JSON for permit info
   - Permit gating **disabled by default** (`READINESS_PERMIT_MIN_AVAILABLE=0`)
   - When enabled: sustain window (20s), recovery window (10s), per-pod jitter (2s) prevent death spirals
   - Consolidated duplicate `/ready` routes (removed from `fastapi_server.py`, kept in `health_router`)

### Env vars (all optional, safe defaults)

| Variable | Default | Purpose |
|----------|---------|---------|
| `READINESS_PERMIT_MIN_AVAILABLE` | `0` (disabled) | Min available permits for readiness |
| `READINESS_PERMIT_SUSTAIN_SECONDS` | `20` | Sustained exhaustion before not-ready |
| `READINESS_PERMIT_RECOVER_SECONDS` | `10` | Sustained recovery before ready again |
| `READINESS_PERMIT_JITTER_SECONDS` | `2` | Per-pod jitter to prevent synchronized flapping |

## Test plan

- [x] Unit tests pass (54/54) — `test_rpc_health_genvm_tracking.py`, `test_set_vote.py`, `test_leader_llm_recovery.py`, `test_error_codes.py`
- [ ] Deploy to Rally TestNet — verify crash loop stops
- [ ] Monitor pod restart count stabilizes at 0
- [ ] Monitor gen_call latency and success rate
- [ ] Optionally enable `READINESS_PERMIT_MIN_AVAILABLE=1` after confirming stability