### PR TITLE
fix: cap recover_stuck_transactions cycles to prevent infinite re-stick

### DIFF
--- a/backend/consensus/worker.py
+++ b/backend/consensus/worker.py
@@ -35,6 +35,7 @@ class ConsensusWorker:
 
     MAX_GENERIC_ERROR_RETRIES = 3
     MAX_LEADER_CRASH_RETRIES = 3
+    MAX_RECOVERY_CYCLES = 3
 
     def __init__(
         self,
@@ -135,6 +136,13 @@ class ConsensusWorker:
             os.environ.get(
                 "LEADER_CRASH_MAX_RETRIES", str(self.MAX_LEADER_CRASH_RETRIES)
             )
+        )
+
+        # Cap on how many times recover_stuck_transactions will reset the
+        # same tx. Past this threshold, the tx is escalated to CANCELED so
+        # the per-contract queue can advance past a poisoned head.
+        self._max_recovery_cycles = int(
+            os.environ.get("RECOVERY_MAX_CYCLES", str(self.MAX_RECOVERY_CYCLES))
         )
 
         # Initialize usage metrics service for reporting transaction metrics
@@ -722,9 +730,60 @@ class ConsensusWorker:
         Resets them back to PENDING status and clears blocking fields.
         Also recovers orphaned transactions (in processing states but no worker).
 
+        Per-tx recovery_count is incremented on each reset. Once a tx hits
+        MAX_RECOVERY_CYCLES, it's escalated to CANCELED instead of another
+        reset — otherwise a deterministically-poisoned tx keeps getting
+        re-claimed and re-stuck, blocking the whole per-contract queue
+        for that address.
+
         Returns:
-            Number of transactions recovered
+            Number of transactions reset (escalations are logged but not
+            counted as recoveries).
         """
+        # Step 1: escalate txs that have already hit the recovery limit.
+        # These have been reset N times and keep getting stuck — cancel
+        # them so the per-contract queue can drain.
+        escalate_query = text(
+            """
+            UPDATE transactions
+            SET status = 'CANCELED',
+                worker_id = NULL,
+                blocked_at = NULL,
+                consensus_data = COALESCE(consensus_data, '{}'::jsonb)
+                                 || jsonb_build_object(
+                                    'error', 'max_recovery_cycles_exceeded',
+                                    'recovery_count', recovery_count
+                                 )
+            WHERE recovery_count >= :max_cycles
+              AND status NOT IN ('FINALIZED', 'CANCELED')
+              AND (
+                  (blocked_at IS NOT NULL
+                   AND blocked_at < NOW() - CAST(:timeout AS INTERVAL))
+                  OR
+                  (blocked_at IS NULL
+                   AND status IN ('PROPOSING', 'COMMITTING', 'REVEALING')
+                   AND created_at < NOW() - CAST(:orphan_timeout AS INTERVAL))
+              )
+            RETURNING hash, recovery_count;
+            """
+        )
+        escalated = session.execute(
+            escalate_query,
+            {
+                "max_cycles": self._max_recovery_cycles,
+                "timeout": f"{self.transaction_timeout_minutes} minutes",
+                "orphan_timeout": "5 minutes",
+            },
+        ).fetchall()
+        if escalated:
+            session.commit()
+            for row in escalated:
+                logger.error(
+                    f"[Worker {self.worker_id}] Transaction {row.hash} canceled "
+                    f"after {row.recovery_count} recovery cycles (stuck repeatedly)"
+                )
+
+        # Step 2: reset txs under the limit and bump their counter.
         recovery_query = text(
             """
             UPDATE transactions
@@ -732,25 +791,28 @@ class ConsensusWorker:
                 worker_id = NULL,
                 consensus_data = NULL,
                 consensus_history = NULL,
