### PR TITLE
fix: raise orphaned tx threshold to 3 and add instanceHealthReasons

### DIFF
--- a/backend/protocol_rpc/health.py
+++ b/backend/protocol_rpc/health.py
@@ -263,7 +263,7 @@ async def _run_health_checks() -> None:
             if overall_status == "healthy":
                 overall_status = "degraded"
             issues.append("consensus_issue")
-        elif consensus_health.get("total_orphaned_transactions", 0) > 0:
+        elif consensus_health.get("total_orphaned_transactions", 0) >= 3:
             if overall_status == "healthy":
                 overall_status = "degraded"
             issues.append("orphaned_transactions")

--- a/backend/services/usage_metrics_service.py
+++ b/backend/services/usage_metrics_service.py
@@ -81,8 +81,9 @@ class UsageMetricsService:
 
         try:
             # Build base payload
+            mapped_status = self._map_health_status(health_cache.status)
             system_health = {
-                "instanceHealth": self._map_health_status(health_cache.status),
+                "instanceHealth": mapped_status,
                 "genVmStatus": "healthy" if health_cache.genvm_healthy else "down",
                 "uptime": health_cache.uptime_percent,
                 "activeWorkers": health_cache.services.get("consensus", {}).get(
@@ -98,6 +99,9 @@ class UsageMetricsService:
                     "cpu_percent", 0
                 ),
             }
+
+            if mapped_status != "healthy":
+                system_health["instanceHealthReasons"] = health_cache.issues
 
             # Add pending contracts breakdown if available
             pending_contracts = getattr(health_cache, "pending_contracts", [])


### PR DESCRIPTION
# What

- Orphaned transactions now only degrade `instanceHealth` when count >= 3 (previously any single orphaned transaction would trigger degradation)
- Added `instanceHealthReasons` array to the system health metrics payload sent to the usage metrics dashboard, populated whenever `instanceHealth` is not `"healthy"`

# Why

- A single orphaned transaction was too sensitive a threshold and caused unnecessary degraded status reports to the dashboard
- `instanceHealthReasons` gives the dashboard visibility into why an instance is degraded or down, enabling better observability

# Testing done

- Verified changes against existing unit tests
- Reviewed diff manually

# Decisions made

- `instanceHealthReasons` reuses the existing `health_cache.issues` list (e.g. `"database_issue"`, `"consensus_issue"`, `"orphaned_transactions"`, `"memory_issue"`, `"redis_unreachable"`) — no new data structures needed
- Property is omitted entirely when `instanceHealth` is `"healthy"` to keep payloads clean

# Checks

- [ ] I have tested this code
- [x] I have reviewed my own PR
- [ ] I have created an issue for this PR
- [x] I have set a descriptive PR title compliant with conventional commits

# User facing release notes

- Internal dashboard improvement: instance health degradation due to orphaned transactions now requires at least 3 orphaned transactions, and the dashboard now receives reasons explaining any non-healthy instance status.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Enhanced system health metrics now include detailed reasons when the system status is not optimal, providing better visibility into system health.

## Bug Fixes
* Adjusted orphaned transaction detection to be less sensitive, reducing unnecessary alerts by requiring at least 3 orphaned transactions to trigger degraded status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->