### PR TITLE
fix: replace curl dispatch with repository-dispatch action

### DIFF
--- a/.github/workflows/release-from-main.yml
+++ b/.github/workflows/release-from-main.yml
@@ -118,7 +118,7 @@ jobs:
           echo "Resolved digest reference: ${image_digest_ref}"
 
       - name: Trigger workload release lane
-        uses: peter-evans/repository-dispatch@v2
+        uses: peter-evans/repository-dispatch@v4
         with:
           token: ${{ steps.ci_bot_token.outputs.token }}
           repository: genlayerlabs/devexp-apps-workload


### PR DESCRIPTION
## Summary
- Replace failing `curl`-based `workflow_dispatch` call (422 error) with `peter-evans/repository-dispatch@v2`
- Dispatches `release-backend` event to `devexp-apps-workload` with `image` and `consensus_worker_image` payload

## Companion PR
- devexp-apps-workload: needs to accept the `repository_dispatch` event (see companion PR there)

## Open question
- Currently only `image` and `consensus_worker_image` are sent. The workload workflow also needs `frontend_image`, `explorer_image`, and `migration_image` — needs discussion on how to handle.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved the release workflow by replacing a manual trigger with a maintained GitHub Actions dispatch mechanism.
  * The new approach reliably forwards release metadata between steps and reduces points of failure in deployment orchestration.
  * No user-facing product behavior changed; this work increases CI reliability and consistency for future releases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->