### PR TITLE
fix(docker): increase Node heap size to prevent OOM crash on macOS

### DIFF
--- a/docker/Dockerfile.frontend
+++ b/docker/Dockerfile.frontend
@@ -14,6 +14,7 @@ RUN chmod +x /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]
 
 FROM base AS builder
+ENV NODE_OPTIONS=--max-old-space-size=4096
 RUN npm run build
 
 FROM alpine:latest AS final


### PR DESCRIPTION
## Problem

On **macOS** (particularly Apple Silicon / M1/M2/M3), `docker compose build` fails on the `frontend` service with:

```
FATAL ERROR: Ineffective mark-compacts near heap limit
Allocation failed - JavaScript heap out of memory
ERROR: "build-only" exited with 134.
```

This happens because Docker Desktop on macOS enforces stricter default memory limits per container, and the Vite/Vue build exhausts Node's default heap (~1.5 GB).

## Fix

Added `ENV NODE_OPTIONS=--max-old-space-size=4096` in the `builder` stage of `docker/Dockerfile.frontend`, giving Node 4 GB of heap to complete the build successfully.

## Test plan

- [x] Run `docker compose build frontend` on macOS — should complete without OOM error
- [x] Verify the built image starts correctly with `docker compose up frontend`
- [x] Confirm no regression on Linux builds (CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved build stability by increasing memory allocation during the build process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->