### PR TITLE
test(explorer): cover zombie-deploy address classification

### DIFF
--- a/tests/db-sqlalchemy/explorer_queries_test.py
+++ b/tests/db-sqlalchemy/explorer_queries_test.py
@@ -476,6 +476,20 @@ class TestGetAddressInfo:
         assert result["balance"] == 999
         assert result["transactions"] == []
 
+    def test_zombie_deploy_classified_as_account(self, session: Session):
+        # An errored deploy leaves a CurrentState row with empty data ({}) —
+        # register_contract only runs on SUCCESS. The explorer must not treat
+        # this as a deployed contract.
+        addr = "0xZOMBIE_CONTRACT"
+        _make_state(session, addr, data={}, balance=42)
+        _make_tx(session, to_address=addr, type=1, from_address="0xDEPLOYER")
+        session.commit()
+
+        result = queries.get_address_info(session, addr)
+        assert result["type"] == "ACCOUNT"
+        assert result["balance"] == 42
+        assert "state" not in result
+
 
 # ---------------------------------------------------------------------------
 # Validators


### PR DESCRIPTION
## Summary

Adds a regression test for the zombie-deploy address classification in `backend/protocol_rpc/explorer/queries.py`. The underlying fix already shipped in #1602; this PR is now test-only after rebasing onto the new main (which absorbed #1602's squashed changes and #1564's URL rename).

The test asserts that an address with:
- a `CurrentState` row whose `data={}` (the placeholder left when `register_contract` is skipped because deploy finalized with ERROR), and
- a matching `type=1` deploy transaction,

resolves to `ACCOUNT`, not `CONTRACT`. Without the fix in #1602, this address would render as a deployed contract page in the explorer.

## Test plan
- [x] `TestGetAddressInfo::test_zombie_deploy_classified_as_account` passes locally against the dockerized db-sqlalchemy suite.
- [x] All 37 existing tests in `tests/db-sqlalchemy/explorer_queries_test.py` continue to pass.