### PR TITLE
feat(tests): make integration test providers configurable via env vars

### DIFF
--- a/tests/integration/icontracts/conftest.py
+++ b/tests/integration/icontracts/conftest.py
@@ -63,7 +63,7 @@ def setup_validators():
                         {
                             "api_key_env_var": mock_cfg["api_key_env_var"],
                             "api_url": mock_cfg["api_url"],
-                            "mock_response": mock_response if mock_response else {},
+                            "mock_response": mock_response if mock_response is not None else {},
                         },
                     )
                 ).json()
@@ -107,7 +107,7 @@ def setup_validators():
 
 def mock_llms() -> bool:
     env_var = os.getenv("TEST_WITH_MOCK_LLMS", "false")  # default no mocking
-    return env_var == "true"
+    return env_var.lower() == "true"
 
 
 def pytest_configure(config: Any) -> None:


### PR DESCRIPTION
## Summary

Closes #340.

Providers and models in `tests/integration/icontracts/conftest.py` were hardcoded, making it impossible to run the backend e2e tests against a different LLM provider (e.g. local Ollama) without editing source files.

This PR introduces two helper functions — `get_provider_config()` and `get_mock_provider_config()` — that read provider settings from environment variables while preserving the existing defaults:

**Non-mock mode** (`TEST_WITH_MOCK_LLMS` not set):

| Env var | Default |
|---|---|
| `TEST_PROVIDER` | `openai` |
| `TEST_PROVIDER_MODEL` | `gpt-4o` |

**Mock mode** (`TEST_WITH_MOCK_LLMS=true`):

| Env var | Default |
|---|---|
| `TEST_MOCK_PROVIDER` | `openrouter` |
| `TEST_MOCK_MODEL` | `@preset/rally-testnet-gpt-5-1` |
| `TEST_MOCK_API_KEY_ENV_VAR` | `OPENROUTERAPIKEY` |
| `TEST_MOCK_API_URL` | `https://openrouter.ai/api` |

### Example — run tests with local Ollama

```bash
TEST_PROVIDER=ollama TEST_PROVIDER_MODEL=llama3 pytest tests/integration/icontracts/
```

## Test plan

- [ ] All existing tests pass unmodified (defaults are identical to the previous hardcoded values)
- [ ] Setting `TEST_PROVIDER=ollama TEST_PROVIDER_MODEL=llama3` creates validators with the specified provider
- [ ] Setting `TEST_MOCK_PROVIDER` / `TEST_MOCK_MODEL` in mock mode uses the overridden values

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Integration tests now read provider/model and mock settings from environment variables instead of hardcoded values.
  * Added configurable mock settings (provider, model, API endpoint, API key env var) for mock and non-mock runs.
  * New helper utilities surface configuration for tests.
  * Test setup gained type annotations and docstrings for clarity.
  * Created test resources are tracked during setup and reliably cleaned up after tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->