### PR TITLE
test(db): run alembic upgrade head + add migration-integrity tests

### DIFF
--- a/tests/db-sqlalchemy/Dockerfile
+++ b/tests/db-sqlalchemy/Dockerfile
@@ -4,9 +4,14 @@ WORKDIR /app
 
 ENV TEST_PATH=tests/db-sqlalchemy
 
-COPY ${TEST_PATH}/requirements.txt .
+COPY ${TEST_PATH}/requirements.txt test-requirements.txt
 
-RUN pip install --no-cache-dir -r requirements.txt
+# Migrations import from backend.* (e.g. backend.node.create_nodes.providers),
+# so running `alembic upgrade head` needs the backend's own dependencies.
+# Install both so the test environment matches what prd actually runs.
+COPY backend/requirements.txt backend-requirements.txt
+
+RUN pip install --no-cache-dir -r test-requirements.txt -r backend-requirements.txt
 
 COPY ${TEST_PATH} .
 

--- a/tests/db-sqlalchemy/conftest.py
+++ b/tests/db-sqlalchemy/conftest.py
@@ -1,72 +1,125 @@
 import os
 from typing import Iterable
+from urllib.parse import urlparse
 
 import pytest
+from alembic import command
+from alembic.config import Config
 from sqlalchemy import Engine, create_engine, text
 from sqlalchemy.orm import Session, sessionmaker
 
-from backend.database_handler.models import Base
 from backend.database_handler.transactions_processor import TransactionsProcessor
 
-# import debugpy
+
+def _alembic_config(postgres_url: str) -> Config:
+    """Build an Alembic Config pointing at the real backend/alembic.ini.
+
+    env.py reads DBUSER/DBPASSWORD/DBHOST/DBPORT/DBNAME from the environment,
+    so parse the test Postgres URL and set those so Alembic connects to the
+    same database the tests use.
+    """
+    parsed = urlparse(postgres_url)
+    os.environ["DBUSER"] = parsed.username or "postgres"
+    os.environ["DBPASSWORD"] = parsed.password or ""
+    os.environ["DBHOST"] = parsed.hostname or "localhost"
+    os.environ["DBPORT"] = str(parsed.port or 5432)
+    db_name = (parsed.path or "/postgres").lstrip("/") or "postgres"
+    os.environ["DBNAME"] = db_name
+
+    # Walk up from this file looking for the backend/database_handler/alembic.ini.
+    # Local layout: tests/db-sqlalchemy/conftest.py → ../../backend/database_handler.
+    # Container layout (docker/db-sqlalchemy/Dockerfile): /app/conftest.py →
+    # /app/backend/database_handler. Both work with the same search.
+    search_dir = os.path.dirname(os.path.abspath(__file__))
+    ini_path = None
+    for _ in range(6):
+        candidate = os.path.join(
+            search_dir, "backend", "database_handler", "alembic.ini"
+        )
+        if os.path.isfile(candidate):
+            ini_path = candidate
+            break
+        parent = os.path.dirname(search_dir)
+        if parent == search_dir:
+            break
+        search_dir = parent
+    if ini_path is None:
+        raise RuntimeError(
+            "Could not locate backend/database_handler/alembic.ini relative "
+            f"to {__file__}"
+        )
+    cfg = Config(ini_path)
+    # script_location in alembic.ini is relative to the ini's dir; make absolute
+    cfg.set_main_option(
+        "script_location",
+        os.path.abspath(os.path.join(os.path.dirname(ini_path), "migration")),
+    )
+    return cfg
 
 
-@pytest.fixture
-def engine() -> Iterable[Engine]:
-    postgres_url = os.getenv("POSTGRES_URL")
+@pytest.fixture(scope="session")
+def migrated_engine() -> Iterable[Engine]:
+    """Session-wide engine whose schema is built via `alembic upgrade head`.
+
+    Runs the real migration chain against the test database — the same thing
+    production does at deploy time. Any migration bug (bad SQL, wrong Alembic
+    API, broken down_revision chain) fails the test suite instead of
+    surfacing at deploy.
+    """
+    postgres_url = os.environ["POSTGRES_URL"]
     engine = create_engine(
         postgres_url,
-        pool_pre_ping=True,  # Test connections before using them
-        pool_recycle=3600,  # Recycle connections after 1 hour
-        # echo=True # Uncomment this line to see the SQL queries
+        pool_pre_ping=True,
+        pool_recycle=3600,
     )
 
