### PR TITLE
fix: track origin_address through contract sub-call chains

### DIFF
--- a/backend/consensus/base.py
+++ b/backend/consensus/base.py
@@ -2571,4 +2571,5 @@ def _emit_messages(
             ),
             triggered_on=triggered_on,
             execution_mode=execution_mode_str,  # Cascade execution mode
+            origin_address=context.transaction.origin_address,
         )

--- a/backend/database_handler/migration/backfill_origin_address.py
+++ b/backend/database_handler/migration/backfill_origin_address.py
@@ -1,0 +1,117 @@
+"""
+Batched backfill script for origin_address column.
+
+Run AFTER the schema migration (a1b2c3d4e5f6) has been applied.
+Safe to re-run (idempotent) — only updates rows where origin_address IS NULL.
+
+Usage:
+    python -m backend.database_handler.migration.backfill_origin_address
+
+Environment:
+    DB_URL or POSTGRES_URL — database connection string
+"""
+
+import os
+import time
+import logging
+
+from sqlalchemy import create_engine, text
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+logger = logging.getLogger(__name__)
+
+BATCH_SIZE = 1000
+SLEEP_BETWEEN_BATCHES = 0.1  # seconds
+
+
+def get_db_url() -> str:
+    url = os.getenv("DB_URL") or os.getenv("POSTGRES_URL")
+    if not url:
+        raise RuntimeError("Set DB_URL or POSTGRES_URL environment variable")
+    return url
+
+
+def backfill():
+    engine = create_engine(get_db_url())
+
+    with engine.connect() as conn:
+        # Step 1: Backfill top-level transactions (no parent)
+        logger.info("Backfilling top-level transactions (triggered_by_hash IS NULL)...")
+        total_top = 0
+        while True:
+            result = conn.execute(
+                text(
+                    """
+                    UPDATE transactions
+                    SET origin_address = from_address
+                    WHERE hash IN (
+                        SELECT hash FROM transactions
+                        WHERE origin_address IS NULL
+                          AND triggered_by_hash IS NULL
+                        LIMIT :batch_size
+                    )
+                """
+                ),
+                {"batch_size": BATCH_SIZE},
+            )
+            conn.commit()
+            updated = result.rowcount
+            total_top += updated
+            if updated == 0:
+                break
+            logger.info(f"  Updated {total_top} top-level rows so far...")
+            time.sleep(SLEEP_BETWEEN_BATCHES)
+
+        logger.info(f"Top-level backfill complete: {total_top} rows updated.")
+
+        # Step 2: Backfill sub-call transactions using recursive walk
+        # Process level by level: children of already-backfilled parents
+        logger.info(
+            "Backfilling sub-call transactions (walking triggered_by_hash chain)..."
+        )
+        total_sub = 0
+        while True:
+            result = conn.execute(
+                text(
+                    """
+                    UPDATE transactions
+                    SET origin_address = parent.origin_address
+                    FROM transactions parent
+                    WHERE transactions.hash IN (
+                        SELECT child.hash FROM transactions child
+                        JOIN transactions p ON child.triggered_by_hash = p.hash
+                        WHERE child.origin_address IS NULL
+                          AND p.origin_address IS NOT NULL
+                        LIMIT :batch_size
+                    )
+                    AND transactions.triggered_by_hash = parent.hash
+                    AND parent.origin_address IS NOT NULL
+                """
+                ),
+                {"batch_size": BATCH_SIZE},
+            )
+            conn.commit()
+            updated = result.rowcount
+            total_sub += updated
+            if updated == 0:
+                break
+            logger.info(f"  Updated {total_sub} sub-call rows so far...")
+            time.sleep(SLEEP_BETWEEN_BATCHES)
+
+        logger.info(f"Sub-call backfill complete: {total_sub} rows updated.")
+
+        # Verify: check for any remaining NULL origin_address
+        remaining = conn.execute(
+            text("SELECT COUNT(*) FROM transactions WHERE origin_address IS NULL")
+        ).scalar()
+        if remaining:
+            logger.warning(
+                f"{remaining} transactions still have NULL origin_address "
+                "(orphaned triggered_by_hash chains?)."
+            )
+        else:
+            logger.info("All transactions have origin_address set.")
+
+
+if __name__ == "__main__":
+    backfill()

