### PR TITLE
fix: remove --no-cache flag from docker setup

### DIFF
--- a/.claude/skills/setup/SKILL.md
+++ b/.claude/skills/setup/SKILL.md
@@ -101,6 +101,6 @@ docker compose down -v && docker compose up -d
 docker compose logs backend
 
 # Rebuild containers
-docker compose build --no-cache
+docker compose build
 docker compose up -d
 ```


### PR DESCRIPTION
## Summary
Removes the `--no-cache` flag from the docker compose build command in the setup skill file. Using Docker's default layer caching speeds up rebuilds significantly.

## Changes
- Removed `--no-cache` flag from `docker compose build` command in `.claude/skills/setup/SKILL.md`
- The `apk add --no-cache` and `pip install --no-cache-dir` flags in Dockerfiles are intentionally kept as they are Alpine/pip best practices for smaller image layers (not related to Docker build cache)

## Related Issue
Closes #469

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Docker rebuild command in troubleshooting guidance by removing the `--no-cache` flag, simplifying the command while maintaining the deployment workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->