### PR TITLE
fix: use fresh snapshot for appeal validators instead of saved empty one

### DIFF
--- a/backend/consensus/base.py
+++ b/backend/consensus/base.py
@@ -442,8 +442,12 @@ class TransactionContext:
         self.shared_contract_snapshot_cache: dict[str, ContractSnapshot] = {}
 
         if self.transaction.type != TransactionType.SEND:
-            if self.transaction.contract_snapshot:
-                self.contract_snapshot = self.transaction.contract_snapshot
+            saved = self.transaction.contract_snapshot
+            has_real_state = (
+                saved and hasattr(saved, "states") and saved.states.get("accepted")
+            )
+            if has_real_state:
+                self.contract_snapshot = saved
             else:
                 self.contract_snapshot = self.contract_snapshot_factory(
                     self.transaction.to_address

--- a/tests/unit/consensus/test_appeal_snapshot.py
+++ b/tests/unit/consensus/test_appeal_snapshot.py
@@ -1,0 +1,117 @@
+"""Tests for contract snapshot handling during appeal rounds.
+
+Regression test for the bug where appeal validators received a saved
+empty snapshot instead of a fresh one from the factory, causing GenVM
+to crash with 'NoneType' errors when accessing root storage.
+"""
+
+from unittest.mock import Mock
+
+from backend.consensus.base import TransactionContext
+from backend.database_handler.contract_snapshot import ContractSnapshot
+from backend.domain.types import Transaction, TransactionType
+
+
+def _make_snapshot(states=None):
+    """Create a ContractSnapshot from_dict (same path as DB deserialization)."""
+    return ContractSnapshot.from_dict(
+        {
+            "contract_address": "0xcontract",
+            "states": states or {"accepted": {}, "finalized": {}},
+        }
+    )
+
+
+def _make_transaction(*, tx_type=TransactionType.RUN_CONTRACT, contract_snapshot=None):
+    """Build a minimal Transaction for context creation."""
+    tx = Mock(spec=Transaction)
+    tx.type = tx_type
+    tx.to_address = "0xcontract"
+    tx.contract_snapshot = contract_snapshot
+    tx.consensus_data = Mock()
+    tx.consensus_data.leader_receipt = None
+    return tx
+
+
+def _make_context(transaction, factory_snapshot=None):
+    """Create a TransactionContext with mocked dependencies."""
+    factory = Mock(
+        return_value=factory_snapshot
+        or _make_snapshot({"accepted": {"slot0": "real_data"}, "finalized": {}})
+    )
+    context = TransactionContext(
+        transaction=transaction,
+        transactions_processor=Mock(),
+        chain_snapshot=None,
+        accounts_manager=Mock(),
+        contract_snapshot_factory=factory,
+        contract_processor=Mock(),
+        node_factory=Mock(),
+        msg_handler=Mock(),
+        consensus_service=Mock(),
+        validators_snapshot=None,
+        genvm_manager=Mock(),
+    )
+    return context, factory
+
+
+class TestAppealSnapshotLoading:
+    """TransactionContext should always use factory for appeal validators."""
+
+    def test_no_saved_snapshot_uses_factory(self):
+        """When transaction has no saved snapshot, factory is called."""
+        tx = _make_transaction(contract_snapshot=None)
+        context, factory = _make_context(tx)
+
+        factory.assert_called_once_with("0xcontract")
+        assert context.contract_snapshot is not None
+        assert context.contract_snapshot.states["accepted"] == {"slot0": "real_data"}
+
+    def test_saved_snapshot_with_empty_states_uses_factory(self):
+        """Saved snapshot with empty states should be ignored in favor of factory.
+
+        The snapshot was saved during AcceptedState with empty states
+        (before the leader's execution populated them). On appeal, the
+        factory should be called to get a fresh snapshot with real state.
+        """
+        empty_snapshot = _make_snapshot({"accepted": {}, "finalized": {}})
+        tx = _make_transaction(contract_snapshot=empty_snapshot)
+        context, factory = _make_context(tx)
+
+        factory.assert_called_once_with("0xcontract")
+        assert context.contract_snapshot.states["accepted"] == {"slot0": "real_data"}
+
+    def test_saved_snapshot_with_real_states_uses_it(self):
+        """When snapshot has real state data, using it is fine."""
+        real_snapshot = _make_snapshot({"accepted": {"slot0": "data"}, "finalized": {}})
+        tx = _make_transaction(contract_snapshot=real_snapshot)
+        context, factory = _make_context(tx)
+
+        factory.assert_not_called()
+        assert context.contract_snapshot.states["accepted"] == {"slot0": "data"}
+
+    def test_deploy_transaction_with_empty_snapshot_on_appeal(self):
+        """Deploy txs are especially affected — snapshot is always empty at save time.
+
+        When a deploy tx reaches ACCEPTED, the contract_snapshot is saved
+        with states={'accepted': {}, 'finalized': {}} because the deploy
+        hasn't committed to DB yet. On appeal, the factory must be called
+        to get the real contract state from the database.
+        """
+        empty_snapshot = _make_snapshot({"accepted": {}, "finalized": {}})
+        tx = _make_transaction(
+            tx_type=TransactionType.DEPLOY_CONTRACT,
+            contract_snapshot=empty_snapshot,
+        )
+        context, factory = _make_context(tx)
+
+        factory.assert_called_once_with("0xcontract")
+        assert context.contract_snapshot.states["accepted"] == {"slot0": "real_data"}
+
+    def test_send_transaction_skips_snapshot(self):
+        """SEND transactions don't need contract snapshots."""
+        tx = _make_transaction(tx_type=TransactionType.SEND)
+        context, factory = _make_context(tx)
+
+        factory.assert_not_called()
+        assert not hasattr(context, "contract_snapshot")


### PR DESCRIPTION
## Summary
- Appeal validators received a saved contract snapshot with empty states (`{'accepted': {}, 'finalized': {}}`) instead of loading fresh state from the database
- This caused all appeal validators to crash with `AttributeError: 'NoneType' object has no attribute 'as_int'` in GenVM root storage initialization
- The snapshot was saved during AcceptedState before the leader's execution committed to DB, so it was always empty for deploy transactions

## Fix
- In `TransactionContext.__init__`, check if the saved snapshot has actual state data before using it
- If the accepted state is empty, fall back to the `contract_snapshot_factory` which loads real contract state from the database

## Observed in production
Transaction `0x8b2563d278c59be0b478e46512ba2448e56d257a5424b89c37fcf8babe473181` on studio-prd:
- Round 1: Leader SUCCESS, validators agreed
- Appeal round: All 7 validators crashed with `exit_code 1`, voted `DETERMINISTIC_VIOLATION`

## Test plan
- [x] Regression test: empty snapshot triggers factory (the bug scenario)
- [x] Regression test: real snapshot is still reused (optimization preserved)
- [x] Regression test: deploy transactions with empty snapshot on appeal
- [x] All 258 existing consensus unit tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved contract state handling during appeal rounds by ensuring only valid contract snapshots with accepted states are reused; otherwise, fresh snapshots are created for more reliable state management.

* **Tests**
  * Added comprehensive regression tests to validate contract snapshot loading behavior during appeal rounds across various transaction scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->