-    # Kill any existing connections to avoid locks
     with engine.connect() as conn:
         conn.execute(
             text(
                 """
-            SELECT pg_terminate_backend(pid)
-            FROM pg_stat_activity
-            WHERE datname = current_database()
-            AND pid <> pg_backend_pid()
-        """
+                SELECT pg_terminate_backend(pid)
+                FROM pg_stat_activity
+                WHERE datname = current_database() AND pid <> pg_backend_pid()
+                """
             )
         )
         conn.commit()
 
-    Base.metadata.create_all(engine)
+    # Start from a clean schema, then migrate end-to-end.
+    with engine.connect() as conn:
+        conn.execute(text("DROP SCHEMA IF EXISTS public CASCADE"))
+        conn.execute(text("CREATE SCHEMA public"))
+        conn.commit()
+
+    command.upgrade(_alembic_config(postgres_url), "head")
+
     yield engine
 
-    # Clean up: truncate instead of drop to avoid lock issues
-    with engine.connect() as conn:
-        # Disable foreign key checks temporarily
-        conn.execute(text("SET session_replication_role = 'replica';"))
+    engine.dispose()
 
-        # Get all tables except alembic_version
+
+@pytest.fixture
+def engine(migrated_engine: Engine) -> Iterable[Engine]:
+    """Per-test view of the migrated engine. Truncates data between tests
+    but keeps the migrated schema + alembic_version intact."""
+    yield migrated_engine
+
+    with migrated_engine.connect() as conn:
+        conn.execute(text("SET session_replication_role = 'replica';"))
         result = conn.execute(
             text(
                 """
-            SELECT tablename FROM pg_tables
-            WHERE schemaname = 'public'
-            AND tablename != 'alembic_version'
-        """
+                SELECT tablename FROM pg_tables
+                WHERE schemaname = 'public' AND tablename != 'alembic_version'
+                """
             )
         )
         tables = [row[0] for row in result]
-
-        # Truncate all tables and reset identity
         for table in tables:
             conn.execute(text(f"TRUNCATE TABLE {table} RESTART IDENTITY CASCADE;"))
-
-        # Reset the snapshot_id_seq sequence specifically
         conn.execute(text("ALTER SEQUENCE IF EXISTS snapshot_id_seq RESTART WITH 1;"))
-
-        # Re-enable foreign key checks
         conn.execute(text("SET session_replication_role = 'origin';"))
         conn.commit()
-
-    engine.dispose()
 
 
 @pytest.fixture

--- a/tests/db-sqlalchemy/requirements.txt
+++ b/tests/db-sqlalchemy/requirements.txt
@@ -1,10 +1,4 @@
-SQLAlchemy==2.0.40
-pytest==8.3.5
-pytest-asyncio==1.3.0
-psycopg2-binary==2.9.11
-debugpy==1.8.14
-requests==2.32.3
-numpy==1.26.4
-eth-account==0.13.6
-python-dotenv==1.1.0
-web3==7.10.0
+# All dependencies come from backend/requirements.txt, which is installed
+# alongside this file by the test Dockerfile. This file intentionally holds
+# only test-ONLY extras. Keep it empty unless there's a dep the backend
+# doesn't already pull in.

