### PR TITLE
fix: offload blocking I/O in health checks to prevent event loop freezes

### DIFF
--- a/backend/protocol_rpc/health.py
+++ b/backend/protocol_rpc/health.py
@@ -459,14 +459,17 @@ async def _check_database_health() -> Dict[str, Any]:
         except Exception as e:
             pool_status = {"class": "unknown", "error": str(e)}
 
-        # Test database connectivity
+        # Test database connectivity — run in thread to avoid blocking event loop
+        def _db_ping():
+            start_t = time.time()
+            with db_manager.engine.connect() as conn:
+                conn.execute(text("SELECT 1"))
+            return (time.time() - start_t) * 1000
+
         db_healthy = False
         query_time_ms = 0
         try:
-            start = time.time()
-            with db_manager.engine.connect() as conn:
-                conn.execute(text("SELECT 1"))
-            query_time_ms = (time.time() - start) * 1000
+            query_time_ms = await asyncio.to_thread(_db_ping)
             db_healthy = True
         except Exception as e:
             logger.error(f"Database connectivity test failed: {e}")
@@ -493,58 +496,58 @@ async def _check_consensus_health() -> Dict[str, Any]:
 
         db_manager = get_database_manager()
 
-        # Get active worker IDs
-        with db_manager.engine.connect() as worker_conn:
+        def _query_consensus():
             now = datetime.now(timezone.utc)
             recent_threshold = now - timedelta(hours=1)
 
-            from sqlalchemy import select, distinct, and_
+            from sqlalchemy import select, distinct, and_, text
 
