### PR TITLE
fix: increase wait_for_transaction timeout for CI stability

### DIFF
--- a/tests/common/request.py
+++ b/tests/common/request.py
@@ -169,7 +169,7 @@ def send_raw_transaction(signed_transaction: str):
     return wait_for_transaction(transaction_hash)
 
 
-def wait_for_transaction(transaction_hash: str, interval: int = 10, retries: int = 15):
+def wait_for_transaction(transaction_hash: str, interval: int = 10, retries: int = 30):
     attempts = 0
     while attempts < retries:
         transaction_response = get_transaction_by_hash(str(transaction_hash))


### PR DESCRIPTION
## Summary

- `test_accounts_funding` is flaky in CI because 4 parallel pytest workers (`-n 4`) compete for 6 consensus worker slots, causing simple fund transactions to sit in PENDING for 3+ minutes due to worker starvation.
- The current `wait_for_transaction` default of `retries=15` with `interval=10` gives only 150s, which is not enough headroom.
- Bumped `retries` from 15 to 30 (300s total), providing sufficient margin for CI starvation scenarios.

## Test plan

- [x] Change is a single default parameter bump — no functional change to existing callers that pass explicit values.
- CI integration tests should no longer time out on `test_accounts_funding` under worker contention.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced transaction finalization testing by increasing retry attempts to improve test reliability and allow more time for transactions to complete during test execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->