--- a/tests/db-sqlalchemy/test_migrations.py
+++ b/tests/db-sqlalchemy/test_migrations.py
@@ -1,0 +1,75 @@
+"""Migration-level integrity tests.
+
+The per-session `migrated_engine` fixture in conftest.py runs
+`alembic upgrade head` against the test database. That on its own would
+have caught the CONCURRENTLY-inside-transaction bug that slipped to prd
+on 2026-04-16.
+
+These tests add two explicit checks on top:
+- single migration head (no accidental branches from merge conflicts)
+- no schema drift between Base.metadata (ORM models) and the migrated schema
+"""
+
+import os
+
+import pytest
+from alembic.autogenerate import compare_metadata
+from alembic.migration import MigrationContext
+from alembic.script import ScriptDirectory
+from sqlalchemy import Engine
+
+from backend.database_handler.models import Base
+from conftest import _alembic_config
+
+
+def test_migrations_have_single_head(migrated_engine: Engine):
+    """Alembic migration chain must have exactly one head.
+
+    Multiple heads appear when two branches both add a migration pointing at
+    the same down_revision (typical merge-conflict outcome). Prd can't apply
+    such a chain without a manual `alembic merge`.
+    """
+    cfg = _alembic_config(os.environ["POSTGRES_URL"])
+    script = ScriptDirectory.from_config(cfg)
+    heads = script.get_heads()
+    assert len(heads) == 1, (
+        f"Migration chain has {len(heads)} heads: {heads}. "
+        "Run `alembic merge` to reconcile."
+    )
+
+
+def _is_benign_drift(diff_entry) -> bool:
+    """Filter out drift entries that are expected and safe.
+
+    Migrations routinely add performance indexes that aren't declared on the
+    ORM models (partial indexes for claim queries, hot-path indexes for the
+    explorer API, etc.). Those are intentional, not drift.
+    """
+    if not isinstance(diff_entry, tuple):
+        return False
+    action = diff_entry[0]
+    return action in ("add_index", "remove_index")
+
+
+def test_no_schema_drift_between_orm_and_migrations(migrated_engine: Engine):
+    """After running every migration, the database schema must match
+    `Base.metadata` (the ORM models).
+
+    If this fails, models.py has diverged from the migration chain. Either
+    a new migration was missed, or the models were edited without a
+    corresponding migration. Both cases would quietly ship a broken schema
+    to prd — this test catches it in CI.
+    """
+    with migrated_engine.connect() as conn:
+        mc = MigrationContext.configure(conn)
+        diff = compare_metadata(mc, Base.metadata)
+
+    significant = [d for d in diff if not _is_benign_drift(d)]
+    if significant:
+        pytest.fail(
+            "Schema drift between models.py and migrations:\n  - "
+            + "\n  - ".join(str(d) for d in significant)
+            + "\n\nEither generate a new migration (`alembic revision "
+            "--autogenerate`) or update models.py to match the intended "
+            "schema."
+        )


### PR DESCRIPTION
## Summary
Plugs the gap that let the CONCURRENTLY-in-transaction bug ship to prd in #1597.

The \`db-integration-test\` CI job previously built the schema via \`Base.metadata.create_all()\`, bypassing Alembic entirely. Any migration-level bug (bad SQL, wrong Alembic API, broken down_revision chain, multiple heads) was invisible to CI until deploy time.

## Changes
- **\`tests/db-sqlalchemy/conftest.py\`**: session-scoped \`migrated_engine\` fixture drops the schema and runs \`alembic upgrade head\`. Per-test \`engine\` fixture truncates data but keeps the migrated schema + \`alembic_version\`.
- **\`tests/db-sqlalchemy/test_migrations.py\`** (new):
  - \`test_migrations_have_single_head\` — catches accidental branches from merge conflicts
  - \`test_no_schema_drift_between_orm_and_migrations\` — compares \`Base.metadata\` to the migrated schema (filters out intentional index-only differences)
- **Dockerfile**: install \`backend/requirements.txt\` so migration files can import their runtime deps (jsonschema, etc.).
- **\`requirements.txt\`**: reduced to test-only extras.

## What would have been caught
The PR #1597 migration had \`connection.execution_options(isolation_level=\"AUTOCOMMIT\")\` inside Alembic's implicit transaction, which SQLAlchemy rejects. With this PR, the first \`pytest\` run would have failed with the same \`InvalidRequestError\` instead of the release-lane dev-verification gate catching it 2 hours later.

## Verified locally
- \`pytest test_migrations.py\`: 2 passed
- Full \`db-integration-test\` suite: **120 passed** (no regressions)
- Migration image build succeeds

## Test plan
- [ ] CI \`db-integration-test\` passes (will run against a real Postgres with \`alembic upgrade head\`)
- [ ] Confirm no existing tests broken

Refs: #1597, #1598