### PR TITLE
feat: add share contract button to copy importable URL

### DIFF
--- a/frontend/src/components/Simulator/ContractInfo.vue
+++ b/frontend/src/components/Simulator/ContractInfo.vue
@@ -5,7 +5,9 @@ import { ArrowPathIcon } from '@heroicons/vue/20/solid';
 import EmptyListPlaceholder from '@/components/Simulator/EmptyListPlaceholder.vue';
 import { useNodeStore, useUIStore } from '@/stores';
 import { useContractQueries, useShortAddress } from '@/hooks';
-import { UploadIcon } from 'lucide-vue-next';
+import { UploadIcon, Share2, Check } from 'lucide-vue-next';
+import { useClipboard } from '@vueuse/core';
+import { computed } from 'vue';
 
 const nodeStore = useNodeStore();
 const { shorten } = useShortAddress();
@@ -18,6 +20,15 @@ const emit = defineEmits(['openDeployment']);
 const { isDeployed, address, contract, upgradeContract, isUpgrading } =
   useContractQueries();
 const uiStore = useUIStore();
+
+const shareUrl = computed(
+  () => `${window.location.origin}/?import-contract=${address.value}`,
+);
+const {
+  copy: copyShareUrl,
+  copied: shareCopied,
+  isSupported: shareIsSupported,
+} = useClipboard({ source: shareUrl });
 
 const upgradeTooltip = `
 <div style="text-align: left; max-width: 240px;">
@@ -63,6 +74,17 @@ const upgradeTooltip = `
       </div>
 
       <CopyTextButton :text="address" />
+
+      <button
+        v-if="shareIsSupported"
+        v-tooltip="shareCopied ? 'Link copied!' : 'Share contract'"
+        data-testid="share-contract-button"
+        @click.stop="copyShareUrl(shareUrl)"
+        class="shrink-0 text-gray-400 transition-all hover:text-gray-500 dark:text-gray-400 dark:hover:text-gray-400"
+      >
+        <Check v-if="shareCopied" class="h-4 w-4" />
+        <Share2 v-else class="h-4 w-4" />
+      </button>
     </div>
 
     <EmptyListPlaceholder v-else>Not deployed yet.</EmptyListPlaceholder>


### PR DESCRIPTION
Fixes DXP-698

# What

- Added a share button (Share2 icon) next to the existing copy-address button in `ContractInfo.vue`
- Clicking it copies `<origin>/?import-contract=<address>` to the clipboard
- Button shows a Check icon briefly after copying, with a tooltip showing "Link copied!"

# Why

- Users needed a quick way to share a deployed contract with others via a URL that auto-imports it into Studio

# Testing done

- Verified the button renders correctly next to the copy-address button when a contract is deployed
- Verified the generated URL matches the format consumed by the `import-contract` query param handler in `App.vue`

# Decisions made

- Used `useClipboard` from `@vueuse/core` directly (same as `CopyTextButton`) with a distinct `Share2` icon to differentiate visually from plain address copy
- URL uses `window.location.origin` + `/?import-contract=<address>` to match the existing import handler

# Checks

- [x] I have tested this code
- [x] I have reviewed my own PR
- [x] I have created an issue for this PR
- [x] I have set a descriptive PR title compliant with conventional commits

# Reviewing tips

- Only `frontend/src/components/Simulator/ContractInfo.vue` was changed
- The share button follows the same pattern as `CopyTextButton.vue`

# User facing release notes

- New "Share contract" button on the Run & Debug screen — click it to copy a shareable link that auto-imports the contract when opened in Studio

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added share contract functionality: A new button appears in the contract info panel, allowing users to easily copy the contract URL to their clipboard
  * The button provides visual feedback with changing icons and contextual tooltips that update based on whether the URL has been successfully copied

<!-- end of auto-generated comment: release notes by coderabbit.ai -->