### PR TITLE
fix: cap GenVM hard-crash retries at 3, finalize with error receipt

### DIFF
--- a/backend/consensus/base.py
+++ b/backend/consensus/base.py
@@ -21,6 +21,7 @@ from backend.consensus.vrf import get_validators_for_transaction
 from backend.database_handler.chain_snapshot import ChainSnapshot
 from backend.database_handler.contract_snapshot import ContractSnapshot
 from backend.database_handler.contract_processor import ContractProcessor
+from backend.database_handler.errors import ContractNotFoundError
 from backend.database_handler.transactions_processor import (
     TransactionsProcessor,
     TransactionStatus,
@@ -462,9 +463,12 @@ class TransactionContext:
                     fresh = self.contract_snapshot_factory(self.transaction.to_address)
                     self.contract_snapshot.balance = fresh.balance
             else:
-                self.contract_snapshot = self.contract_snapshot_factory(
-                    self.transaction.to_address
-                )
+                try:
+                    self.contract_snapshot = self.contract_snapshot_factory(
+                        self.transaction.to_address
+                    )
+                except ContractNotFoundError:
+                    self.contract_snapshot = None
 
         self.validators_snapshot = validators_snapshot
 

--- a/backend/consensus/worker.py
+++ b/backend/consensus/worker.py
@@ -34,6 +34,7 @@ class ConsensusWorker:
     """
 
     MAX_GENERIC_ERROR_RETRIES = 3
+    MAX_LEADER_CRASH_RETRIES = 3
 
     def __init__(
         self,
@@ -123,6 +124,17 @@ class ConsensusWorker:
         self._generic_error_retries: dict[str, dict] = {}
         self._generic_error_base_backoff = float(
             os.environ.get("GENERIC_ERROR_BASE_BACKOFF_SECONDS", "10")
+        )
+
+        # Track retry counts for transactions hitting non-classifiable GenVM crashes
+        # (WASM host-side traps before Lua can produce a structured error).
+        # Counter is in-memory; survives the lifetime of one worker pod only.
+        # Key: transaction_hash, Value: {"count": int, "last_attempt": float}
+        self._leader_crash_retries: dict[str, dict] = {}
+        self._max_leader_crash_retries = int(
+            os.environ.get(
+                "LEADER_CRASH_MAX_RETRIES", str(self.MAX_LEADER_CRASH_RETRIES)
+            )
         )
 
         # Initialize usage metrics service for reporting transaction metrics
@@ -647,24 +659,40 @@ class ConsensusWorker:
                     f"consensus will continue with remaining validators"
                 )
             else:
-                # Leader error (or unknown) - reset transaction for reprocessing
-                try:
-                    with self.get_session() as reset_session:
-                        self.reset_transaction(reset_session, tx_hash)
-                        transaction_reset = True
-                except Exception as reset_error:
-                    logger.error(
-                        f"[Worker {self.worker_id}] Failed to reset {tx_type} {tx_hash}: {reset_error}",
-                        exc_info=True,
-                    )
+                # Leader error (or unknown origin).
+                # First, cap retries for the non-classifiable "hard crash" class
+                # (code=None + causes=[] with is_fatal=False): these are deterministic
+                # WASM host-side traps that repeat indefinitely on the same input,
+                # generating thousands of identical Sentry events. Finalize with an
+                # error receipt instead, mirroring contract-raised-exception flow.
+                is_hard_crash = e.error_code is None and not e.causes and not e.is_fatal
+                cap_hit = False
+                if is_hard_crash:
+                    cap_hit = await self._handle_leader_crash_retry(tx_hash, tx_type, e)
 
-                # For fatal leader errors, stop the worker to trigger K8s restart via health check
-                if e.is_fatal:
-                    logger.warning(
-                        f"[Worker {self.worker_id}] Fatal GenVM error in leader - stopping worker. "
-                        f"{tx_type.capitalize()} {tx_hash} will be reset for another worker."
-                    )
-                    self.running = False
+                if cap_hit:
+                    # Transaction finalized with synthetic error receipt by the
+                    # helper above. Don't release/reset — it's in ACCEPTED now.
+                    transaction_reset = True
+                else:
+                    # Retryable leader error — reset for another worker to pick up.
+                    try:
+                        with self.get_session() as reset_session:
+                            self.reset_transaction(reset_session, tx_hash)
+                            transaction_reset = True
+                    except Exception as reset_error:
+                        logger.error(
+                            f"[Worker {self.worker_id}] Failed to reset {tx_type} {tx_hash}: {reset_error}",
+                            exc_info=True,
+                        )
+
+                    # For fatal leader errors, stop the worker to trigger K8s restart via health check
+                    if e.is_fatal:
+                        logger.warning(
+                            f"[Worker {self.worker_id}] Fatal GenVM error in leader - stopping worker. "
+                            f"{tx_type.capitalize()} {tx_hash} will be reset for another worker."
+                        )
+                        self.running = False
         except (ContractNotFoundError, _NoValidatorsError):
             # Re-raise for specific handling by caller
             raise
@@ -855,6 +883,8 @@ class ConsensusWorker:
                     del self._no_validators_retries[transaction.hash]
                 if transaction.hash in self._generic_error_retries:
                     del self._generic_error_retries[transaction.hash]
+                if transaction.hash in self._leader_crash_retries:
+                    del self._leader_crash_retries[transaction.hash]
 
         except NoValidatorsAvailableError:
             # Handle no-validators case with retry logic and backoff
@@ -1039,6 +1069,98 @@ class ConsensusWorker:
                 f"retry {retry_info['count']}/{self.MAX_GENERIC_ERROR_RETRIES}, "
                 f"next attempt in {backoff}s - error: {error}"
             )
+
+    async def _handle_leader_crash_retry(
+        self, tx_hash: str, tx_type: str, error: GenVMInternalError
+    ) -> bool:
+        """
+        Cap retries on non-classifiable GenVM leader crashes (WASM traps that
+        produce no structured error code). Past the cap, finalize the transaction
+        with a synthetic error receipt so it reaches a terminal FINALIZED state
+        with execution_result=ERROR — same observable outcome as a contract that
+        raised an exception.
+
+        Returns:
+            True if the cap was hit and the transaction was finalized with an
+            error receipt. Caller must NOT reset/release the transaction.
+            False if the caller should fall back to the existing reset-retry path.
+        """
+        retry_info = self._leader_crash_retries.get(
+            tx_hash, {"count": 0, "last_attempt": 0}
+        )
+        retry_info["count"] += 1
+        retry_info["last_attempt"] = time.time()
+        self._leader_crash_retries[tx_hash] = retry_info
+
+        if retry_info["count"] < self._max_leader_crash_retries:
+            logger.warning(
+                f"[Worker {self.worker_id}] GenVM hard crash on {tx_type} {tx_hash}, "
+                f"retry {retry_info['count']}/{self._max_leader_crash_retries}"
+            )
+            return False
+
+        # Cap reached — synthesize a leader error receipt and push the tx to
+        # ACCEPTED. From there the normal finalization path handles it.
+        import base64
+        from backend.node.types import ExecutionMode, ExecutionResultStatus
+
+        detail_str = str(error.detail) if error.detail is not None else ""
+        if len(detail_str) > 2000:
+            detail_str = detail_str[:2000] + "...(truncated)"
+        error_description = (
+            f"GenVM crashed {retry_info['count']} times with a non-classifiable "
+            f"internal error (no structured cause). Detail: {detail_str}"
+        )
+        error_payload = error_description.encode("utf-8")
+        error_receipt = {
+            "vote": None,
+            "execution_result": ExecutionResultStatus.ERROR.value,
+            "result": base64.b64encode(error_payload).decode("ascii"),
+            "calldata": base64.b64encode(b"").decode("ascii"),
+            "gas_used": 0,
+            "mode": ExecutionMode.LEADER.value,
+            "contract_state": {},
+            "node_config": {"address": "genvm_crash_handler"},
+            "eq_outputs": {},
+            "pending_transactions": [],
+            "genvm_result": {
+                "error_code": "INTERNAL_ERROR",
+                "error_description": error_description,
+                "raw_error": {
+                    "causes": error.causes,
+                    "ctx": error.ctx,
+                    "detail": detail_str,
+                },
+            },
+            "processing_time": 0,
+        }
+
+        logger.error(
+            f"[Worker {self.worker_id}] Transaction {tx_hash} finalizing with "
+            f"synthetic ERROR receipt after {retry_info['count']} leader crashes"
+        )
+
+        with self.get_session() as error_session:
+            tx = error_session.query(Transactions).filter_by(hash=tx_hash).one()
+            tx.status = TransactionStatus.ACCEPTED
+            tx.timestamp_awaiting_finalization = int(time.time())
+            tx.consensus_data = {
+                "votes": {},
+                "leader_receipt": [error_receipt],
+                "validators": [],
+            }
+            error_session.commit()
+
+            await ConsensusAlgorithm.dispatch_transaction_status_update(
+                TransactionsProcessor(error_session),
+                tx_hash,
+                TransactionStatus.ACCEPTED,
+                self.msg_handler,
+            )
+
+        # Clean up retry tracking
+        del self._leader_crash_retries[tx_hash]
+        return True
 
     async def _process_upgrade_transaction(
         self, transaction_data: dict, session: Session

--- a/tests/integration/accounts/test_accounts.py
+++ b/tests/integration/accounts/test_accounts.py
@@ -45,7 +45,7 @@ def test_accounts_funding():
         payload("eth_getBalance", new_account_address)
     ).json()
     assert has_success_status(get_balance_after_fund_result)
-    assert get_balance_after_fund_result["result"] == fund_amount
+    assert int(get_balance_after_fund_result["result"], 16) == fund_amount
 
     # TODO: this is not working on CI https://github.com/yeagerai/genlayer-simulator/issues/548
     # Test get_balance with invalid address
@@ -85,13 +85,15 @@ def test_accounts_transfers():
         payload("eth_getBalance", account_1_address)
     ).json()
     assert has_success_status(get_balance_1_after_transfer)
-    assert get_balance_1_after_transfer["result"] == fund_amount - transfer_amount
+    assert (
+        int(get_balance_1_after_transfer["result"], 16) == fund_amount - transfer_amount
+    )
 
     get_balance_2_after_transfer = post_request_localhost(
         payload("eth_getBalance", account_2_address)
     ).json()
     assert has_success_status(get_balance_2_after_transfer)
-    assert get_balance_2_after_transfer["result"] == transfer_amount
+    assert int(get_balance_2_after_transfer["result"], 16) == transfer_amount
 
 
 def test_accounts_burn():
@@ -115,4 +117,4 @@ def test_accounts_burn():
         payload("eth_getBalance", account_1_address)
     ).json()
     assert has_success_status(get_balance_1_after_transfer)
-    assert get_balance_1_after_transfer["result"] == fund_amount - burn_amount
+    assert int(get_balance_1_after_transfer["result"], 16) == fund_amount - burn_amount

--- a/tests/integration/icontracts/contracts/payable_escrow.py
+++ b/tests/integration/icontracts/contracts/payable_escrow.py
@@ -21,14 +21,14 @@ class PayableEscrow(gl.Contract):
         self.deposited = self.deposited + v
 
     @gl.public.write
-    def withdraw(self, to: Address) -> None:
+    def withdraw(self, to: str) -> None:
         if gl.message.sender_address != self.depositor:
             raise gl.vm.UserError("not depositor")
         amount = self.deposited
         if amount == u256(0):
             raise gl.vm.UserError("nothing to withdraw")
         self.deposited = u256(0)
-        gl.get_contract_at(to).emit_transfer(value=amount)
+        gl.get_contract_at(Address(to)).emit_transfer(value=amount)
 
     @gl.public.view
     def get_deposited(self) -> u256:

--- a/tests/unit/test_worker_leader_crash_retry.py
+++ b/tests/unit/test_worker_leader_crash_retry.py
@@ -1,0 +1,270 @@
+"""
+Tests for leader-crash retry cap in the consensus worker.
+
+When GenVM produces a non-classifiable internal error (code=None, causes=[],
+is_fatal=False) during leader execution, the worker caps retries and then
+finalizes the transaction with a synthetic ERROR leader receipt rather than
+looping forever. This mirrors the behavior for contract-raised exceptions:
+tx reaches a terminal state with execution_result=ERROR visible to the user.
+"""
+
+import pytest
+from unittest.mock import MagicMock, patch, AsyncMock
+from sqlalchemy.orm import Session
+
+from backend.database_handler.models import TransactionStatus
+from backend.node.genvm.error_codes import GenVMInternalError
+
+
+def _make_worker():
+    from backend.consensus.worker import ConsensusWorker
+
+    def get_session_side_effect():
+        ctx = MagicMock()
+        inner = MagicMock(spec=Session)
+        inner.commit = MagicMock()
+        tx_row = MagicMock()
+        tx_row.status = TransactionStatus.PROPOSING
+        tx_row.consensus_data = None
+        tx_row.timestamp_awaiting_finalization = None
+        inner.query.return_value.filter_by.return_value.one.return_value = tx_row
+        ctx.__enter__ = MagicMock(return_value=inner)
+        ctx.__exit__ = MagicMock(return_value=None)
+        return ctx
+
+    worker = ConsensusWorker(
+        get_session=get_session_side_effect,
+        msg_handler=MagicMock(),
+        consensus_service=MagicMock(),
+        validators_manager=MagicMock(),
+        genvm_manager=MagicMock(),
+        worker_id="test-worker",
+    )
+    # Deterministic cap regardless of env
+    worker._max_leader_crash_retries = 3
+    return worker
+
+
+def _hard_crash_error(detail="Fingerprint {...}"):
+    return GenVMInternalError(
+        message="GenVM internal error",
+        error_code=None,
+        causes=[],
+        is_fatal=False,
+        is_leader=True,
+        ctx=None,
+        detail=detail,
+    )
+
+
+class TestLeaderCrashRetryCap:
+    @pytest.mark.asyncio
+    async def test_under_cap_returns_false(self):
+        """First two hard crashes are retryable — helper returns False."""
+        worker = _make_worker()
+        tx_hash = "0xpoisoned"
+
+        with patch(
+            "backend.consensus.base.ConsensusAlgorithm.dispatch_transaction_status_update",
+            new_callable=AsyncMock,
+        ) as mock_dispatch:
+            assert (
+                await worker._handle_leader_crash_retry(
+                    tx_hash, "transaction", _hard_crash_error()
+                )
+                is False
+            )
+            assert (
+                await worker._handle_leader_crash_retry(
+                    tx_hash, "transaction", _hard_crash_error()
+                )
+                is False
+            )
+
+        assert worker._leader_crash_retries[tx_hash]["count"] == 2
+        mock_dispatch.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_at_cap_finalizes_with_error_receipt(self):
+        """Nth crash synthesizes a leader ERROR receipt and dispatches ACCEPTED."""
+        worker = _make_worker()
+        tx_hash = "0xpoisoned"
+
+        with patch(
+            "backend.consensus.base.ConsensusAlgorithm.dispatch_transaction_status_update",
+            new_callable=AsyncMock,
+        ) as mock_dispatch:
+            # two under-cap calls
+            await worker._handle_leader_crash_retry(
+                tx_hash, "transaction", _hard_crash_error()
+            )
+            await worker._handle_leader_crash_retry(
+                tx_hash, "transaction", _hard_crash_error()
+            )
+            # third call hits the cap
+            result = await worker._handle_leader_crash_retry(
+                tx_hash,
+                "transaction",
+                _hard_crash_error(detail="wasm trap at py_gl_call"),
+            )
+
+        assert result is True
+        # Counter cleaned up
+        assert tx_hash not in worker._leader_crash_retries
+
+        # Dispatch called once with ACCEPTED for this tx hash
+        mock_dispatch.assert_called_once()
+        args = mock_dispatch.call_args.args
+        assert args[1] == tx_hash
+        assert args[2] == TransactionStatus.ACCEPTED
+
+    @pytest.mark.asyncio
+    async def test_synthetic_receipt_shape(self):
+        """The synthetic receipt carries execution_result=ERROR + INTERNAL_ERROR code."""
+        worker = _make_worker()
+        tx_hash = "0xpoisoned"
+
+        # Capture the tx row the worker writes to
+        tx_row = MagicMock()
+        tx_row.status = TransactionStatus.PROPOSING
+        tx_row.consensus_data = None
+
+        def get_session_side_effect():
+            ctx = MagicMock()
+            inner = MagicMock(spec=Session)
+            inner.commit = MagicMock()
+            inner.query.return_value.filter_by.return_value.one.return_value = tx_row
+            ctx.__enter__ = MagicMock(return_value=inner)
+            ctx.__exit__ = MagicMock(return_value=None)
+            return ctx
+
+        worker.get_session = get_session_side_effect
+
+        with patch(
+            "backend.consensus.base.ConsensusAlgorithm.dispatch_transaction_status_update",
+            new_callable=AsyncMock,
+        ):
+            for _ in range(3):
+                await worker._handle_leader_crash_retry(
+                    tx_hash, "transaction", _hard_crash_error(detail="trap-detail")
+                )
+
+        # Status pushed to ACCEPTED, consensus_data carries the synthetic receipt
+        assert tx_row.status == TransactionStatus.ACCEPTED
+        cd = tx_row.consensus_data
+        assert cd["votes"] == {}
+        assert cd["validators"] == []
+        assert len(cd["leader_receipt"]) == 1
+        receipt = cd["leader_receipt"][0]
+        assert receipt["execution_result"] == "ERROR"
+        assert receipt["genvm_result"]["error_code"] == "INTERNAL_ERROR"
+        assert "GenVM crashed" in receipt["genvm_result"]["error_description"]
+        assert "trap-detail" in receipt["genvm_result"]["error_description"]
+        assert receipt["node_config"]["address"] == "genvm_crash_handler"
+
+    @pytest.mark.asyncio
+    async def test_per_tx_counter_isolation(self):
+        """Two different tx hashes get independent counters."""
+        worker = _make_worker()
+
+        with patch(
+            "backend.consensus.base.ConsensusAlgorithm.dispatch_transaction_status_update",
+            new_callable=AsyncMock,
+        ):
+            for _ in range(2):
+                await worker._handle_leader_crash_retry(
+                    "0xaaa", "transaction", _hard_crash_error()
+                )
+            # 0xbbb is fresh
+            assert (
+                await worker._handle_leader_crash_retry(
+                    "0xbbb", "transaction", _hard_crash_error()
+                )
+                is False
+            )
+
+        assert worker._leader_crash_retries["0xaaa"]["count"] == 2
+        assert worker._leader_crash_retries["0xbbb"]["count"] == 1
+
+    @pytest.mark.asyncio
+    async def test_detail_is_truncated(self):
+        """Very long detail strings are truncated in the error_description."""
+        worker = _make_worker()
+        tx_row = MagicMock()
+
+        def get_session_side_effect():
+            ctx = MagicMock()
+            inner = MagicMock(spec=Session)
+            inner.commit = MagicMock()
+            inner.query.return_value.filter_by.return_value.one.return_value = tx_row
+            ctx.__enter__ = MagicMock(return_value=inner)
+            ctx.__exit__ = MagicMock(return_value=None)
+            return ctx
+
+        worker.get_session = get_session_side_effect
+
+        long_detail = "X" * 5000
+
+        with patch(
+            "backend.consensus.base.ConsensusAlgorithm.dispatch_transaction_status_update",
+            new_callable=AsyncMock,
+        ):
+            for _ in range(3):
+                await worker._handle_leader_crash_retry(
+                    "0xlong", "transaction", _hard_crash_error(detail=long_detail)
+                )
+
+        desc = tx_row.consensus_data["leader_receipt"][0]["genvm_result"][
+            "error_description"
+        ]
+        assert "truncated" in desc
+        # Bound the raw-detail portion (not the whole description which has a prefix)
+        assert len(desc) < 5000
+
+
+class TestHardCrashClassification:
+    """The retry cap must only trigger for the non-classifiable crash class,
+    not for structured errors like LLM_NO_PROVIDER (those should keep retrying)."""
+
+    @pytest.mark.asyncio
+    async def test_structured_error_bypasses_helper(self):
+        """LLM_NO_PROVIDER has a code and causes → should NOT hit the cap helper."""
+        worker = _make_worker()
+
+        structured = GenVMInternalError(
+            message="no provider",
+            error_code="LLM_NO_PROVIDER",
+            causes=["NO_PROVIDER_FOR_PROMPT"],
+            is_fatal=False,
+            is_leader=True,
+        )
+
+        # Classification check mirrors the one in the except block in worker.py
+        is_hard_crash = (
+            structured.error_code is None
+            and not structured.causes
+            and not structured.is_fatal
+        )
+        assert is_hard_crash is False
+
+        # Also: the counter should stay empty if we only ever route hard crashes
+        assert worker._leader_crash_retries == {}
+
+    @pytest.mark.asyncio
+    async def test_fatal_error_bypasses_helper(self):
+        """Fatal errors should go through the stop-worker path, not the cap."""
+        worker = _make_worker()
+
+        fatal = GenVMInternalError(
+            message="fatal crash",
+            error_code=None,
+            causes=[],
+            is_fatal=True,
+            is_leader=True,
+        )
+
+        is_hard_crash = (
+            fatal.error_code is None and not fatal.causes and not fatal.is_fatal
+        )
+        assert is_hard_crash is False
+        assert worker._leader_crash_retries == {}


### PR DESCRIPTION
## Summary
- After 3 consecutive `GenVMInternalError` with `code=None + causes=[]` (non-classifiable WASM host-side traps) on the same tx, stop retrying.
- Synthesize a leader receipt with `execution_result=ERROR`, `error_code=INTERNAL_ERROR`, carrying the crash fingerprint detail.
- Tx flows through normal finalization → FINALIZED with error outcome visible in explorer.
- One poisoned tx (`0x451098…`) generated **~6,500 identical Sentry events** over 4 weeks. This fix caps that at 3.

## Scope
- Only `GenVMInternalError` with `code=None + causes=[] + is_fatal=False` — the deterministic "hard crash" class.
- LLM errors (`NO_PROVIDER`, rate limits), fatal errors, and validator-side errors are **unchanged**.
- Counter is in-memory per worker pod (matches existing `_generic_error_retries` pattern).
- Configurable via `LEADER_CRASH_MAX_RETRIES` env var (default 3).

## Test plan
- [x] 7 new unit tests pass (under-cap, at-cap, receipt shape, per-tx isolation, truncation, classification).
- [x] 76 existing related tests still pass.
- [ ] CI green.
- [ ] After deploy: Sentry `GENLAYER-STUDIO-11X` rate should drop to max 3 events per poisoned tx.

Refs: Sentry `GENLAYER-STUDIO-11X`, [genvm#288](https://github.com/genlayerlabs/genvm/issues/288)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved consensus resilience: leader-failure retries capped (3 attempts) and transactions finalized with an error receipt when cap reached; normal fatal errors still stop processing.
* **Tests**
  * Added unit tests covering leader-crash retry behavior, counter isolation, status dispatch, and truncation of long error details.
* **Integration**
  * Updated account balance assertions to parse hex API responses.
* **Tests (contracts)**
  * Adjusted test contract withdrawal parameter typing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->