### PR TITLE
fix: allow CI to pass for fork PRs

### DIFF
--- a/.github/workflows/frontend-unit-tests.yml
+++ b/.github/workflows/frontend-unit-tests.yml
@@ -4,7 +4,7 @@ on:
   workflow_call:
     secrets:
       codecov_token:
-        required: true
+        required: false
 
 jobs:
   frontend:
@@ -32,5 +32,5 @@ jobs:
         with:
           verbose: true
           token: ${{ secrets.codecov_token }}
-          fail_ci_if_error: true
+          fail_ci_if_error: false
           directory: frontend/coverage

--- a/.github/workflows/unit-tests-pr.yml
+++ b/.github/workflows/unit-tests-pr.yml
@@ -34,6 +34,7 @@ jobs:
       - run: pip install pytest-cov pytest-xdist
       - run: pytest tests/unit --cov=backend --cov-report=xml --cov-branch -n auto
       - name: SonarCloud Scan
+        if: github.event.pull_request.head.repo.full_name == github.repository || github.event_name == 'push'
         uses: sonarsource/sonarqube-scan-action@v7.0.0
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}


### PR DESCRIPTION
## Summary
- Make Codecov token optional and upload non-blocking for fork PRs (no access to repo secrets)
- Skip SonarCloud scan for fork PRs (requires `SONAR_TOKEN`, no workaround)
- Internal PRs and pushes to main are unaffected

## Context
All 5 recent external PRs from contributors show CI failures despite tests passing, because post-test steps (Codecov, SonarCloud) require repo secrets that forks don't have access to.

## Test plan
- [ ] Verify internal PR still runs Codecov + SonarCloud
- [ ] Verify fork PR CI passes when tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Made codecov token optional for workflow calls, allowing callers to skip code coverage uploads if needed
  * Updated codecov step to not fail CI when coverage upload encounters errors
  * Added security check to SonarCloud scan, restricting execution to pull requests from the same repository and push events

<!-- end of auto-generated comment: release notes by coderabbit.ai -->