### PR TITLE
fix: finalize calls to non-deployed contracts with error receipt

### DIFF
--- a/backend/consensus/base.py
+++ b/backend/consensus/base.py
@@ -469,7 +469,20 @@ class TransactionContext:
                         self.transaction.to_address
                     )
                 except ContractNotFoundError:
-                    self.contract_snapshot = None
+                    # For DEPLOY, the current_state row exists (created at tx
+                    # submission) but is still empty — this is expected, the
+                    # contract hasn't executed yet.
+                    #
+                    # For RUN_CONTRACT / UPGRADE_CONTRACT, a missing contract
+                    # (no row, or data={} left behind by a failed deploy) means
+                    # the user is calling something that was never successfully
+                    # deployed. Re-raise so the worker-level handler can
+                    # finalize the tx with a proper error receipt instead of
+                    # letting it hang.
+                    if self.transaction.type == TransactionType.DEPLOY_CONTRACT:
+                        self.contract_snapshot = None
+                    else:
+                        raise
 
         self.validators_snapshot = validators_snapshot
 

--- a/backend/protocol_rpc/explorer/queries.py
+++ b/backend/protocol_rpc/explorer/queries.py
@@ -703,9 +703,12 @@ def get_address_info(session: Session, address: str) -> Optional[dict]:
     except Exception:
         pass
 
-    # 1. Check if it's a contract (exists in CurrentState with a deploy tx)
+    # 1. Check if it's a contract (exists in CurrentState with a successful
+    # deploy). An errored deploy also leaves a CurrentState row, but with an
+    # empty `data` blob (register_contract only runs on SUCCESS) — treat those
+    # as ACCOUNT so the explorer doesn't render a zombie contract page.
     state = session.query(CurrentState).filter(CurrentState.id == address).first()