-                status = 'PENDING'
-            WHERE (
-                -- Case 1: Transactions with expired blocks
-                (blocked_at IS NOT NULL
-                 AND blocked_at < NOW() - CAST(:timeout AS INTERVAL)
-                 AND status NOT IN ('FINALIZED', 'CANCELED'))
-                OR
-                -- Case 2: Orphaned transactions in processing states with no block
-                (blocked_at IS NULL
-                 AND status IN ('PROPOSING', 'COMMITTING', 'REVEALING')
-                 AND created_at < NOW() - CAST(:orphan_timeout AS INTERVAL))
-            )
-            RETURNING hash, status;
-        """
+                status = 'PENDING',
+                recovery_count = recovery_count + 1
+            WHERE recovery_count < :max_cycles
+              AND (
+                  -- Case 1: Transactions with expired blocks
+                  (blocked_at IS NOT NULL
+                   AND blocked_at < NOW() - CAST(:timeout AS INTERVAL)
+                   AND status NOT IN ('FINALIZED', 'CANCELED'))
+                  OR
+                  -- Case 2: Orphaned transactions in processing states with no block
+                  (blocked_at IS NULL
+                   AND status IN ('PROPOSING', 'COMMITTING', 'REVEALING')
+                   AND created_at < NOW() - CAST(:orphan_timeout AS INTERVAL))
+              )
+            RETURNING hash, status, recovery_count;
+            """
         )
 
         result = session.execute(
             recovery_query,
             {
+                "max_cycles": self._max_recovery_cycles,
                 "timeout": f"{self.transaction_timeout_minutes} minutes",
                 "orphan_timeout": "5 minutes",  # Shorter timeout for orphaned transactions
             },
@@ -760,7 +822,9 @@ class ConsensusWorker:
             session.commit()
             for row in recovered:
                 logger.info(
-                    f"[Worker {self.worker_id}] Recovered stuck transaction {row.hash} (was {row.status}, now PENDING)"
+                    f"[Worker {self.worker_id}] Recovered stuck transaction {row.hash} "
+                    f"(was {row.status}, now PENDING, cycle {row.recovery_count}/"
+                    f"{self._max_recovery_cycles})"
                 )
 
         return len(recovered)

--- a/backend/database_handler/migration/versions/f2c3d4e5a6b7_add_recovery_count_to_transactions.py
+++ b/backend/database_handler/migration/versions/f2c3d4e5a6b7_add_recovery_count_to_transactions.py
@@ -1,0 +1,42 @@
+"""add recovery_count column to transactions
+
+Tracks how many times `recover_stuck_transactions` has reset a tx back
+to PENDING. Used to cap the recovery-reclaim cycle: after N resets on
+the same tx, escalate to CANCELED instead of letting it keep blocking
+the per-contract queue indefinitely.
+
+Revision ID: f2c3d4e5a6b7
+Revises: e1f2a3b4c5d6
+Create Date: 2026-04-17 11:30:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision: str = "f2c3d4e5a6b7"
+down_revision: Union[str, None] = "e1f2a3b4c5d6"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # ADD COLUMN with constant DEFAULT is metadata-only in PG 11+
+    # (no table rewrite, no long lock). Safe on the 158K-row transactions table.
+    op.add_column(
+        "transactions",
+        sa.Column(
+            "recovery_count",
+            sa.Integer(),
+            server_default="0",
+            nullable=False,
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("transactions", "recovery_count")

--- a/backend/database_handler/migration/versions/f2c3d4e5a6b7_add_recovery_count_to_transactions.py
+++ b/backend/database_handler/migration/versions/f2c3d4e5a6b7_add_recovery_count_to_transactions.py
@@ -26,7 +26,17 @@ depends_on: Union[str, Sequence[str], None] = None
 
 def upgrade() -> None:
     # ADD COLUMN with constant DEFAULT is metadata-only in PG 11+
-    # (no table rewrite, no long lock). Safe on the 158K-row transactions table.
+    # (no table rewrite, no per-row scan). It still needs a brief
+    # ACCESS EXCLUSIVE lock though, and on a hot table like `transactions`
+    # a slow long-running query could queue the ALTER behind it — which
+    # in turn queues every new read/write behind the ALTER.
+    #
+    # Belt + suspenders: cap how long we're willing to wait for the lock.
+    # If we can't grab it in 5s, fail the migration fast and let it retry,
+    # rather than pile up every consensus-worker commit behind us.
+    op.execute("SET LOCAL lock_timeout = '5s'")
+    op.execute("SET LOCAL statement_timeout = '30s'")
+
     op.add_column(
         "transactions",
         sa.Column(
@@ -39,4 +49,5 @@ def upgrade() -> None:
 
 
 def downgrade() -> None:
+    op.execute("SET LOCAL lock_timeout = '5s'")
     op.drop_column("transactions", "recovery_count")

--- a/backend/database_handler/models.py
+++ b/backend/database_handler/models.py
@@ -176,6 +176,9 @@ class Transactions(Base):
     value_credited: Mapped[bool] = mapped_column(
         Boolean, server_default="false", nullable=False, default=False
     )
+    recovery_count: Mapped[int] = mapped_column(
+        Integer, server_default="0", nullable=False, default=0
+    )
 
 
 class Validators(Base):


### PR DESCRIPTION
## Summary
Adds a persistent recovery-cycle cap. After N=3 resets on the same tx, it's escalated to CANCELED so the per-contract queue can advance past a poisoned head. This stops the 20-min reset→reclaim→stick loop that has produced 1,500+ tx backlogs twice in 2 days (manual cancellations were required both times).

## Why
Before this PR, \`recover_stuck_transactions\` resets any stuck tx back to PENDING every 20 min. The claim query's per-contract lock means ONE poisoned tx blocks all newer txs for that address — forever. Root causes vary (GenVM WASM trap, persistent provider outage, deterministic validator failure) but the pattern is the same.

## Fix
- New column \`transactions.recovery_count INTEGER NOT NULL DEFAULT 0\` (metadata-only migration on PG 11+, no table rewrite).
- \`recover_stuck_transactions\` now does two steps:
  1. **Escalate**: txs with \`recovery_count >= MAX_RECOVERY_CYCLES\` that are still stuck → \`status=CANCELED\` with \`{error: "max_recovery_cycles_exceeded"}\` in \`consensus_data\`.
  2. **Reset**: txs under the limit get the existing reset + counter bump.
- Threshold: 3 cycles. Env-tunable via \`RECOVERY_MAX_CYCLES\`.
- Counter persists via DB column — survives worker pod restarts, unlike the in-memory counters used elsewhere.

## Verified
- [x] 120 db-integration tests pass (including the migration-integrity tests added in PR #1599).
- [x] 16 worker-related unit tests pass.
- [x] Migration applies cleanly against a fresh PG via \`alembic upgrade head\`.

## Deferred
Reset \`recovery_count\` to 0 on successful FINALIZE: a tx that gets recovered once and then succeeds shouldn't count against its quota. Not important right now because the counter only matters when it hits the cap — transient recoveries don't reach 3.

Refs: yesterday's manual cancel of 0x1AE5Eb9a chain head (recurred today and was canceled again), and today's cancel of 0xe8760c16.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Transaction recovery cycle limits introduced. Stuck transactions are now subject to a configurable maximum number of recovery cycles (default: 3). Transactions exceeding this limit are automatically cancelled with detailed error status information. This prevents infinite recovery loops and enhances overall system stability and transaction management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->