### PR TITLE
fix: use Alembic autocommit_block for CONCURRENTLY index migration

### DIFF
--- a/backend/database_handler/migration/versions/e1f2a3b4c5d6_add_explorer_query_indexes.py
+++ b/backend/database_handler/migration/versions/e1f2a3b4c5d6_add_explorer_query_indexes.py
@@ -19,54 +19,63 @@ depends_on: Union[str, Sequence[str], None] = None
 
 
 def upgrade() -> None:
-    # Exit the implicit transaction so CREATE INDEX CONCURRENTLY can run.
-    # CONCURRENTLY builds indexes without blocking concurrent writes,
-    # which is critical for the transactions table (consensus workers
-    # update it continuously).
-    connection = op.get_bind()
-    connection.execution_options(isolation_level="AUTOCOMMIT")
+    # CREATE INDEX CONCURRENTLY cannot run inside a transaction block.
+    # Each index gets its own autocommit block so the builds run without
+    # blocking concurrent writes — critical for the transactions table
+    # (consensus workers update it continuously).
 
     # Index for GROUP BY status (used by /api/explorer/stats and /stats/counts)
     # Fixes GENLAYER-STUDIO-1SN (1259 events)
-    op.execute(
-        """
-        CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_transactions_status
-        ON transactions (status)
-        """
-    )
+    with op.get_context().autocommit_block():
+        op.execute(
+            """
+            CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_transactions_status
+            ON transactions (status)
+            """
+        )
 
     # Index for GROUP BY triggered_by_hash (used by /api/explorer/transactions batch fetch)
     # Fixes GENLAYER-STUDIO-1W8 (25 events)
-    op.execute(
-        """
-        CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_transactions_triggered_by_hash
-        ON transactions (triggered_by_hash)
-        WHERE triggered_by_hash IS NOT NULL
-        """
-    )
+    with op.get_context().autocommit_block():
+        op.execute(
+            """
+            CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_transactions_triggered_by_hash
+            ON transactions (triggered_by_hash)
+            WHERE triggered_by_hash IS NOT NULL
+            """
+        )
 
     # Index for WHERE type = 1 count (deploy count in /api/explorer/stats)
     # Part of GENLAYER-STUDIO-102 (196 events)
-    op.execute(
-        """
-        CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_transactions_type
-        ON transactions (type)
-        """
-    )
+    with op.get_context().autocommit_block():
+        op.execute(
+            """
+            CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_transactions_type
+            ON transactions (type)
+            """
+        )
 
     # Index for WHERE appealed = true count
     # Part of GENLAYER-STUDIO-102 (196 events)
-    op.execute(
-        """
-        CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_transactions_appealed
-        ON transactions (appealed)
-        WHERE appealed = true
-        """
-    )
+    with op.get_context().autocommit_block():
+        op.execute(
+            """
+            CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_transactions_appealed
+            ON transactions (appealed)
+            WHERE appealed = true
+            """
+        )
 
 
 def downgrade() -> None:
-    op.execute("DROP INDEX IF EXISTS idx_transactions_appealed")
-    op.execute("DROP INDEX IF EXISTS idx_transactions_type")
-    op.execute("DROP INDEX IF EXISTS idx_transactions_triggered_by_hash")
-    op.execute("DROP INDEX IF EXISTS idx_transactions_status")
+    # DROP INDEX CONCURRENTLY for symmetry (no write lock on downgrade)
+    with op.get_context().autocommit_block():
+        op.execute("DROP INDEX CONCURRENTLY IF EXISTS idx_transactions_appealed")
+    with op.get_context().autocommit_block():
+        op.execute("DROP INDEX CONCURRENTLY IF EXISTS idx_transactions_type")
+    with op.get_context().autocommit_block():
+        op.execute(
+            "DROP INDEX CONCURRENTLY IF EXISTS idx_transactions_triggered_by_hash"
+        )
+    with op.get_context().autocommit_block():
+        op.execute("DROP INDEX CONCURRENTLY IF EXISTS idx_transactions_status")


### PR DESCRIPTION
## Summary
The migration added in #1597 (e1f2a3b4c5d6) fails on apply because it tries to change the connection's isolation level to AUTOCOMMIT inside Alembic's implicit transaction. SQLAlchemy rejects this:

\`\`\`
sqlalchemy.exc.InvalidRequestError: This connection has already initialized a SQLAlchemy Transaction() object via begin() or autobegin; isolation_level may not be altered unless rollback() or commit() is called first.
\`\`\`

This broke the release pipeline — \`database-migration\` Job failed on studio-dev, blocking the release-lane's dev-verification gate, which in turn blocked prd promotion.

## Fix
Use \`op.get_context().autocommit_block()\` per index — the documented Alembic pattern for \`CREATE INDEX CONCURRENTLY\`.

## Verification
Ran manually against studio-dev with the fix:
- \`alembic_version\` advanced to \`e1f2a3b4c5d6\` ✓
- All 4 indexes created, all \`indisvalid = true\` ✓

## Test plan
- [x] Manual apply on studio-dev (done)
- [ ] CI db-integration-test passes
- [ ] Release pipeline dev-verification gate passes
- [ ] Prd promotion PR gets created and merged

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized database performance by adding indexes for explorer transaction queries, improving response times for status grouping, batch transaction fetching, deployment counting, and appeal tracking.
  * Streamlined CI/CD build process with updated caching mechanisms for faster pipeline execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->