### PR TITLE
feat(frontend): use genlayer-js cancelTransaction API

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -24,7 +24,7 @@
         "cross-env": "^7.0.3",
         "dexie": "^4.0.4",
         "floating-vue": "^5.2.2",
-        "genlayer-js": "^0.18.2",
+        "genlayer-js": "^0.20.0",
         "hash-sum": "^2.0.0",
         "jump.js": "^1.0.2",
         "lodash-es": "^4.17.21",
@@ -9146,9 +9146,9 @@
       }
     },
     "node_modules/genlayer-js": {
-      "version": "0.18.9",
-      "resolved": "https://registry.npmjs.org/genlayer-js/-/genlayer-js-0.18.9.tgz",
-      "integrity": "sha512-KMKLCKU4v7FCQhJBwC3Nx+Y6ezN7UC4ATCJozKoHHhsC9rk9fcac7TIinonPfwQa8ghXMYBLCcqkhNy7BltREA==",
+      "version": "0.20.0",
+      "resolved": "https://registry.npmjs.org/genlayer-js/-/genlayer-js-0.20.0.tgz",
+      "integrity": "sha512-NtIEfc4tFGodb+tdRDIbF+421juRmHNAlDagkd0MrZsgSR4zUQpxt/Oxi6iXtp/F18y+lp+hURw8jFbneGU3vg==",
       "license": "MIT",
       "dependencies": {
         "eslint-plugin-import": "^2.30.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -37,7 +37,7 @@
     "cross-env": "^7.0.3",
     "dexie": "^4.0.4",
     "floating-vue": "^5.2.2",
-    "genlayer-js": "^0.18.2",
+    "genlayer-js": "^0.20.0",
     "hash-sum": "^2.0.0",
     "jump.js": "^1.0.2",
     "lodash-es": "^4.17.21",

--- a/frontend/src/components/Simulator/TransactionItem.vue
+++ b/frontend/src/components/Simulator/TransactionItem.vue
@@ -96,9 +96,8 @@ const hasSenderAddress = computed(() =>
 );
 
 const canCancel = computed(() => {
-  const cancellableStatus =
-    props.transaction.statusName === 'PENDING' ||
-    props.transaction.statusName === 'ACTIVATED';
+  const status = String(props.transaction.statusName);
+  const cancellableStatus = status === 'PENDING' || status === 'ACTIVATED';
   const requiresAdminOnly =
     isHosted && props.transaction.type === 'upgrade' && !hasSenderAddress.value;
   return cancellableStatus && !requiresAdminOnly;

--- a/frontend/src/stores/transactions.ts
+++ b/frontend/src/stores/transactions.ts
@@ -105,37 +105,9 @@ export const useTransactionsStore = defineStore('transactionsStore', () => {
   }
 
   async function cancelTransaction(txHash: `0x${string}`) {
-    const { useRpcClient } = await import('@/hooks/useRpcClient');
-    const rpcClient = useRpcClient();
-
-    const { useAccountsStore } = await import('@/stores/accounts');
-    const accountsStore = useAccountsStore();
-    const account = accountsStore.selectedAccount;
-    let signature: string | undefined;
-
-    if (account) {
-      const { keccak256, toBytes, concat, stringToBytes } =
-        await import('viem');
-      const { privateKeyToAccount } = await import('viem/accounts');
-
-      const messageHash = keccak256(
-        concat([stringToBytes('cancel_transaction'), toBytes(txHash)]),
-      );
-
-      if (account.type === 'local' && account.privateKey) {
-        const signer = privateKeyToAccount(account.privateKey as `0x${string}`);
-        signature = await signer.signMessage({
-          message: { raw: messageHash },
-        });
-      } else if (account.type === 'metamask' && window.ethereum) {
-        signature = await window.ethereum.request({
-          method: 'personal_sign',
-          params: [messageHash, account.address],
-        });
-      }
-    }
-
-    await rpcClient.cancelTransaction(txHash, signature);
+    await genlayerClient.value?.cancelTransaction({
+      hash: txHash as TransactionHash,
+    });
   }
 
   function subscribe(topics: string[]) {


### PR DESCRIPTION
Fixes #issue-number-here

# What

- bump `genlayer-js` to `^0.20.0` and update lockfile
- replace frontend transaction cancellation raw JSON-RPC/signing path with `genlayerClient.cancelTransaction({ hash })`
- update unit tests to mock/assert `cancelTransaction` usage instead of low-level RPC details
- adjust transaction status guard in `TransactionItem.vue` to keep type-check/build compatibility

# Why

- align cancellation flow with the SDK API introduced in `genlayer-js` v0.20.0
- remove duplicated low-level request/signature logic from the store
- reduce integration risk by using the officially supported client surface

# Testing done

- `cd frontend && npm run test -- test/unit/stores/transactions.test.ts test/unit/services/JsonRpcService.test.ts`
- `cd frontend && npm run build`

# Decisions made

- cancellation is delegated to `genlayer-js` client APIs rather than direct JSON-RPC calls
- tests validate behavior through SDK invocation boundaries

# Checks

- [x] I have tested this code
- [x] I have reviewed my own PR
- [ ] I have created an issue for this PR
- [x] I have set a descriptive PR title compliant with [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)

# Reviewing tips

- start with `frontend/src/stores/transactions.ts` for the cancellation flow change
- then review `frontend/test/unit/stores/transactions.test.ts` for updated expectations

# User facing release notes

- transaction cancellation in the frontend now uses the official `genlayer-js` SDK API, improving compatibility with backend verification.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified transaction cancellation mechanism for improved reliability.

* **Bug Fixes**
  * Enhanced robustness of transaction status comparisons to handle edge cases.

* **Chores**
  * Updated core library dependency to the latest version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->