### PR TITLE
fix(ci): bake explorer image for Load Tests

### DIFF
--- a/.github/workflows/load-test-oha.yml
+++ b/.github/workflows/load-test-oha.yml
@@ -106,6 +106,7 @@ jobs:
             database-migration
             jsonrpc
             consensus-worker
+            explorer
           set: |
             *.cache-from=type=gha
             *.cache-to=type=gha,mode=max
@@ -113,6 +114,7 @@ jobs:
             database-migration.tags=genlayer-studio-database-migration:latest
             jsonrpc.tags=genlayer-studio-jsonrpc:latest
             consensus-worker.tags=genlayer-studio-consensus-worker:latest
+            explorer.tags=genlayer-studio-explorer:latest
           load: true
 
       - name: Run Docker Compose with multiple workers


### PR DESCRIPTION
## Summary

The Load Tests workflow (`.github/workflows/load-test-oha.yml`) builds images via `docker/bake-action` and then runs `docker compose up --no-build --wait`. But the bake targets list only includes `frontend`, `database-migration`, `jsonrpc`, and `consensus-worker` — the `explorer` service (part of `docker-compose.yml`) is never baked or tagged.

Result: when the GitHub runner doesn't have a cached `genlayer-studio-explorer:latest` image, Docker Compose fails with:

```
Container genlayer-studio-explorer-1  Error response from daemon: No such image: genlayer-studio-explorer:latest
```

This has been flaking Load Tests across multiple PRs (e.g. PR #1564 and PR #1604 failed a few minutes apart on the same commit that had previously succeeded). Not a regression from any branch, just an infra gap.

### Fix

Add `explorer` to the bake `targets` and pin `explorer.tags=genlayer-studio-explorer:latest` so every run has the image locally before `docker compose up`.

## Test plan
- [ ] Load Tests workflow runs against this branch and succeeds.
- [ ] No more "No such image: genlayer-studio-explorer:latest" errors in subsequent PRs.