-            worker_query = select(distinct(Transactions.worker_id)).where(
-                and_(
-                    Transactions.worker_id.isnot(None),
-                    Transactions.created_at > recent_threshold,
+            # Get active worker IDs
+            with db_manager.engine.connect() as worker_conn:
+                worker_query = select(distinct(Transactions.worker_id)).where(
+                    and_(
+                        Transactions.worker_id.isnot(None),
+                        Transactions.created_at > recent_threshold,
+                    )
                 )
-            )
-            worker_result = worker_conn.execute(worker_query)
-            active_workers = {row[0] for row in worker_result if row[0]}
+                worker_result = worker_conn.execute(worker_query)
+                active_workers = {row[0] for row in worker_result if row[0]}
 
-        # Get transaction statistics
-        with db_manager.engine.connect() as conn:
-            from sqlalchemy import text
-
-            query = text(
+            # Get transaction statistics
+            with db_manager.engine.connect() as conn:
+                query = text(
+                    """
+                    SELECT
+                        COUNT(*) FILTER (WHERE status IN ('ACTIVATED', 'PROPOSING', 'COMMITTING', 'REVEALING', 'ACCEPTED', 'UNDETERMINED')) as processing_count,
+                        COUNT(*) FILTER (WHERE worker_id IS NOT NULL AND status IN ('PENDING', 'ACTIVATED', 'PROPOSING', 'COMMITTING', 'REVEALING', 'ACCEPTED', 'UNDETERMINED')) as blocked_count
+                    FROM transactions
+                    WHERE to_address IS NOT NULL
                 """
-                SELECT
-                    COUNT(*) FILTER (WHERE status IN ('ACTIVATED', 'PROPOSING', 'COMMITTING', 'REVEALING', 'ACCEPTED', 'UNDETERMINED')) as processing_count,
-                    COUNT(*) FILTER (WHERE worker_id IS NOT NULL AND status IN ('PENDING', 'ACTIVATED', 'PROPOSING', 'COMMITTING', 'REVEALING', 'ACCEPTED', 'UNDETERMINED')) as blocked_count
-                FROM transactions
-                WHERE to_address IS NOT NULL
-            """
-            )
-            result = conn.execute(query)
-            row = result.fetchone()
+                )
+                result = conn.execute(query)
+                row = result.fetchone()
 
-            total_processing = row.processing_count if row else 0
-            total_blocked = row.blocked_count if row else 0
+                total_processing = row.processing_count if row else 0
+                total_blocked = row.blocked_count if row else 0
 
-            # Simplified orphan detection
-            total_orphaned = 0
-            if total_blocked > 0 and len(active_workers) == 0:
-                total_orphaned = total_blocked
+                total_orphaned = 0
+                if total_blocked > 0 and len(active_workers) == 0:
+                    total_orphaned = total_blocked
 
-            status = (
-                "healthy"
-                if total_processing < 100 and total_orphaned == 0
-                else "degraded"
-            )
+                status = (
+                    "healthy"
+                    if total_processing < 100 and total_orphaned == 0
+                    else "degraded"
+                )
 
-            return {
-                "status": status,
-                "total_processing_transactions": total_processing,
-                "total_orphaned_transactions": total_orphaned,
-                "active_workers": len(active_workers),
-            }
+                return {
+                    "status": status,
+                    "total_processing_transactions": total_processing,
+                    "total_orphaned_transactions": total_orphaned,
+                    "active_workers": len(active_workers),
+                }
+
+        return await asyncio.to_thread(_query_consensus)
 
     except Exception as e:
         logger.exception("Consensus health check failed")
@@ -559,11 +562,15 @@ async def _check_memory_health() -> Dict[str, Any]:
         process = psutil.Process()
         memory_info = process.memory_info()
 
+        # cpu_percent(interval=0.1) blocks for 100ms — run in thread to avoid
+        # freezing the event loop (this runs every health-check cycle).
+        cpu_pct = await asyncio.to_thread(process.cpu_percent, 0.1)
+
         return {
             "status": "healthy",
             "memory_usage_mb": memory_info.rss / 1024 / 1024,
             "memory_percent": process.memory_percent(),
-            "cpu_percent": process.cpu_percent(interval=0.1),
+            "cpu_percent": cpu_pct,
         }
     except Exception as e:
         return {"status": "error", "error": str(e)}
@@ -573,7 +580,7 @@ async def _get_aggregate_counts() -> tuple[int, int, int]:
     """Query total decisions, unique users, and pending transactions from database."""
     from sqlalchemy import text
 
-    try:
+    def _query():
         db_manager = get_database_manager()
         with db_manager.engine.connect() as conn:
             query = text(
@@ -592,6 +599,9 @@ async def _get_aggregate_counts() -> tuple[int, int, int]:
                 if row
                 else (0, 0, 0)
             )
+
+    try:
+        return await asyncio.to_thread(_query)
     except Exception as e:
         logger.warning(f"Failed to get aggregate counts: {e}")
         return (0, 0, 0)
@@ -601,7 +611,7 @@ async def _get_pending_contracts() -> list[dict]:
     """Query pending transactions grouped by contract address."""
     from sqlalchemy import text
 
-    try:
+    def _query():
         db_manager = get_database_manager()
         with db_manager.engine.connect() as conn:
             query = text(
@@ -625,26 +635,29 @@ async def _get_pending_contracts() -> list[dict]:
                 }
                 for row in result
             ]
+
+    try:
+        return await asyncio.to_thread(_query)
     except Exception as e:
         logger.warning(f"Failed to get pending contracts: {e}")
         return []
 
 
 async def _check_redis_health() -> str:
-    """Check Redis connectivity."""
+    """Check Redis connectivity using async client."""
     redis_url = os.getenv("REDIS_URL")
     if not redis_url:
         return "not_configured"
 
     try:
-        import redis
+        import redis.asyncio as aioredis
 
-        redis_client = redis.from_url(redis_url)
+        redis_client = aioredis.from_url(redis_url)
         try:
-            redis_client.ping()
+            await redis_client.ping()
             return "healthy"
         finally:
-            redis_client.close()
+            await redis_client.aclose()
     except Exception:
         return "unhealthy"
 
@@ -883,14 +896,17 @@ async def health_database() -> Dict[str, Any]:
             logger.debug(f"Could not get pool statistics: {e}")
             pool_status = {"class": "unknown", "error": str(e)}
 
-        # Test database connectivity
+        # Test database connectivity — run in thread to avoid blocking event loop
+        def _db_ping_detail():
+            start_t = time.time()
+            with db_manager.engine.connect() as conn:
+                conn.execute(text("SELECT 1"))
+            return (time.time() - start_t) * 1000
+
         db_healthy = False
         query_time_ms = 0
         try:
-            start = time.time()
-            with db_manager.engine.connect() as conn:
-                conn.execute(text("SELECT 1"))
-            query_time_ms = (time.time() - start) * 1000
+            query_time_ms = await asyncio.to_thread(_db_ping_detail)
             db_healthy = True
         except Exception as e:
             logger.error(f"Database connectivity test failed: {e}")
@@ -982,27 +998,29 @@ async def health_cpu() -> Dict[str, Any]:
     try:
         import psutil
 
-        process = psutil.Process()
-        cpu_times = process.cpu_times()
+        def _collect_cpu():
+            process = psutil.Process()
+            cpu_times = process.cpu_times()
+            return {
+                "status": "healthy",
+                "cpu_percent": process.cpu_percent(interval=0.1),
+                "cpu_times": {
+                    "user": cpu_times.user,
+                    "system": cpu_times.system,
+                },
+                "num_threads": process.num_threads(),
+                "system_cpu": {
+                    "percent": psutil.cpu_percent(interval=0.1),
+                    "per_cpu_percent": psutil.cpu_percent(interval=0.1, percpu=True),
+                    "cpu_count": psutil.cpu_count(),
+                    "cpu_count_logical": psutil.cpu_count(logical=True),
+                    "load_average": (
+                        psutil.getloadavg() if hasattr(psutil, "getloadavg") else None
+                    ),
+                },
+            }
 
-        return {
-            "status": "healthy",
-            "cpu_percent": process.cpu_percent(interval=0.1),
-            "cpu_times": {
-                "user": cpu_times.user,
-                "system": cpu_times.system,
-            },
-            "num_threads": process.num_threads(),
-            "system_cpu": {
-                "percent": psutil.cpu_percent(interval=0.1),
-                "per_cpu_percent": psutil.cpu_percent(interval=0.1, percpu=True),
-                "cpu_count": psutil.cpu_count(),
-                "cpu_count_logical": psutil.cpu_count(logical=True),
-                "load_average": (
-                    psutil.getloadavg() if hasattr(psutil, "getloadavg") else None
-                ),
-            },
-        }
+        return await asyncio.to_thread(_collect_cpu)
     except Exception as e:
         logger.exception("CPU health check failed")
         return {"status": "error", "error": str(e)}
@@ -1021,134 +1039,141 @@ async def health_consensus(
         if not rpc_router:
             return {"status": "not_initialized", "error": "RPC router not available"}
 
-        # Get active worker IDs from recent transactions
-        db_manager = get_database_manager()
-        with db_manager.engine.connect() as worker_conn:
-            now = datetime.now(timezone.utc)
-            recent_threshold = now - timedelta(hours=1)
+        def _query_consensus_detail():
+            # Get active worker IDs from recent transactions
+            db_manager = get_database_manager()
+            with db_manager.engine.connect() as worker_conn:
+                now = datetime.now(timezone.utc)
+                recent_threshold = now - timedelta(hours=1)
 
-            from sqlalchemy import select, distinct, and_
+                from sqlalchemy import select, distinct, and_
 
-            worker_query = select(distinct(Transactions.worker_id)).where(
-                and_(
-                    Transactions.worker_id.isnot(None),
-                    Transactions.created_at > recent_threshold,
+                worker_query = select(distinct(Transactions.worker_id)).where(
+                    and_(
+                        Transactions.worker_id.isnot(None),
+                        Transactions.created_at > recent_threshold,
+                    )
                 )
-            )
 
-            worker_result = worker_conn.execute(worker_query)
-            active_workers = {row[0] for row in worker_result if row[0]}
+                worker_result = worker_conn.execute(worker_query)
+                active_workers = {row[0] for row in worker_result if row[0]}
 
-        # Query transaction statistics by contract
-        db_manager = get_database_manager()
-        with db_manager.engine.connect() as conn:
-            now = datetime.now(timezone.utc)
+            # Query transaction statistics by contract
+            with db_manager.engine.connect() as conn:
+                now = datetime.now(timezone.utc)
 
-            from sqlalchemy import text
+                from sqlalchemy import text
 
-            query = text(
+                query = text(
+                    """
+                    SELECT
+                        to_address as contract_address,
+                        COUNT(*) FILTER (WHERE status IN ('ACTIVATED', 'PROPOSING', 'COMMITTING', 'REVEALING', 'ACCEPTED', 'UNDETERMINED')) as processing_count,
+                        COUNT(*) FILTER (WHERE status = 'PENDING') as pending_count,
+                        COUNT(*) FILTER (WHERE created_at > :one_hour_ago) as created_last_1h,
+                        COUNT(*) FILTER (WHERE created_at > :three_hours_ago) as created_last_3h,
+                        COUNT(*) FILTER (WHERE created_at > :six_hours_ago) as created_last_6h,
+                        COUNT(*) FILTER (WHERE created_at > :twelve_hours_ago) as created_last_12h,
+                        COUNT(*) FILTER (WHERE created_at > :one_day_ago) as created_last_1d,
+                        MIN(blocked_at) as oldest_blocked_at,
+                        MIN(created_at) FILTER (WHERE status IN ('PENDING', 'ACTIVATED', 'PROPOSING', 'COMMITTING', 'REVEALING', 'ACCEPTED', 'UNDETERMINED')) as oldest_processing_created_at,
+                        COUNT(*) FILTER (WHERE worker_id IS NOT NULL AND status IN ('PENDING', 'ACTIVATED', 'PROPOSING', 'COMMITTING', 'REVEALING', 'ACCEPTED', 'UNDETERMINED')) as blocked_count,
+                        json_agg(DISTINCT jsonb_build_object('worker_id', worker_id, 'hash', hash))
+                            FILTER (WHERE worker_id IS NOT NULL AND status IN ('PENDING', 'ACTIVATED', 'PROPOSING', 'COMMITTING', 'REVEALING', 'ACCEPTED', 'UNDETERMINED')) as worker_transactions
+                    FROM transactions
+                    WHERE to_address IS NOT NULL
+                    GROUP BY to_address
+                    HAVING COUNT(*) FILTER (WHERE status IN ('PENDING', 'ACTIVATED', 'PROPOSING', 'COMMITTING', 'REVEALING', 'ACCEPTED', 'UNDETERMINED')) > 0
+                    ORDER BY processing_count DESC
                 """
-                SELECT
-                    to_address as contract_address,
-                    COUNT(*) FILTER (WHERE status IN ('ACTIVATED', 'PROPOSING', 'COMMITTING', 'REVEALING', 'ACCEPTED', 'UNDETERMINED')) as processing_count,
-                    COUNT(*) FILTER (WHERE status = 'PENDING') as pending_count,
-                    COUNT(*) FILTER (WHERE created_at > :one_hour_ago) as created_last_1h,
-                    COUNT(*) FILTER (WHERE created_at > :three_hours_ago) as created_last_3h,
-                    COUNT(*) FILTER (WHERE created_at > :six_hours_ago) as created_last_6h,
-                    COUNT(*) FILTER (WHERE created_at > :twelve_hours_ago) as created_last_12h,
-                    COUNT(*) FILTER (WHERE created_at > :one_day_ago) as created_last_1d,
-                    MIN(blocked_at) as oldest_blocked_at,
-                    MIN(created_at) FILTER (WHERE status IN ('PENDING', 'ACTIVATED', 'PROPOSING', 'COMMITTING', 'REVEALING', 'ACCEPTED', 'UNDETERMINED')) as oldest_processing_created_at,
-                    COUNT(*) FILTER (WHERE worker_id IS NOT NULL AND status IN ('PENDING', 'ACTIVATED', 'PROPOSING', 'COMMITTING', 'REVEALING', 'ACCEPTED', 'UNDETERMINED')) as blocked_count,
-                    json_agg(DISTINCT jsonb_build_object('worker_id', worker_id, 'hash', hash))
-                        FILTER (WHERE worker_id IS NOT NULL AND status IN ('PENDING', 'ACTIVATED', 'PROPOSING', 'COMMITTING', 'REVEALING', 'ACCEPTED', 'UNDETERMINED')) as worker_transactions
-                FROM transactions
-                WHERE to_address IS NOT NULL
-                GROUP BY to_address
-                HAVING COUNT(*) FILTER (WHERE status IN ('PENDING', 'ACTIVATED', 'PROPOSING', 'COMMITTING', 'REVEALING', 'ACCEPTED', 'UNDETERMINED')) > 0
-                ORDER BY processing_count DESC
-            """
-            )
+                )
 
-            result = conn.execute(
-                query,
-                {
-                    "one_hour_ago": now - timedelta(hours=1),
-                    "three_hours_ago": now - timedelta(hours=3),
-                    "six_hours_ago": now - timedelta(hours=6),
-                    "twelve_hours_ago": now - timedelta(hours=12),
-                    "one_day_ago": now - timedelta(days=1),
-                },
-            )
+                result = conn.execute(
+                    query,
+                    {
+                        "one_hour_ago": now - timedelta(hours=1),
+                        "three_hours_ago": now - timedelta(hours=3),
+                        "six_hours_ago": now - timedelta(hours=6),
+                        "twelve_hours_ago": now - timedelta(hours=12),
+                        "one_day_ago": now - timedelta(days=1),
+                    },
+                )
 
-            contracts = []
-            total_orphaned = 0
+                contracts = []
+                total_orphaned = 0
 
-            for row in result:
-                contract_data = {
-                    "contract_address": row.contract_address,
-                    "processing_count": row.processing_count,
-                    "pending_count": row.pending_count,
-                    "created_last_1h": row.created_last_1h,
-                    "created_last_3h": row.created_last_3h,
-                    "created_last_6h": row.created_last_6h,
-                    "created_last_12h": row.created_last_12h,
-                    "created_last_1d": row.created_last_1d,
+                for row in result:
+                    contract_data = {
+                        "contract_address": row.contract_address,
+                        "processing_count": row.processing_count,
+                        "pending_count": row.pending_count,
+                        "created_last_1h": row.created_last_1h,
+                        "created_last_3h": row.created_last_3h,
+                        "created_last_6h": row.created_last_6h,
+                        "created_last_12h": row.created_last_12h,
+                        "created_last_1d": row.created_last_1d,
+                    }
+
+                    if row.oldest_blocked_at:
+                        elapsed = now - row.oldest_blocked_at
+                        minutes = int(elapsed.total_seconds() / 60)
+                        if minutes < 60:
+                            contract_data["oldest_transaction_elapsed"] = f"{minutes}m"
+                        else:
+                            hours = minutes // 60
+                            contract_data["oldest_transaction_elapsed"] = f"{hours}h"
+                    else:
+                        contract_data["oldest_transaction_elapsed"] = None
+
+                    if row.oldest_processing_created_at:
+                        contract_data["oldest_processing_created_at"] = (
+                            row.oldest_processing_created_at.isoformat()
+                        )
+                        elapsed = now - row.oldest_processing_created_at
+                        minutes = int(elapsed.total_seconds() / 60)
+                        if minutes < 60:
+                            contract_data["oldest_processing_elapsed"] = f"{minutes}m"
+                        else:
+                            hours = minutes // 60
+                            contract_data["oldest_processing_elapsed"] = f"{hours}h"
+                    else:
+                        contract_data["oldest_processing_created_at"] = None
+                        contract_data["oldest_processing_elapsed"] = None
+
+                    orphaned_tx_hashes = []
+                    if row.worker_transactions:
+                        for tx_info in row.worker_transactions:
+                            if (
+                                tx_info
+                                and tx_info.get("worker_id") not in active_workers
+                            ):
+                                orphaned_tx_hashes.append(tx_info.get("hash"))
+
+                    contract_data["orphaned_transactions"] = len(orphaned_tx_hashes)
+                    if orphaned_tx_hashes:
+                        contract_data["orphaned_transaction_hashes"] = (
+                            orphaned_tx_hashes
+                        )
+                    total_orphaned += contract_data["orphaned_transactions"]
+
+                    contracts.append(contract_data)
+
+                total_processing = sum(c["processing_count"] for c in contracts)
+                status = (
+                    "healthy"
+                    if total_processing < 100 and total_orphaned == 0
+                    else "degraded"
+                )
+
+                return {
+                    "status": status,
+                    "total_processing_transactions": total_processing,
+                    "total_orphaned_transactions": total_orphaned,
+                    "active_workers": len(active_workers),
+                    "contracts": contracts,
                 }
 
-                if row.oldest_blocked_at:
-                    elapsed = now - row.oldest_blocked_at
-                    minutes = int(elapsed.total_seconds() / 60)
-                    if minutes < 60:
-                        contract_data["oldest_transaction_elapsed"] = f"{minutes}m"
-                    else:
-                        hours = minutes // 60
-                        contract_data["oldest_transaction_elapsed"] = f"{hours}h"
-                else:
-                    contract_data["oldest_transaction_elapsed"] = None
-
-                if row.oldest_processing_created_at:
-                    contract_data["oldest_processing_created_at"] = (
-                        row.oldest_processing_created_at.isoformat()
-                    )
-                    elapsed = now - row.oldest_processing_created_at
-                    minutes = int(elapsed.total_seconds() / 60)
-                    if minutes < 60:
-                        contract_data["oldest_processing_elapsed"] = f"{minutes}m"
-                    else:
-                        hours = minutes // 60
-                        contract_data["oldest_processing_elapsed"] = f"{hours}h"
-                else:
-                    contract_data["oldest_processing_created_at"] = None
-                    contract_data["oldest_processing_elapsed"] = None
-
-                orphaned_tx_hashes = []
-                if row.worker_transactions:
-                    for tx_info in row.worker_transactions:
-                        if tx_info and tx_info.get("worker_id") not in active_workers:
-                            orphaned_tx_hashes.append(tx_info.get("hash"))
-
-                contract_data["orphaned_transactions"] = len(orphaned_tx_hashes)
-                if orphaned_tx_hashes:
-                    contract_data["orphaned_transaction_hashes"] = orphaned_tx_hashes
-                total_orphaned += contract_data["orphaned_transactions"]
-
-                contracts.append(contract_data)
-
-            total_processing = sum(c["processing_count"] for c in contracts)
-            status = (
-                "healthy"
-                if total_processing < 100 and total_orphaned == 0
-                else "degraded"
-            )
-
-            return {
-                "status": status,
-                "total_processing_transactions": total_processing,
-                "total_orphaned_transactions": total_orphaned,
-                "active_workers": len(active_workers),
-                "contracts": contracts,
-            }
+        return await asyncio.to_thread(_query_consensus_detail)
 
     except Exception as e:
         logger.exception("Consensus health check failed")
@@ -1168,37 +1193,37 @@ async def metrics():
     from backend.database_handler.session_factory import get_database_manager
 
     try:
-        db_manager = get_database_manager()
-        with db_manager.engine.connect() as conn:
+
+        def _query_metrics():
             from sqlalchemy import text
 
-            # Count distinct contracts that have schedulable work:
-            # - "occupied": has an in-flight tx (worker is actively processing)
-            # - "runnable": has pending tx but no in-flight (a worker could pick it up)
-            # This directly measures max useful parallelism since transactions
-            # for the same contract are processed sequentially.
-            row = conn.execute(
-                text(
-                    """
-                    WITH per_contract AS (
+            db_manager = get_database_manager()
+            with db_manager.engine.connect() as conn:
+                row = conn.execute(
+                    text(
+                        """
+                        WITH per_contract AS (
+                            SELECT
+                                to_address,
+                                BOOL_OR(status = 'PENDING') AS has_pending,
+                                BOOL_OR(status IN ('PROPOSING', 'COMMITTING', 'UNDETERMINED')) AS has_inflight
+                            FROM transactions
+                            WHERE status IN ('PENDING', 'PROPOSING', 'COMMITTING', 'UNDETERMINED')
+                            GROUP BY to_address
+                        )
                         SELECT
-                            to_address,
-                            BOOL_OR(status = 'PENDING') AS has_pending,
-                            BOOL_OR(status IN ('PROPOSING', 'COMMITTING', 'UNDETERMINED')) AS has_inflight
-                        FROM transactions
-                        WHERE status IN ('PENDING', 'PROPOSING', 'COMMITTING', 'UNDETERMINED')
-                        GROUP BY to_address
+                            COALESCE(COUNT(*) FILTER (WHERE has_inflight), 0) AS occupied,
+                            COALESCE(COUNT(*) FILTER (WHERE has_pending AND NOT has_inflight), 0) AS runnable
+                        FROM per_contract
+                        """
                     )
-                    SELECT
-                        COALESCE(COUNT(*) FILTER (WHERE has_inflight), 0) AS occupied,
-                        COALESCE(COUNT(*) FILTER (WHERE has_pending AND NOT has_inflight), 0) AS runnable
-                    FROM per_contract
-                    """
-                )
-            ).fetchone()
+                ).fetchone()
 
-            occupied_count = row[0] if row else 0
-            runnable_count = row[1] if row else 0
+                occupied = row[0] if row else 0
+                runnable = row[1] if row else 0
+                return occupied, runnable
+
+        occupied_count, runnable_count = await asyncio.to_thread(_query_metrics)
 
         base = occupied_count + runnable_count
         # Add 10% headroom for burst absorption, minimum 0 (HPA minReplicas handles floor)


### PR DESCRIPTION
## Summary

Production jsonrpc pods were crash-looping because two compounding issues prevented health probes from being served:

### Fix 1: Offload blocking I/O in health checks (`health.py`)
- The background health checker was running **synchronous blocking I/O directly on the asyncio event loop** every 10 seconds, freezing Uvicorn and preventing it from responding to HTTP requests
- Switched `_check_redis_health()` from sync `redis` to `redis.asyncio`
- Wrapped `psutil.cpu_percent(interval=0.1)` (hard 100ms block) and all sync `engine.connect()` DB calls in `asyncio.to_thread()`
- Also fixed the same blocking pattern in `/health/cpu`, `/health/db`, `/health/consensus`, and `/metrics` HTTP endpoints

### Fix 2: Move Redis subscriber to background task (`app_lifespan.py`)
- The Redis subscriber's `connect()` + `subscribe()` was **blocking the Uvicorn lifespan for ~2.5 minutes** in production
- Uvicorn doesn't serve HTTP requests until the lifespan yields, so health probes had no server to talk to during this entire window
- Root cause: the blocking health checker (Fix 1) was starving the async Redis connect, turning a sub-second operation into a multi-minute ordeal
- Fix: Redis subscriber now connects in a background task, so Uvicorn starts serving immediately

### Blocking calls fixed in health.py

| Function | Blocking call | Fix |
|---|---|---|
| `_check_redis_health()` | Sync `redis.from_url().ping()` | `redis.asyncio` |
| `_check_memory_health()` | `cpu_percent(interval=0.1)` — 100ms block | `asyncio.to_thread()` |
| `_check_database_health()` | `engine.connect()` + SELECT 1 | `asyncio.to_thread()` |
| `_check_consensus_health()` | Two `engine.connect()` calls | `asyncio.to_thread()` |
| `_get_aggregate_counts()` | `engine.connect()` + query | `asyncio.to_thread()` |
| `_get_pending_contracts()` | `engine.connect()` + query | `asyncio.to_thread()` |
| `/health/cpu` endpoint | 3x `cpu_percent(interval=0.1)` = 300ms | `asyncio.to_thread()` |
| `/health/db` endpoint | `engine.connect()` | `asyncio.to_thread()` |
| `/health/consensus` endpoint | Two `engine.connect()` calls | `asyncio.to_thread()` |
| `/metrics` endpoint | `engine.connect()` + query | `asyncio.to_thread()` |

## Test plan

- [x] Backend unit tests pass (585 passed)
- [x] Frontend unit tests pass (pre-existing failure in consensus store test unrelated)
- [ ] Deploy to dev/staging and verify health probes respond consistently
- [ ] Verify pods no longer enter crash loops under normal load
- [ ] Monitor startup time — should drop from ~2.5min to <20s