### PR TITLE
fix: replace bare except blocks with specific exception types

### DIFF
--- a/backend/consensus/worker_service.py
+++ b/backend/consensus/worker_service.py
@@ -494,7 +494,7 @@ def health_check():
             "cpu_percent": round(process.cpu_percent(), 2),
             "memory_percent": round(process.memory_percent(), 2),
         }
-    except:
+    except (psutil.Error, OSError):
         pass
 
     # Probe local GenVM manager responsiveness.

--- a/backend/database_handler/migration/versions/02aa0c34a463_validator_config_string_to_jsonb.py
+++ b/backend/database_handler/migration/versions/02aa0c34a463_validator_config_string_to_jsonb.py
@@ -31,7 +31,7 @@ def upgrade() -> None:
         if isinstance(value, str):
             try:
                 return json.loads(value)
-            except:
+            except (json.JSONDecodeError, TypeError):
                 print(f"Failed to parse JSON: {value}. Removing configuration.")
                 return {}
         print(f"Unexpected type: {type(value)}. Removing configuration.")

--- a/backend/database_handler/transactions_processor.py
+++ b/backend/database_handler/transactions_processor.py
@@ -900,7 +900,7 @@ class TransactionsProcessor:
         # Normalize address to checksum format
         try:
             checksum_address = self.web3.to_checksum_address(address)
-        except:
+        except (ValueError, TypeError):
             checksum_address = address
 
         # Always use database count as source of truth

--- a/backend/node/create_nodes/providers.py
+++ b/backend/node/create_nodes/providers.py
@@ -23,7 +23,7 @@ def is_ollama_available() -> bool:
         result = sock.connect_ex(("ollama", int(os.getenv("OLAMAPORT", "11434"))))
         sock.close()
         return result == 0
-    except:
+    except (OSError, ValueError):
         return False
 
 

--- a/backend/protocol_rpc/fastapi_endpoint_generator.py
+++ b/backend/protocol_rpc/fastapi_endpoint_generator.py
@@ -315,7 +315,7 @@ class FastAPIEndpointRegistry:
             if db and hasattr(db, "rollback"):
                 try:
                     db.rollback()
-                except:
+                except Exception:
                     pass  # Ignore rollback errors
 
             raise


### PR DESCRIPTION
## Summary
Replaces all bare \except:\ blocks in the backend with specific exception types to prevent silently swallowing unexpected errors like \KeyboardInterrupt\, \SystemExit\, or \MemoryError\.

## Changes
| File | Before | After | Rationale |
|------|--------|-------|-----------|
| \consensus/worker_service.py\ | \except:\ | \except (psutil.Error, OSError):\ | Only process metric collection errors should be ignored |
| \database_handler/transactions_processor.py\ | \except:\ | \except (ValueError, TypeError):\ | Address checksum conversion only fails on invalid input |
| \
ode/create_nodes/providers.py\ | \except:\ | \except (OSError, ValueError):\ | Socket/port errors are the expected failures |
| \protocol_rpc/fastapi_endpoint_generator.py\ | \except:\ | \except Exception:\ | Rollback cleanup should not propagate but should not catch \BaseException\ |
| \migration/02aa0c34a463_*.py\ | \except:\ | \except (json.JSONDecodeError, TypeError):\ | JSON parsing has specific failure modes |

## Related Issue
Contributes to #313

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved exception handling across backend services to catch only specific error types rather than suppressing all exceptions, enhancing error visibility and system reliability while preventing unexpected failures from being masked during operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->