### PR TITLE
fix: move Redis subscriber connect to background task for faster startup

### DIFF
--- a/backend/database_handler/migration/versions/e4f8a2b7c913_add_transactions_status_indexes.py
+++ b/backend/database_handler/migration/versions/e4f8a2b7c913_add_transactions_status_indexes.py
@@ -1,0 +1,38 @@
+"""add transactions status indexes
+
+Revision ID: e4f8a2b7c913
+Revises: c3d7f2a8b104
+Create Date: 2026-03-17 12:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision: str = "e4f8a2b7c913"
+down_revision: Union[str, None] = "c3d7f2a8b104"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_index(
+        "idx_transactions_status",
+        "transactions",
+        ["status"],
+        if_not_exists=True,
+    )
+    op.create_index(
+        "idx_transactions_status_to_address",
+        "transactions",
+        ["status", "to_address"],
+        if_not_exists=True,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("idx_transactions_status_to_address", table_name="transactions")
+    op.drop_index("idx_transactions_status", table_name="transactions")

--- a/backend/protocol_rpc/app_lifespan.py
+++ b/backend/protocol_rpc/app_lifespan.py
@@ -372,6 +372,7 @@ async def rpc_app_lifespan(app, settings: RPCAppSettings) -> AsyncIterator[RPCAp
         resources.background_tasks.append(monitor_task)
 
     # Initialize Redis subscriber - REQUIRED for distributed worker architecture
+    # Connects in background so Uvicorn can start serving health probes immediately.
     redis_url = os.environ.get("REDIS_URL")
     if not redis_url:
         error_msg = (
@@ -383,42 +384,24 @@ async def rpc_app_lifespan(app, settings: RPCAppSettings) -> AsyncIterator[RPCAp
         logger.error(error_msg)
         raise RuntimeError(error_msg)
 
-    try:
-        redis_subscriber = RedisEventSubscriber(
-            redis_url=redis_url,
-            broadcast=broadcast,
-            instance_id=f"rpc-{os.getpid()}",
-        )
-        await redis_subscriber.connect()
-        await redis_subscriber.start()
+    redis_subscriber = RedisEventSubscriber(
+        redis_url=redis_url,
+        broadcast=broadcast,
+        instance_id=f"rpc-{os.getpid()}",
+    )
 
-        # Register handler for validator change events
-        async def handle_validator_change(event_data):
-            """Reload validators when they change."""
-            logger.info(f"RPC worker reloading validators due to change event")
-            await validators_manager.restart()
+    # Register handler for validator change events (before connect — handlers are
+    # stored locally and will fire once the subscriber is listening).
+    async def handle_validator_change(event_data):
+        """Reload validators when they change."""
+        logger.info(f"RPC worker reloading validators due to change event")
+        await validators_manager.restart()
 
-        redis_subscriber.register_handler("validator_created", handle_validator_change)
-        redis_subscriber.register_handler("validator_updated", handle_validator_change)
-        redis_subscriber.register_handler("validator_deleted", handle_validator_change)
-        redis_subscriber.register_handler(
-            "all_validators_deleted", handle_validator_change
-        )
-        redis_subscriber.register_handler(
-            "validators_replaced", handle_validator_change
-        )
-
-        logger.info(
-            f"[STARTUP] Redis subscriber connected at {redis_url} for worker event broadcasting"
-        )
-    except Exception as e:
-        error_msg = (
-            f"FATAL: Failed to connect to Redis at {redis_url}. "
-            f"Redis is required for receiving events from consensus workers. "
-            f"Ensure Redis is running and accessible. Error: {e}"
-        )
-        logger.error(error_msg)
-        raise RuntimeError(error_msg) from e
+    redis_subscriber.register_handler("validator_created", handle_validator_change)
+    redis_subscriber.register_handler("validator_updated", handle_validator_change)
+    redis_subscriber.register_handler("validator_deleted", handle_validator_change)
+    redis_subscriber.register_handler("all_validators_deleted", handle_validator_change)
+    redis_subscriber.register_handler("validators_replaced", handle_validator_change)
 
     # Initialize rate limiter with a dedicated Redis client
     rate_limit_redis = aioredis.from_url(redis_url, decode_responses=True)
@@ -427,7 +410,39 @@ async def rpc_app_lifespan(app, settings: RPCAppSettings) -> AsyncIterator[RPCAp
         get_session=lambda: db_manager.open_session(),
     )
     app_state.rate_limiter = rate_limiter
-    logger.info(f"[STARTUP] Rate limiter initialized (enabled={rate_limiter.enabled})")
+
+    async def _connect_redis_subscriber():
+        """Connect Redis subscriber in background so Uvicorn starts serving immediately."""
+        try:
+            await redis_subscriber.connect()
+            await redis_subscriber.start()
+            logger.info(
+                f"[STARTUP] Redis subscriber connected at {redis_url} for worker event broadcasting"
+            )
+        except Exception as e:
+            logger.error(
+                f"Failed to connect Redis subscriber at {redis_url}: {e}. "
+                f"Worker events will not be received. Retrying in 5s..."
+            )
+            await asyncio.sleep(5)
+            try:
+                await redis_subscriber.connect()
+                await redis_subscriber.start()
+                logger.info(
+                    f"[STARTUP] Redis subscriber connected at {redis_url} (retry succeeded)"
+                )
+            except Exception as retry_err:
+                logger.error(
+                    f"Redis subscriber retry failed: {retry_err}. "
+                    f"Worker events will NOT be forwarded to WebSocket clients."
+                )
+
+    redis_task = asyncio.create_task(_connect_redis_subscriber())
+    background_tasks.append(redis_task)
+    logger.info(
+        f"[STARTUP] Redis subscriber connecting in background, "
+        f"rate limiter initialized (enabled={rate_limiter.enabled})"
+    )
 
     try:
         yield app_state


### PR DESCRIPTION
## Summary

- The Redis subscriber's `connect()` + `subscribe()` was **blocking the Uvicorn lifespan for ~2.5 minutes** in production (rally-studio-prd), preventing health probes from being served
- Uvicorn doesn't serve HTTP requests until the lifespan yields, so startup/liveness/readiness probes had no server to talk to during this window
- Root cause: the blocking health checker (fixed in #1537) was starving the async Redis connect, turning a sub-second operation into a multi-minute ordeal. Even with #1537 merged, the Redis connect still blocks the lifespan unnecessarily
- Fix: Redis subscriber now connects in a background task with retry logic, so Uvicorn starts serving immediately (~16s instead of ~2.5min)

## Evidence from rally-studio-prd logs

```
10:19:11 - [STARTUP] Application startup completed in 15.69 seconds
10:19:11 - RPC instance rpc-1 Redis subscriber initialized
10:21:38 - RPC instance rpc-1 connected to Redis        ← 2m27s gap!
10:21:38 - Application startup complete.                 ← Uvicorn FINALLY serves
10:21:38 - Uvicorn running on http://0.0.0.0:4000
```

## Test plan

- [x] Backend unit tests pass (585 passed)
- [ ] Deploy and verify Uvicorn starts serving within ~20s
- [ ] Verify Redis subscriber connects in background and events flow normally
- [ ] Verify pods stop crash-looping in rally-studio-prd

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Redis subscriber now connects in the background during startup, with improved retry handling, pre-registered event handlers, and clearer startup/health logging to reduce startup blocking and improve reliability.

* **Chores**
  * Add database migration to create indexes on transaction status (and status+recipient) to speed related queries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->