### PR TITLE
fix: use runtime middleware for explorer API proxy

### DIFF
--- a/docker/Dockerfile.explorer
+++ b/docker/Dockerfile.explorer
@@ -9,8 +9,6 @@ FROM base AS dev
 CMD ["npm", "run", "dev"]
 
 FROM base AS builder
-ARG BACKEND_URL=http://jsonrpc:4000
-ENV BACKEND_URL=${BACKEND_URL}
 RUN npm run build
 
 FROM node:24.1.0-alpine3.20 AS final

--- a/explorer/next.config.ts
+++ b/explorer/next.config.ts
@@ -1,16 +1,5 @@
 import type { NextConfig } from "next";
 
-const BACKEND_URL = process.env.BACKEND_URL || "http://localhost:4000";
-
-const nextConfig: NextConfig = {
-  async rewrites() {
-    return [
-      {
-        source: "/api/:path*",
-        destination: `${BACKEND_URL}/api/explorer/:path*`,
-      },
-    ];
-  },
-};
+const nextConfig: NextConfig = {};
 
 export default nextConfig;

--- a/explorer/src/middleware.ts
+++ b/explorer/src/middleware.ts
@@ -1,0 +1,14 @@
+import { type NextRequest, NextResponse } from "next/server";
+
+const BACKEND_URL = process.env.BACKEND_URL || "http://localhost:4000";
+
+export function middleware(request: NextRequest) {
+  const { pathname, search } = request.nextUrl;
+  const destination = `${BACKEND_URL}/api/explorer${pathname.slice("/api".length)}${search}`;
+
+  return NextResponse.rewrite(new URL(destination));
+}
+
+export const config = {
+  matcher: "/api/:path*",
+};


### PR DESCRIPTION
## Summary
- Replace Next.js build-time `rewrites()` with runtime middleware for the explorer API proxy
- Remove `ARG`/`ENV BACKEND_URL` from Dockerfile builder stage (no longer needed at build time)
- The same Docker image now works in any environment by setting `BACKEND_URL` at deploy time

## Problem
Next.js bakes `rewrites()` into `routes-manifest.json` at build time. The Docker image had `http://jsonrpc:4000` hardcoded (from the Dockerfile `ARG`), but in Kubernetes the backend service is named `studio-jsonrpc`. The runtime `BACKEND_URL` env var was silently ignored, causing all explorer API calls to fail with 500.

## Solution
Added `explorer/src/middleware.ts` that reads `BACKEND_URL` from `process.env` on each request and proxies `/api/:path*` → `${BACKEND_URL}/api/explorer/:path*`. This matches the same runtime configuration pattern used by the frontend's `entrypoint-frontend.sh` / `runtime-config.js`.

## Files changed
- `explorer/src/middleware.ts` — new runtime API proxy middleware
- `explorer/next.config.ts` — removed build-time rewrites
- `docker/Dockerfile.explorer` — removed build-time `BACKEND_URL` ARG/ENV

## Test plan
- [x] `npm run build` succeeds in explorer directory
- [x] Docker build succeeds: `docker build -f docker/Dockerfile.explorer .`
- [x] Explorer loads and fetches data at `explorer-studio.genlayer.com` after deploy
- [x] Works locally with `BACKEND_URL=http://localhost:4000 npm run dev`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized API routing to support runtime-based backend URL configuration instead of build-time setup, improving deployment flexibility without affecting existing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->