-    if state:
+    if state and state.data:
         deploy_tx = (
             session.query(Transactions)
             .filter(

--- a/explorer/src/app/transactions/[hash]/components/DataTab.tsx
+++ b/explorer/src/app/transactions/[hash]/components/DataTab.tsx
@@ -11,9 +11,14 @@ interface DataTabProps {
 }
 
 export function DataTab({ transaction: tx }: DataTabProps) {
-  const calldataB64 = (tx.type === 1 || tx.type === 2) && tx.data && typeof tx.data === 'object'
-    ? (tx.data as Record<string, unknown>).calldata as string | undefined
-    : undefined;
+  const dataObj =
+    tx.data && typeof tx.data === 'object' ? (tx.data as Record<string, unknown>) : null;
+  const calldataB64 =
+    (tx.type === 1 || tx.type === 2) && dataObj
+      ? (dataObj.calldata as string | undefined)
+      : undefined;
+  const contractCodeB64 =
+    tx.type === 1 && dataObj ? (dataObj.contract_code as string | undefined) : undefined;
 
   return (
     <div className="space-y-6">
@@ -29,8 +34,21 @@ export function DataTab({ transaction: tx }: DataTabProps) {
         </div>
       )}
 
-      {/* Etherscan-style input data panel for call transactions */}
-      {calldataB64 && (
+      {/* Deploy transactions: show contract source code alongside constructor args.
+          DataDecodePanel renders each base64 field with the best decoder per key
+          (CodeBlock for contract_code, calldata decoder for calldata). */}
+      {contractCodeB64 && dataObj && (
+        <div>
+          <h4 className="font-medium text-foreground mb-2 flex items-center gap-2">
+            <FileCode className="w-4 h-4" />
+            Contract Source
+          </h4>
+          <DataDecodePanel data={dataObj} />
+        </div>
+      )}
+
+      {/* Call transactions: focused Etherscan-style decoder on calldata. */}
+      {calldataB64 && !contractCodeB64 && (
         <div>
           <h4 className="font-medium text-foreground mb-2 flex items-center gap-2">
             <FileCode className="w-4 h-4" />
@@ -40,8 +58,8 @@ export function DataTab({ transaction: tx }: DataTabProps) {
         </div>
       )}
 
-      {/* Generic data panel for non-call transactions */}
-      {tx.data && !calldataB64 && (
+      {/* Fallback for non-call/non-deploy transactions that still carry data. */}
+      {tx.data && !calldataB64 && !contractCodeB64 && (
         <div>
           <h4 className="font-medium text-foreground mb-2 flex items-center gap-2">
             <FileCode className="w-4 h-4" />

--- a/explorer/src/app/transactions/[hash]/components/OverviewTab.tsx
+++ b/explorer/src/app/transactions/[hash]/components/OverviewTab.tsx
@@ -13,6 +13,7 @@ import { getExecutionResult, getConsensusRoundResult } from '@/lib/transactionUt
 import { ConsensusResultBadge } from '@/components/ConsensusResultBadge';
 import { resultStatusLabel, type DecodedResult } from '@/lib/resultDecoder';
 import { InputDataPanel } from '@/components/InputDataPanel';
+import { DataDecodePanel } from '@/components/DataDecodePanel';
 import { formatGenValue } from '@/lib/formatters';
 
 interface OverviewTabProps {
@@ -98,9 +99,14 @@ export function OverviewTab({ transaction: tx }: OverviewTabProps) {
   const decodedResult = execResult?.decodedResult;
   const eqOutputs = execResult?.eqOutputs;
 
-  const calldataB64 = (tx.type === 1 || tx.type === 2) && tx.data && typeof tx.data === 'object'
-    ? (tx.data as Record<string, unknown>).calldata as string | undefined
-    : undefined;
+  const dataObj =
+    tx.data && typeof tx.data === 'object' ? (tx.data as Record<string, unknown>) : null;
+  const calldataB64 =
+    (tx.type === 1 || tx.type === 2) && dataObj
+      ? (dataObj.calldata as string | undefined)
+      : undefined;
+  const contractCodeB64 =
+    tx.type === 1 && dataObj ? (dataObj.contract_code as string | undefined) : undefined;
 
   return (
     <div className="space-y-1">
@@ -162,7 +168,15 @@ export function OverviewTab({ transaction: tx }: OverviewTabProps) {
       />
       {tx.worker_id && <InfoRow label="Worker ID" value={tx.worker_id} />}
 
-      {calldataB64 && (
+      {contractCodeB64 && dataObj && (
+        <div className="border-t border-border mt-4 pt-4">
+          <h4 className="text-sm font-semibold text-foreground mb-3">Input Data</h4>
+          {/* Deploy: show both constructor calldata and contract source */}
+          <DataDecodePanel data={dataObj} />
+        </div>
+      )}
+
+      {calldataB64 && !contractCodeB64 && (
         <div className="border-t border-border mt-4 pt-4">
           <h4 className="text-sm font-semibold text-foreground mb-3">Input Data</h4>
           <InputDataPanel calldataB64={calldataB64} />

--- a/tests/integration/icontracts/tests/test_call_to_errored_deploy.py
+++ b/tests/integration/icontracts/tests/test_call_to_errored_deploy.py
@@ -1,0 +1,81 @@
+"""
+Regression: a deploy tx that finalizes with execution_result=ERROR must not
+leave a "zombie" contract at its address.
+
+Bug: today, the deploy failure still creates a current_state row for the
+target address. Subsequent calls to that address don't raise
+ContractNotFoundError — they hang in the consensus loop until the
+recovery-cycle cap cancels them.
+
+Expected: deploy failure should leave the address undeployed, and calls
+to it should finalize with execution_result=ERROR (FinishedWithError)
+within normal consensus time.
+"""
+
+from gltest import get_contract_factory
+from gltest.assertions import tx_execution_failed
+from gltest.clients import get_gl_client
+from gltest.utils import extract_contract_address
+from genlayer_py.types import TransactionStatus
+from backend.node.types import ExecutionResultStatus
+import pytest
+
+pytestmark = pytest.mark.error_handling
+
+
+def test_call_to_errored_deploy_address_finalizes_with_error(setup_validators):
+    setup_validators()
+    factory = get_contract_factory("ErrorExecutionContract")
+
+    # Deploy with testcase=5 → __init__ raises ValueError.
+    # deploy_contract_tx returns the receipt on exec-failure (it only wraps
+    # unexpected RPC exceptions as DeploymentError).
+    deploy_receipt = factory.deploy_contract_tx(args=[5])
+    assert tx_execution_failed(
+        deploy_receipt
+    ), "Precondition: deploy is expected to fail with execution_result=ERROR"
+
+    errored_address = extract_contract_address(deploy_receipt)
+
+    # Now send a call to that address. The contract was never successfully
+    # deployed, so this should finalize with a contract-not-found error.
+    client = get_gl_client()
+    call_tx_hash = client.write_contract(
+        address=errored_address,
+        function_name="test_value_error",
+        args=[],
+    )
+
+    # Bounded wait: if the bug is present, the tx hangs and never finalizes
+    # within this window (it either stays PROPOSING/COMMITTING or gets
+    # canceled much later via the recovery-cycle cap). A correct
+    # implementation finalizes in normal consensus time. wait_for_transaction_receipt
+    # raises GenLayerError on timeout, so reaching this assert means FINALIZED.
+    call_receipt = client.wait_for_transaction_receipt(
+        transaction_hash=call_tx_hash,
+        status=TransactionStatus.FINALIZED,
+        interval=5000,  # ms
+        retries=60,  # ≈ 5 min ceiling
+    )
+
+    # Execution result must be ERROR, synthesized by the worker's
+    # ContractNotFoundError handler. Identified by the pseudo-validator address
+    # "contract_not_found_handler", which is the handler's distinctive marker
+    # (see backend/consensus/worker.py, ContractNotFoundError branch of
+    # process_transaction).
+    consensus_data = call_receipt.get("consensus_data") or {}
+    leader_receipts = consensus_data.get("leader_receipt") or []
+    assert (
+        leader_receipts
+    ), f"receipt must carry a leader_receipt with the error: {call_receipt}"
+
+    leader = leader_receipts[0]
+    assert (
+        leader.get("execution_result") == ExecutionResultStatus.ERROR.value
+    ), f"execution_result must be ERROR, got {leader.get('execution_result')}"
+
+    handler_marker = (leader.get("node_config") or {}).get("address")
+    assert handler_marker == "contract_not_found_handler", (
+        "leader receipt must come from the contract-not-found handler, "
+        f"got node_config.address={handler_marker!r}; receipt={call_receipt}"
+    )

--- a/tests/integration/icontracts/tests/test_error_execution.py
+++ b/tests/integration/icontracts/tests/test_error_execution.py
@@ -67,8 +67,16 @@ def _check_last_round(tx_receipt: dict, expected_round: str):
 
 
 def _deployment_error_to_tx_receipt(e: DeploymentError):
-    error_dict_str = str(e).split("error: ", 1)[1]
-    return literal_eval(error_dict_str)
+    # gltest raises DeploymentError with one of two message shapes:
+    #   "Deployment transaction failed: {receipt_dict}"
+    #   "Failed to deploy contract <Name>: <nested error: {receipt_dict}>"
+    # Pick whichever prefix matches, then literal_eval the dict portion.
+    msg = str(e)
+    for prefix in ("Deployment transaction failed: ", "error: "):
+        idx = msg.find(prefix)
+        if idx != -1:
+            return literal_eval(msg[idx + len(prefix) :])
+    raise ValueError(f"could not parse DeploymentError payload: {msg!r}")
 
 
 def _run_testcase(setup_validators, testcase: ErrorType):


### PR DESCRIPTION
## Summary
- Re-raise `ContractNotFoundError` in `TransactionContext.__init__` for RUN_CONTRACT / UPGRADE_CONTRACT so the existing worker handler finalizes them with a `contract_not_found_handler` error receipt. DEPLOY_CONTRACT unchanged (row exists with empty data at tx submission — expected).
- Add failing→passing integration test that deploys an always-erroring contract, calls a method on the resulting address, and asserts it finalizes with the handler marker rather than hanging in PROPOSING until the recovery-cycle cap force-cancels it.
- Fix the `_deployment_error_to_tx_receipt` helper in `test_error_execution.py` — gltest now emits a `"Deployment transaction failed: "` prefix, not the legacy `"error: "`.

## Why
Reproduced on studio-dev: a user deploys a contract whose `__init__` raises (e.g. `TreeMap` re-initialization). The deploy tx finalizes with `execution_result=ERROR`. A follow-up call to that address sits in `PROPOSING` indefinitely — eventually canceled only by the recovery-cycle cap (60+ min). Root cause: `TransactionContext.__init__` silently set `contract_snapshot=None` for every non-SEND type, swallowing the signal that the worker's `ContractNotFoundError` branch needed to finalize with a proper error receipt.

## Test plan
- [x] New `test_call_to_errored_deploy_address_finalizes_with_error` passes on the fix; without it, the call hangs >5min.
- [x] All 611 backend unit tests pass (`pytest tests/unit/ -v`).
- [x] Verified via studio-dev log traces: new code path hits `process_transaction:960` ContractNotFoundError branch → ACCEPTED with error → `process_finalization:1432` branch → FINALIZED.
- [ ] CI green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced contract deployment error handling to prevent transaction execution stalls when accessing failed deployments.
  * Improved error message parsing to support multiple message formats for better error reporting.

* **Tests**
  * Added regression test to validate transaction finalization and error handling for calls to failed contract addresses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->