--- a/backend/database_handler/migration/versions/a1b2c3d4e5f6_add_origin_address_to_transactions.py
+++ b/backend/database_handler/migration/versions/a1b2c3d4e5f6_add_origin_address_to_transactions.py
@@ -1,0 +1,30 @@
+"""add origin_address to transactions
+
+Revision ID: a1b2c3d4e5f6
+Revises: f7a1b3c5d9e2
+Create Date: 2026-04-07 12:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision: str = "a1b2c3d4e5f6"
+down_revision: Union[str, None] = "f7a1b3c5d9e2"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "transactions",
+        sa.Column("origin_address", sa.String(255), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("transactions", "origin_address")

--- a/backend/database_handler/migration/versions/d4e5f6a7b8c9_add_origin_address_to_transactions.py
+++ b/backend/database_handler/migration/versions/d4e5f6a7b8c9_add_origin_address_to_transactions.py
@@ -1,7 +1,7 @@
 """add origin_address to transactions
 
-Revision ID: a1b2c3d4e5f6
-Revises: f7a1b3c5d9e2
+Revision ID: d4e5f6a7b8c9
+Revises: b2c3d4e5f6a7
 Create Date: 2026-04-07 12:00:00.000000
 
 """
@@ -13,8 +13,8 @@ from alembic import op
 
 
 # revision identifiers, used by Alembic.
-revision: str = "a1b2c3d4e5f6"
-down_revision: Union[str, None] = "f7a1b3c5d9e2"
+revision: str = "d4e5f6a7b8c9"
+down_revision: Union[str, None] = "b2c3d4e5f6a7"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 

--- a/backend/database_handler/models.py
+++ b/backend/database_handler/models.py
@@ -167,6 +167,9 @@ class Transactions(Base):
     worker_id: Mapped[Optional[str]] = mapped_column(
         String(255), nullable=True, default=None
     )
+    origin_address: Mapped[Optional[str]] = mapped_column(
+        String(255), nullable=True, default=None
+    )
     execution_mode: Mapped[str] = mapped_column(
         String(30), server_default="NORMAL", nullable=False, default="NORMAL"
     )

--- a/backend/database_handler/transactions_processor.py
+++ b/backend/database_handler/transactions_processor.py
@@ -104,6 +104,7 @@ class TransactionsProcessor:
             "created_at": transaction_data.created_at.isoformat(),
             "leader_only": transaction_data.leader_only,
             "execution_mode": transaction_data.execution_mode,
+            "origin_address": transaction_data.origin_address,
             "triggered_by": transaction_data.triggered_by_hash,
             "triggered_on": transaction_data.triggered_on,
             "triggered_transactions": [
@@ -229,6 +230,7 @@ class TransactionsProcessor:
         sim_config: dict | None = None,
         triggered_on: str | None = None,  # "accepted" or "finalized"
         execution_mode: str = "NORMAL",  # "NORMAL", "LEADER_ONLY", or "LEADER_SELF_VALIDATOR"
+        origin_address: str | None = None,
     ) -> str:
 
         if transaction_hash is None:
@@ -262,6 +264,7 @@ class TransactionsProcessor:
             s=None,
             v=None,
             leader_only=leader_only,
+            origin_address=origin_address if origin_address else from_address,
             execution_mode=execution_mode,
             triggered_by=(
                 self.session.query(Transactions).filter_by(hash=triggered_by_hash).one()

--- a/backend/domain/types.py
+++ b/backend/domain/types.py
@@ -202,6 +202,7 @@ class Transaction:
     appeal_validators_timeout: bool = False
     sim_config: SimConfig | None = None
     triggered_by_hash: str | None = None
+    origin_address: str | None = None
 
     def to_dict(self):
         return {
@@ -243,6 +244,7 @@ class Transaction:
             "appeal_validators_timeout": self.appeal_validators_timeout,
             "sim_config": self.sim_config.to_dict() if self.sim_config else None,
             "triggered_by": self.triggered_by_hash,
+            "origin_address": self.origin_address,
         }
 
     @classmethod
@@ -292,4 +294,5 @@ class Transaction:
                 else None
             ),
             triggered_by_hash=input.get("triggered_by"),
+            origin_address=input.get("origin_address"),
         )

--- a/backend/node/base.py
+++ b/backend/node/base.py
@@ -631,6 +631,7 @@ class Node:
                 transaction.hash,
                 transaction_created_at,
                 value=transaction.value or 0,
+                origin_address=transaction.origin_address,
             )
 
             self.timing_callback("DEPLOY_END")
@@ -647,6 +648,7 @@ class Node:
                 transaction.hash,
                 transaction_created_at,
                 value=transaction.value or 0,
+                origin_address=transaction.origin_address,
             )
 
             self.timing_callback("RUN_END")
@@ -776,6 +778,7 @@ class Node:
         transaction_hash: str | None = None,
         transaction_created_at: str | None = None,
         value: int = 0,
+        origin_address: str | None = None,
     ) -> Receipt:
         assert self.contract_snapshot is not None
 
@@ -792,6 +795,7 @@ class Node:
             transaction_datetime=transaction_datetime,
             code=code_to_deploy,
             value=value,
+            origin_address=origin_address,
         )
 
     async def run_contract(
@@ -801,6 +805,7 @@ class Node:
         transaction_hash: str | None = None,
         transaction_created_at: str | None = None,
         value: int = 0,
+        origin_address: str | None = None,
     ) -> Receipt:
         return await self._run_genvm(
             from_address,
@@ -810,6 +815,7 @@ class Node:
             transaction_hash=transaction_hash,
             transaction_datetime=self._date_from_str(transaction_created_at),
             value=value,
+            origin_address=origin_address,
         )
 
     async def get_contract_data(
@@ -818,6 +824,7 @@ class Node:
         calldata: bytes,
         state_status: str | None = None,
         transaction_datetime: datetime.datetime | None = None,
+        origin_address: str | None = None,
     ) -> Receipt:
         return await self._run_genvm(
             from_address,
@@ -831,6 +838,7 @@ class Node:
                 else datetime.datetime.now().astimezone(datetime.UTC)
             ),
             state_status=state_status,
+            origin_address=origin_address,
         )
 
     async def _execution_finished(
@@ -944,6 +952,7 @@ class Node:
         timeout: float = 10 * 60,
         code: bytes | None = None,
         value: int = 0,
+        origin_address: str | None = None,
     ) -> Receipt:
         self.timing_callback("GENVM_PREPARATION_START")
 
@@ -998,9 +1007,7 @@ class Node:
             "is_init": is_init,
             "contract_address": contract_address,
             "sender_address": Address(from_address),
-            "origin_address": Address(
-                from_address
-            ),  # FIXME: no origin in simulator #751
+            "origin_address": Address(origin_address or from_address),
             "value": int(value),
             "chain_id": get_simulator_chain_id(),
         }

--- a/backend/protocol_rpc/endpoints.py
+++ b/backend/protocol_rpc/endpoints.py
@@ -1096,6 +1096,7 @@ async def _gen_call_with_validator(
     data = params["data"]
     to_address = params["to"]
     from_address = params["from"]
+    origin_address = params.get("origin_address")
     call_value = int(params.get("value", "0x0"), 16) if params.get("value") else 0
     transaction_hash_variant = (
         params["transaction_hash_variant"]
@@ -1181,6 +1182,7 @@ async def _gen_call_with_validator(
                     calldata=decoded_data.calldata,
                     state_status=state_status,
                     transaction_datetime=txn_dt,
+                    origin_address=origin_address,
                 )
             elif type == "write":
                 txn_created_at = None
@@ -1200,6 +1202,7 @@ async def _gen_call_with_validator(
                     calldata=decoded_data.calldata,
                     transaction_created_at=txn_created_at,
                     value=call_value,
+                    origin_address=origin_address,
                 )
             elif type == "deploy":
                 txn_created_at = None
@@ -1220,6 +1223,7 @@ async def _gen_call_with_validator(
                     calldata=decoded_data.calldata,
                     transaction_created_at=txn_created_at,
                     value=call_value,
+                    origin_address=origin_address,
                 )
             else:
                 raise JSONRPCError(

--- a/tests/db-sqlalchemy/test_origin_address.py
+++ b/tests/db-sqlalchemy/test_origin_address.py
@@ -1,0 +1,214 @@
+"""Regression tests for origin_address tracking through transaction chains."""
+
+import pytest
+from unittest.mock import patch, MagicMock
+import os
+from web3 import Web3
+from web3.providers import BaseProvider
+
+from backend.database_handler.transactions_processor import (
+    TransactionsProcessor,
+)
+
+
+_tx_counter = 100_000  # offset to avoid collisions with other test files
+
+
+def _make_tx(tp, **overrides):
+    """Create a transaction with sensible defaults and unique hash."""
+    global _tx_counter
+    _tx_counter += 1
+    defaults = dict(
+        from_address="0x9F0e84243496AcFB3Cd99D02eA59673c05901501",
+        to_address="0xAcec3A6d871C25F591aBd4fC24054e524BBbF794",
+        data={"key": "value"},
+        value=0,
+        type=2,
+        nonce=0,
+        leader_only=True,
+        config_rotation_rounds=3,
+        triggered_by_hash=None,
+        transaction_hash=f"0x{_tx_counter:064x}",
+    )
+    defaults.update(overrides)
+    tx_hash = tp.insert_transaction(**{k: v for k, v in defaults.items()})
+    tp.session.commit()
+    return tx_hash
+
+
+@pytest.fixture
+def mock_env_and_web3_connected():
+    with patch.dict(
+        os.environ,
+        {
+            "HARDHAT_PORT": "8545",
+            "HARDHAT_URL": "http://localhost",
+            "HARDHAT_PRIVATE_KEY": "0x0123456789",
+        },
+    ), patch("web3.Web3.HTTPProvider"):
+        web3_instance = Web3(MagicMock(spec=BaseProvider))
+        web3_instance.eth = MagicMock()
+        web3_instance.eth.accounts = ["0x0000000000000000000000000000000000000000"]
+        call_count = {"count": 0}
+
+        def mock_get_transaction_count(address, block_identifier="latest"):
+            result = call_count["count"]
+            call_count["count"] += 1
+            return result
+
+        web3_instance.eth.get_transaction_count = mock_get_transaction_count
+        web3_instance.is_connected = MagicMock(return_value=True)
+
+        with patch(
+            "backend.database_handler.transactions_processor.Web3",
+            return_value=web3_instance,
+        ):
+            yield web3_instance
+
+
+EOA = "0x1111111111111111111111111111111111111111"
+CONTRACT_A = "0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+CONTRACT_B = "0xBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB"
+CONTRACT_C = "0xCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC"
+
+
+class TestOriginAddressTopLevel:
+    """Top-level transactions should set origin_address = from_address."""
+
+    def test_origin_defaults_to_from_address(
+        self, tp: TransactionsProcessor, mock_env_and_web3_connected
+    ):
+        tp.web3 = mock_env_and_web3_connected
+        tx_hash = _make_tx(tp, from_address=EOA, to_address=CONTRACT_A)
+
+        tx = tp.get_transaction_by_hash(tx_hash)
+        assert tx["origin_address"] == EOA
+
+    def test_origin_defaults_when_not_provided(
+        self, tp: TransactionsProcessor, mock_env_and_web3_connected
+    ):
+        """When origin_address param is omitted, it falls back to from_address."""
+        tp.web3 = mock_env_and_web3_connected
+        tx_hash = _make_tx(tp, from_address=EOA, to_address=CONTRACT_A)
+
+        tx = tp.get_transaction_by_hash(tx_hash)
+        assert tx["origin_address"] == EOA
+        assert tx["from_address"] == EOA
+
+
+class TestOriginAddressSubCalls:
+    """Sub-call transactions should preserve the root origin_address."""
+
+    def test_subcall_preserves_origin(
+        self, tp: TransactionsProcessor, mock_env_and_web3_connected
+    ):
+        """Contract A called by EOA emits message to Contract B.
+        Contract B's transaction should have origin_address = EOA."""
+        tp.web3 = mock_env_and_web3_connected
+
+        # Top-level: EOA -> Contract A
+        parent_hash = _make_tx(tp, from_address=EOA, to_address=CONTRACT_A)
+
+        # Sub-call: Contract A -> Contract B (origin propagated from parent)
+        child_hash = _make_tx(
+            tp,
+            from_address=CONTRACT_A,
+            to_address=CONTRACT_B,
+            triggered_by_hash=parent_hash,
+            origin_address=EOA,  # propagated from parent
+        )
+
+        child_tx = tp.get_transaction_by_hash(child_hash)
+        assert child_tx["from_address"] == CONTRACT_A
+        assert child_tx["origin_address"] == EOA
+
+    def test_deep_chain_preserves_origin(
+        self, tp: TransactionsProcessor, mock_env_and_web3_connected
+    ):
+        """EOA -> A -> B -> C: all should have origin_address = EOA."""
+        tp.web3 = mock_env_and_web3_connected
+
+        tx1 = _make_tx(tp, from_address=EOA, to_address=CONTRACT_A)
+
+        tx2 = _make_tx(
+            tp,
+            from_address=CONTRACT_A,
+            to_address=CONTRACT_B,
+            triggered_by_hash=tx1,
+            origin_address=EOA,
+        )
+
+        tx3 = _make_tx(
+            tp,
+            from_address=CONTRACT_B,
+            to_address=CONTRACT_C,
+            triggered_by_hash=tx2,
+            origin_address=EOA,
+        )
+
+        for tx_hash in [tx1, tx2, tx3]:
+            tx = tp.get_transaction_by_hash(tx_hash)
+            assert (
+                tx["origin_address"] == EOA
+            ), f"Transaction {tx_hash} has origin_address={tx['origin_address']}, expected {EOA}"
+
+
+class TestOriginAddressExplicitOverride:
+    """origin_address can be explicitly set (for gen_call use case)."""
+
+    def test_explicit_origin_address(
+        self, tp: TransactionsProcessor, mock_env_and_web3_connected
+    ):
+        """When origin_address is explicitly provided, it should be used."""
+        tp.web3 = mock_env_and_web3_connected
+        custom_origin = "0xDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDD"
+
+        tx_hash = _make_tx(
+            tp,
+            from_address=EOA,
+            to_address=CONTRACT_A,
+            origin_address=custom_origin,
+        )
+
+        tx = tp.get_transaction_by_hash(tx_hash)
+        assert tx["origin_address"] == custom_origin
+        assert tx["from_address"] == EOA
+
+
+class TestOriginAddressNullFallback:
+    """Old transactions with NULL origin_address should be handled gracefully."""
+
+    def test_null_origin_in_domain_type(self):
+        """Transaction domain type handles missing origin_address."""
+        from backend.domain.types import Transaction, TransactionType
+        from backend.database_handler.models import TransactionStatus
+
+        tx = Transaction(
+            hash="0x123",
+            status=TransactionStatus.PENDING,
+            type=TransactionType.RUN_CONTRACT,
+            from_address=EOA,
+            to_address=CONTRACT_A,
+            origin_address=None,
+        )
+        assert tx.origin_address is None
+
+        # to_dict includes it
+        d = tx.to_dict()
+        assert "origin_address" in d
+        assert d["origin_address"] is None
+
+    def test_from_dict_without_origin(self):
+        """from_dict handles missing origin_address (old data)."""
+        from backend.domain.types import Transaction, TransactionType
+        from backend.database_handler.models import TransactionStatus
+
+        data = {
+            "hash": "0x123",
+            "status": TransactionStatus.PENDING.value,
+            "type": TransactionType.RUN_CONTRACT.value,
+            "from_address": EOA,
+            "to_address": CONTRACT_A,
+        }
+        tx = Transaction.from_dict(data)
+        assert tx.origin_address is None


### PR DESCRIPTION
## Summary
- **Fixes #751** — `origin_address` was hardcoded to `sender_address` in GenVM messages, so contracts in sub-call chains (EOA→A→B) couldn't distinguish the original sender from the immediate caller
- Adds `origin_address` column to transactions table (nullable, non-blocking `ADD COLUMN`)
- Propagates origin from parent transaction through `_emit_messages()` so sub-calls inherit the root EOA
- Threads `origin_address` through `Node.exec_transaction` → `deploy_contract`/`run_contract`/`get_contract_data` → `_run_genvm()`
- `gen_call` now accepts optional `origin_address` param for simulating calls with arbitrary origin
- Includes batched backfill script (`backfill_origin_address.py`) for existing data — run post-deploy, idempotent

## Deployment notes
1. Schema migration runs automatically (non-blocking `ADD COLUMN ... NULL`)
2. Code handles `NULL` gracefully (falls back to `from_address`)
3. Run backfill script after deploy: `python -m backend.database_handler.migration.backfill_origin_address`

## Test plan
- [x] DB/SQLAlchemy tests pass (118 passed)
- [x] Regression tests for origin tracking: top-level default, sub-call propagation, deep chain, explicit override, null fallback
- [ ] CI green