### PR TITLE
fix: add missing @types/sortablejs dev dependency

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -53,6 +53,7 @@
         "@types/mocha": "^10.0.6",
         "@types/node": "^24.0.0",
         "@types/selenium-webdriver": "^4.1.22",
+        "@types/sortablejs": "^1.15.9",
         "@types/splitpanes": "^2.2.6",
         "@types/uuid": "^11.0.0",
         "@vitejs/plugin-vue": "^6.0.0",
@@ -4183,6 +4184,13 @@
         "@types/node": "*",
         "@types/ws": "*"
       }
+    },
+    "node_modules/@types/sortablejs": {
+      "version": "1.15.9",
+      "resolved": "https://registry.npmjs.org/@types/sortablejs/-/sortablejs-1.15.9.tgz",
+      "integrity": "sha512-7HP+rZGE2p886PKV9c9OJzLBI6BBJu1O7lJGYnPyG3fS4/duUCcngkNCjsLwIMV+WMqANe3tt4irrXHSIe68OQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/splitpanes": {
       "version": "2.2.6",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -66,6 +66,7 @@
     "@types/mocha": "^10.0.6",
     "@types/node": "^24.0.0",
     "@types/selenium-webdriver": "^4.1.22",
+    "@types/sortablejs": "^1.15.9",
     "@types/splitpanes": "^2.2.6",
     "@types/uuid": "^11.0.0",
     "@vitejs/plugin-vue": "^6.0.0",


### PR DESCRIPTION
## Summary
- Added `@types/sortablejs` to frontend devDependencies to fix the Docker build failure in the release workflow
- Without this package, `useSortable()` from `@vueuse/integrations` cannot resolve Sortable.js option types (e.g. `animation`), causing `vue-tsc` type-check to fail

## Test plan
- [ ] Verify `npm run type-check` passes in the frontend
- [ ] Verify the frontend Docker image builds successfully

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development dependencies to enhance development environment tooling and type support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->