### PR TITLE
fix: allow /api/health through explorer proxy middleware

### DIFF
--- a/explorer/src/proxy.ts
+++ b/explorer/src/proxy.ts
@@ -5,8 +5,9 @@ const BACKEND_URL = process.env.BACKEND_URL || "http://localhost:4000";
 export function proxy(request: NextRequest) {
   const { pathname, search } = request.nextUrl;
 
-  // Let Next.js API routes handle /api/rpc
-  if (pathname.startsWith('/api/rpc')) return NextResponse.next();
+  // Let Next.js API routes handle these paths directly
+  if (pathname.startsWith('/api/rpc') || pathname.startsWith('/api/health'))
+    return NextResponse.next();
 
   const destination = `${BACKEND_URL}/api/explorer${pathname.slice("/api".length)}${search}`;
   return NextResponse.rewrite(new URL(destination));


### PR DESCRIPTION
## Summary
- The explorer proxy.ts middleware rewrites all `/api/*` requests to the backend, which intercepted the `/api/health` endpoint added in #1539
- Adds `/api/health` to the passthrough list so GCE health checks reach the Next.js API route directly
- Without this fix, GCE health checks hit `GET /` (the dashboard SSR page), triggering heavy backend queries every 5 seconds

## Test plan
- [ ] Verify `GET /api/health` returns `{"status":"ok"}` on the explorer
- [ ] Verify other `/api/*` routes still proxy to the backend correctly