### PR TITLE
chore: configure Renovate to target main branch instead of staging

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -16,5 +16,5 @@
     "minimumReleaseAge": "3 days"
   },
   "reviewers": ["denishacquin", "mpaya5", "kstroobants", "epsjunior"],
-  "baseBranches": ["staging"]
+  "baseBranches": ["main"]
 }


### PR DESCRIPTION
# What

- Changed Renovate's `baseBranches` configuration from `["staging"]` to `["main"]`
- Renovate will now create PRs targeting the main branch instead of staging

# Why

- Aligns dependency updates with the primary development branch

# Testing done

- Verified the configuration change in renovate.json

# Decisions made

- Direct configuration change without requiring additional validation

# Checks

- [x] I have tested this code
- [x] I have reviewed my own PR
- [ ] I have created an issue for this PR
- [x] I have set a descriptive PR title compliant with conventional commits

# User facing release notes

- Renovate dependency update PRs will now target main instead of staging

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency management configuration to target the main branch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->