### PR TITLE
feat(frontend): network selector for Studio / Bradbury targets

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,6 +15,7 @@ REMOTE_DATABASE='false'
 LOGCONFIG='dev'                   # dev/prod
 LOG_LEVEL='debug'                 # 'critical', 'error', 'warning', 'info', 'debug', 'trace'
 DISABLE_INFO_LOGS_ENDPOINTS='["ping", "eth_getTransactionByHash","gen_getContractSchema", "gen_getContractSchemaForCode", "net_version", "sim_getTransactionsForAddress", "sim_getConsensusContract", "eth_estimateGas", "eth_chainId", "eth_getBlockByNumber", "eth_gasPrice", "sim_getFinalityWindowTime"]'
+SHOW_VALIDATOR_PRIVATE_KEYS_IN_LOGS='false' # Set true only when debugging local validator signing.
 
 ########################################
 # JsonRPC Server Configuration

--- a/backend/protocol_rpc/message_handler/base.py
+++ b/backend/protocol_rpc/message_handler/base.py
@@ -103,9 +103,10 @@ class MessageHandler(IMessageHandler):
         gray = "\033[38;5;245m"
         reset = "\033[0m"
 
-        if log_event.data:
+        data = log_event.sanitized_data()
+        if data:
             try:
-                data_to_log = self._apply_log_level_truncation(log_event.data)
+                data_to_log = self._apply_log_level_truncation(data)
 
                 def json_serializer(o):
                     if isinstance(o, bytes):
@@ -124,9 +125,7 @@ class MessageHandler(IMessageHandler):
                 data_str = json.dumps(data_to_log, default=json_serializer)
                 log_message += f" {gray}{data_str}{reset}"
             except TypeError as e:
-                log_message += (
-                    f" {gray}{str(log_event.data)} (serialization error: {e}){reset}"
-                )
+                log_message += f" {gray}{str(data)} (serialization error: {e}){reset}"
 
         log_method(log_message)
 

--- a/backend/protocol_rpc/message_handler/fastapi_handler.py
+++ b/backend/protocol_rpc/message_handler/fastapi_handler.py
@@ -123,9 +123,10 @@ class MessageHandler(IMessageHandler):
         gray = "\033[38;5;245m"
         reset = "\033[0m"
 
-        if getattr(log_event, "data", None):
+        data = log_event.sanitized_data()
+        if data:
             try:
-                data_to_log = self._apply_log_level_truncation(log_event.data)
+                data_to_log = self._apply_log_level_truncation(data)
                 import decimal
 
                 data_str = json.dumps(
@@ -136,7 +137,9 @@ class MessageHandler(IMessageHandler):
                 )
                 message = f"{message} {gray}{data_str}{reset}"
             except TypeError as e:
-                message = f"{message} {gray}{str(log_event.data)} (serialization error: {e}){reset}"
+                message = (
+                    f"{message} {gray}{str(data)} (serialization error: {e}){reset}"
+                )
 
         if log_event.type == EventType.ERROR:
             logger.error(message)

--- a/backend/protocol_rpc/message_handler/types.py
+++ b/backend/protocol_rpc/message_handler/types.py
@@ -1,5 +1,7 @@
+import os
 from enum import Enum
 from dataclasses import dataclass
+from typing import Any
 
 
 class EventType(Enum):
@@ -17,6 +19,46 @@ class EventScope(Enum):
     TRANSACTION = "Transaction"
 
 
+def show_validator_private_keys_in_logs() -> bool:
+    return os.getenv("SHOW_VALIDATOR_PRIVATE_KEYS_IN_LOGS", "").lower() in {
+        "1",
+        "true",
+        "yes",
+    }
+
+
+def _is_private_key_field(key: Any) -> bool:
+    if not isinstance(key, str):
+        return False
+
+    normalized = key.replace("_", "").replace("-", "").lower()
+    return normalized == "privatekey" or normalized.endswith("privatekey")
+
+
+def sanitize_log_data(value: Any) -> Any:
+    """Return a copy of log data with private-key fields removed."""
+    if show_validator_private_keys_in_logs():
+        return value
+
+    if isinstance(value, dict):
+        return {
+            key: sanitize_log_data(item)
+            for key, item in value.items()
+            if not _is_private_key_field(key)
+        }
+
+    if isinstance(value, list):
+        return [sanitize_log_data(item) for item in value]
+
+    if isinstance(value, tuple):
+        return tuple(sanitize_log_data(item) for item in value)
+
+    if hasattr(value, "__dict__"):
+        return sanitize_log_data(vars(value))
+
+    return value
+
+
 @dataclass
 class LogEvent:
     name: str
@@ -28,13 +70,16 @@ class LogEvent:
     client_session_id: str | None = None
     account_address: str | None = None
 
+    def sanitized_data(self):
+        return sanitize_log_data(self.data)
+
     def to_dict(self):
         return {
             "name": self.name,
             "type": self.type.value,
             "scope": self.scope.value,
             "message": self.message,
-            "data": self.data,
+            "data": self.sanitized_data(),
             "transaction_hash": self.transaction_hash,
             "client_id": self.client_session_id,
             "account_address": self.account_address,

--- a/docs/plans/studio-network-selector.md
+++ b/docs/plans/studio-network-selector.md
@@ -1,0 +1,260 @@
+# Studio Network Selector — Full Scope Plan
+
+**Goal:** Users of the hosted Studio frontend at `studio.genlayer.com` can pick between **Local Studio backend** and **Bradbury testnet** via a UI dropdown. (Asimov shares chain ID 4221 with Bradbury — same underlying network, different RPC frontend — so it is not a separate dropdown option. Reachable via `VITE_GENLAYER_NETWORK=testnetAsimov` deployment override only.) Contract deploy / read / write / simulate / attach flows work on all three. Studio-exclusive features (node logs, validators, providers, faucet, finality tuning) degrade gracefully on testnet. MetaMask is forced to the selected chain; burner wallets work on any chain.
+
+---
+
+## 1. What already exists
+
+The infrastructure is ~80% wired at build time; only the runtime layer and UX are missing.
+
+| Piece | File | What it does today |
+|---|---|---|
+| Chain selection | `frontend/src/hooks/useGenlayer.ts:19-32` | Reads `VITE_GENLAYER_NETWORK` → picks chain from `{localnet, studionet, testnetAsimov}` map |
+| Chain override | `frontend/src/hooks/useGenlayer.ts:29-32` | `VITE_CHAIN_ID` overrides SDK chain.id |
+| MetaMask switch/add | `frontend/src/hooks/useChainEnforcer.ts` | Fires `wallet_switchEthereumChain`, falls back to `wallet_addEthereumChain` on 4902 |
+| Runtime config overlay | `frontend/src/utils/runtimeConfig.ts` | `window.__RUNTIME_CONFIG__` can inject values at container start |
+| Feature flags | `frontend/src/hooks/useConfig.ts` | Already has `canUpdateValidators`, `canUpdateProviders` gated by `VITE_IS_HOSTED` |
+| SDK chain defs | `genlayer-js` package | Exports `localnet`, `studionet`, `testnetAsimov` (and `testnetBradbury`) with `isStudio` flag |
+| Field transform | `backend/.../transactions_processor.get_studio_transaction_by_hash` | Partial Studio→testnet field rename |
+
+**Gap:** everything is resolved once at module load. There is no reactive "current network" anywhere in the frontend.
+
+---
+
+## 2. End-state UX
+
+1. A **network selector** in the header, styled like a chip/dropdown: `● Studio` / `● Bradbury` / `● Asimov`. Active dot tinted per network.
+2. Selecting a new network:
+   - Persists choice to `localStorage`.
+   - Re-initializes the genlayer-js client against the new chain/RPC.
+   - Reconnects the WebSocket transport (close old, open new — only the Studio variant emits events).
+   - If an external wallet is connected: immediately prompts MetaMask to switch chain. On rejection, revert the dropdown + toast "Wallet still on X".
+   - Filters contracts/transactions UI to only the new network's records.
+3. Studio-exclusive UI hides or disables on testnet (node logs, validators, providers, faucet, finality editor).
+4. On reload, the last-selected network is restored. Operator's `VITE_GENLAYER_NETWORK` env var is the **default** (used only when no persisted choice); set `VITE_LOCK_NETWORK=true` to hide the dropdown entirely for single-network deployments.
+
+---
+
+## 3. Architecture changes
+
+### 3.1 New Pinia store — `networkStore`
+
+`frontend/src/stores/network.ts` (new)
+
+```ts
+state: {
+  currentNetwork: 'localnet' | 'studionet' | 'testnetAsimov' | 'testnetBradbury'
+}
+getters: {
+  chain,              // resolved GenLayerChain from genlayer-js
+  rpcUrl,             // derived from chain or per-network override map
+  wsUrl,              // Studio-only; null for testnets
+  chainId,            // number
+  isStudio,           // chain.isStudio
+  isLocked,           // VITE_LOCK_NETWORK
+  availableNetworks,  // filtered list for dropdown
+}
+actions: {
+  setCurrentNetwork(name) // persists + triggers downstream re-inits
+}
+```
+
+Seeds from `localStorage['networkStore.currentNetwork']` → falls back to `VITE_GENLAYER_NETWORK`.
+
+### 3.2 Reactive transport
+
+**Problem:** `rpc.ts` reads the URL once at module load; WebSocket singleton is constructed once; genlayer-js client is re-initialized only on account change.
+
+**Fix:**
+- `frontend/src/clients/rpc.ts` — replace the module-level `JSON_RPC_SERVER_URL` constant with a getter that reads `networkStore.rpcUrl`. Each `fetch` call resolves the URL fresh.
+- `frontend/src/hooks/useWebSocketClient.ts` — add `reconnect(newUrl)` that closes the current socket, clears subscriptions, and opens a new one. Watch `networkStore.wsUrl` and call `reconnect()` on change. When `wsUrl` is null (testnet), tear down without reopening.
+- `frontend/src/hooks/useGenlayer.ts` — add `watch(() => networkStore.currentNetwork, initClient)` alongside the existing account watcher. Client re-instantiation already handles `publicClient` + `walletClient` cleanly.
+
+### 3.3 AppKit chain registration
+
+`frontend/src/hooks/useAppKit.ts:44-48` today hardcodes `[genlayerLocalnet, mainnet, sepolia]`. This means MetaMask has no idea what Bradbury/Asimov are when switching.
+
+**Fix:** build the AppKit networks array from the `networkStore.availableNetworks` (or from genlayer-js chain definitions). Pass `allowUnsupportedChain: true` so mid-session switches don't break AppKit's state.
+
+### 3.4 Network selector component
+
+`frontend/src/components/Global/NetworkSelector.vue` (new) — dropdown with the three networks, current selection highlighted, confirmation dialog if there are pending transactions on the current network (those will be filtered out of the UI after switch).
+
+Mount in `frontend/src/components/Header.vue:13-25` between the logo and `AccountSelect`. Hide when `networkStore.isLocked`.
+
+### 3.5 Per-network data scoping
+
+**Accounts:** stay global. Same private key is valid on every chain; that's the standard wallet model. Balance display must re-fetch on network change (currently there's no balance widget anyway — if we add one, it reads from the reactive RPC).
+
+**Deployed contracts** (`contractsStore.deployedContracts`, stored in IndexedDB via `frontend/src/hooks/useDb.ts`): today no `chainId` field. Add one. Without scoping, deploying `Storage` to localnet then attaching the same contract at a Bradbury address would collide.
+
+**Transactions** (`transactionsStore.transactions`, also IndexedDB): same problem, plus worse — `refreshPendingTransactions()` (`frontend/src/stores/transactions.ts:64-85`) will query the wrong network and silently drop pending txs as "not found."
+
+**Schema migration (Dexie v5):**
+```ts
+deployedContracts: '++id, contractId, [chainId+address]'
+transactions:      '++id, type, statusName, chainId, [chainId+hash], [chainId+contractAddress], [chainId+localContractId]'
+```
+Backfill existing rows with the current `VITE_GENLAYER_NETWORK`'s chain ID on upgrade. Getters (`deployedContracts`, `transactions`) filter by `networkStore.chainId` before returning.
+
+### 3.6 Graceful degradation
+
+Extend `useConfig` with a new computed: `isStudioNetwork = networkStore.isStudio`.
+
+| Component | File | On testnet |
+|---|---|---|
+| Node Logs pane | `frontend/src/components/Simulator/NodeLogs.vue` | Hide. Show placeholder "Live node logs are only available on local Studio." |
+| Validators view | `frontend/src/views/Simulator/ValidatorsView.vue` | Already gated by `canUpdateValidators`; tighten to also require `isStudioNetwork` |
+| Providers section | `frontend/src/components/Simulator/settings/ProviderSection.vue` | Same |
+| Finality window editor | `frontend/src/components/Simulator/settings/ConsensusSection.vue` | Disable edit; read-only displayed value from chain config |
+| Faucet button | `frontend/src/components/Simulator/AccountSelect.vue:170-207` | On testnet, swap action: open `https://testnet-faucet.genlayer.foundation` in new tab instead of calling `sim_fundAccount`. Hide amount input (faucet fixed at 100 GEN / 24h). |
+| Tutorial fake-log injection | `frontend/src/stores/tutorial.ts` | Skip `nodeStore.addLog` calls; deploy step still works via genlayer-js |
+| Reset storage | `frontend/src/components/Simulator/settings/SimulatorSection.vue:45` | Scope label: "Clears data for *[current network]*" — only clears rows matching chainId |
+| `sim_cancelTransaction` button (if exposed) | — | Hide |
+| `sim_upgradeContractCode` button (if exposed) | — | Hide |
+
+The WebSocket itself should be torn down on non-Studio networks — no events to consume, no reason to hold the connection.
+
+### 3.7 Wallet / chain enforcement on switch
+
+Today `ensureCorrectChain()` (`useChainEnforcer.ts`) fires **only before deploy/write**. That leaves a window where the UI says "Bradbury" but MetaMask is still on localnet until the first transaction.
+
+**Fix:** on `networkStore.setCurrentNetwork`, if `accountsStore.currentAccount.type === 'external'`, call `ensureCorrectChain()` immediately. On user rejection (error 4001): revert `networkStore.currentNetwork` to the previous value and toast "Keep wallet on previous network — switch canceled."
+
+Also handle: user changes MetaMask's network manually → `eth_chainChanged` event → sync `networkStore` to match (if the chain is one we know) or show a banner "Wallet is on an unknown chain."
+
+---
+
+## 4. Verification before / during implementation
+
+These are the known unknowns. Settle them early — they affect scope:
+
+1. **Does Bradbury/Asimov support `gen_call`, `gen_getContractCode`, `gen_getContractSchema`, `gen_getContractNonce`?**
+   - **Resolved.** All three supported; `gen_getContractNonce` isn't a real RPC on any chain (nonces come from `eth_getTransactionCount`).
+   - `gen_getContractSchema` has **divergent semantics** between Studio (takes `address`) and the node (takes base64 `code`). See `docs/plans/studio-testnet-format-alignment.md` § "Schema method divergence".
+   - **Unblocker for this plan:** patch `genlayer-js` to hide the divergence — `getContractSchema(address)` does a `gen_getContractCode` then `gen_getContractSchema({code})` on non-Studio chains, single RPC on Studio. Also remove the `if (!isStudio) throw` guards on `getContractCode` / `getContractSchema` / `getContractSchemaForCode`. Once the SDK patch ships, contract attach and deployed-contract method UI work unchanged on testnet.
+   - **Long term:** align the two sides at the protocol level and drop the SDK workaround. Tracked in the divergence doc.
+
+2. **Does genlayer-js `extractGenCallResult` shim actually handle both Studio and Bradbury response shapes?**
+   - User believes yes. Verify by grep'ing genlayer-js source and spot-checking on a Bradbury RPC.
+
+3. **Chain IDs for Bradbury / Asimov** — **Resolved.** Both share chain ID `4221` by design: they are different RPC frontends onto the same underlying chain. Distinct consensus/staking contract addresses per chain def, but same network from MetaMask's perspective. **v1 ships Bradbury only.** Asimov reachable via deployment-time `VITE_GENLAYER_NETWORK=testnetAsimov` override if ever needed, but not in the runtime dropdown — the shared chain ID makes simultaneous MetaMask support confusing (can't distinguish which RPC MetaMask's "4221" points at).
+
+4. **Public faucet URLs** — **Resolved.** `https://testnet-faucet.genlayer.foundation` (100 GEN per 24h, gated on 0.01 ETH mainnet balance). Shared between Bradbury and Asimov. On Bradbury, faucet button opens this URL in a new tab; amount input is hidden. Worth noting in the network-switch warning banner that burner-only wallets can't self-fund (faucet gates on mainnet balance).
+
+5. **Does `sim_lintContract` have a testnet equivalent?** — **Resolved.** No. Decision: linting is a developer tool, not a chain operation — keep the Monaco linter pointed at the Studio backend regardless of the currently selected target network. In hosted deployments that have no Studio backend at all, the linter disables cleanly (no inline errors; editor still usable). Means `monacoLinter.ts` keeps using `VITE_JSON_RPC_SERVER_URL` directly rather than routing through `networkStore.rpcUrl`.
+
+6. **WebSocket on testnet** — **Resolved.** Bradbury has no WebSocket / push-event support, so drop the WS entirely when the selected network is non-Studio. Tear down the singleton on switch to a testnet, suppress its auto-reconnect behavior; rebuild cleanly on switch back to Studio. Transaction status falls back to polling `eth_getTransactionByHash` (the `refreshPendingTransactions` path at `frontend/src/stores/transactions.ts:64-85` is already the fallback).
+
+---
+
+## 5. Implementation phases
+
+### Phase 0 — Verification & scaffolding (pre-code)
+- Confirm the 6 open questions above. File a followup for any that require SDK or backend work before the UI can ship.
+- Snapshot the current `refactor/multi-network-prep` branch; decide whether to rebase on `main` and continue, or start fresh on a new branch. (Recommend fresh; the existing branch is 27 behind and its one commit already landed on main.)
+
+### Phase 1 — Reactive transport (no UI yet)
+- Add `networkStore` (seeded from env, no dropdown yet).
+- Make `rpc.ts` URL reactive.
+- Make WebSocket singleton reconnect on URL change / tear down when URL is null.
+- Add network watcher to `useGenlayer`.
+- Test: set `networkStore.currentNetwork` from devtools, verify next RPC call hits the new URL.
+
+### Phase 2 — Data scoping
+- Dexie v5 migration: add `chainId` to `deployedContracts` and `transactions`.
+- Backfill on upgrade.
+- Update store getters / computed to filter by `networkStore.chainId`.
+- Update `contractsStore.addDeployedContract`, `transactionsStore.addTransaction` to stamp `chainId`.
+- Update `importContract` duplicate check to include `chainId`.
+
+### Phase 3 — UI selector + wallet flow
+- `NetworkSelector.vue` in header.
+- Persistence to localStorage.
+- On selection change: trigger `ensureCorrectChain()` when external wallet is connected; revert on rejection.
+- Register all supported chains in AppKit.
+- Listen for MetaMask `chainChanged` and sync store.
+
+### Phase 4 — Degradation
+- Extend `useConfig` with `isStudioNetwork`.
+- Gate Node Logs, Validators, Providers, Finality editor, `sim_*` buttons.
+- Swap faucet button behavior for testnet.
+- Skip tutorial log injection on testnet.
+- Scope reset-storage button label + effect to current network.
+
+### Phase 5 — Polish + test
+- Banner on testnet: "You are on Bradbury testnet. Contracts and transactions deployed here are separate from your local Studio work."
+- E2E tests per network: deploy, write, read, simulate, attach. Separate spec file per network, parameterized.
+- Manual test matrix: burner-only, MetaMask on localnet, MetaMask on wrong chain, switch mid-pending-tx, reload preserves selection.
+- Sentry events tagged with current network.
+
+---
+
+## 6. Risk register
+
+| Risk | Likelihood | Mitigation |
+|---|---|---|
+| `gen_getContractCode` / `gen_getContractSchema` don't exist on testnet → contract attach breaks | Medium | Fall back to `eth_getCode` + client-side ABI parse, or disable attach UI on testnet with explanatory message |
+| `gen_call` response shape differs → simulate returns garbage | Medium | Verify genlayer-js shim; if missing, add response normalization in `useContractQueries.simulateWriteMethod` |
+| Pending txs silently lost on network switch | High (if we don't scope) | Phase 2 (data scoping) is a hard prerequisite for the dropdown ship |
+| MetaMask refuses to add Bradbury (e.g. bad RPC URL) | Medium | Test `wallet_addEthereumChain` payload against each network manually; document fallback "add it yourself" |
+| AppKit holds stale chain state after switch | Medium | Use `allowUnsupportedChain`; reinit AppKit network list on selection change |
+| Existing IndexedDB users break on schema v5 | Low | Dexie upgrade hook backfills `chainId = localnet`; existing data stays visible on localnet |
+| Hosted operator wants to disable the dropdown | Low | `VITE_LOCK_NETWORK=true` hides selector and forces `VITE_GENLAYER_NETWORK` |
+
+---
+
+## 7. Out of scope
+
+- Format-alignment work (that's `docs/plans/studio-testnet-format-alignment.md`). Plan assumes genlayer-js handles response-shape divergence. If it doesn't, that's a separate branch.
+- Per-network account scoping (accounts stay global — standard wallet behavior).
+- Sharing or importing a contract URL that encodes its network (`?network=bradbury&address=0x...`). Nice-to-have, defer.
+- Testnet block explorer deep-links from tx rows. Nice-to-have, defer.
+- Switching Studio's consensus contracts / staking contracts per network — those come from genlayer-js chain defs, already handled.
+
+---
+
+## 8. File change summary
+
+**New:**
+- `frontend/src/stores/network.ts`
+- `frontend/src/components/Global/NetworkSelector.vue`
+
+**Modified:**
+- `frontend/src/clients/rpc.ts` — reactive URL
+- `frontend/src/hooks/useWebSocketClient.ts` — reconnect API
+- `frontend/src/hooks/useGenlayer.ts` — watch network
+- `frontend/src/hooks/useChainEnforcer.ts` — triggerable from store action
+- `frontend/src/hooks/useAppKit.ts` — dynamic chain list
+- `frontend/src/hooks/useConfig.ts` — add `isStudioNetwork`
+- `frontend/src/hooks/useDb.ts` — Dexie v5 migration
+- `frontend/src/stores/contracts.ts` — chainId stamping, scoped getter
+- `frontend/src/stores/transactions.ts` — chainId stamping, scoped getter, scoped polling
+- `frontend/src/stores/tutorial.ts` — skip log injection on testnet
+- `frontend/src/components/Header.vue` — mount selector
+- `frontend/src/components/Simulator/AccountSelect.vue` — faucet swap
+- `frontend/src/components/Simulator/NodeLogs.vue` — hide on testnet
+- `frontend/src/components/Simulator/settings/ConsensusSection.vue` — read-only on testnet
+- `frontend/src/components/Simulator/settings/SimulatorSection.vue` — scoped reset label
+- `frontend/src/composables/useContractImport.ts` — scoped duplicate check
+- `.env.example` — add `VITE_LOCK_NETWORK`
+
+**Tests:**
+- `frontend/test/unit/stores/network.test.ts` (new)
+- `frontend/test/unit/hooks/useGenlayer.test.ts` — watcher behavior
+- `frontend/test/unit/hooks/useDb.test.ts` — migration
+- `frontend/test/e2e/` — parameterized specs per network
+
+---
+
+## 9. Rough estimate
+
+2–3 weeks of focused frontend work, assuming the Phase 0 verifications don't uncover SDK gaps:
+- Phase 1 (reactive transport): 2–3 days
+- Phase 2 (data scoping + migration): 3–4 days
+- Phase 3 (UI + wallet flow): 3–4 days
+- Phase 4 (degradation): 2–3 days
+- Phase 5 (polish + test): 2–3 days
+
+If SDK-level work is needed for testnet `gen_*` methods or response-shape normalization, add another 1–2 weeks.

--- a/docs/plans/studio-testnet-format-alignment.md
+++ b/docs/plans/studio-testnet-format-alignment.md
@@ -75,16 +75,32 @@ Studio needs to be updated so its transaction response format matches the testne
 
 ## GenLayer RPC Methods
 
-These methods exist in studio but NOT on testnet RPC:
+### Availability
 
-| Method | Studio | Testnet |
+| Method | Studio | Testnet (Bradbury / Asimov) |
 |---|---|---|
-| `gen_getContractCode` | Returns base64 contract source | **Not available** — `contractActions` throws "not supported on this network" |
-| `gen_getContractSchema` | Returns JSON schema | **Not available** — same |
-| `gen_getContractSchemaForCode` | Returns schema for code string | **Not available** — same |
-| `gen_call` | Returns bare hex string (e.g. `"818080a8..."`) | Returns object: `{"data": "818080...", "eqOutputs": [], "status": {"code": 0, "message": "success"}, "stdout": "", "stderr": "", "logs": [...]}` |
+| `gen_getContractCode` | Available — param: `address` | Available — param: `{ address }` |
+| `gen_getContractSchema` | Available — param: `address`, returns schema for contract deployed at that address | **Available but semantically different** — param: `{ code }` (base64), returns schema for the supplied code. See "Schema method divergence" below. |
+| `gen_getContractSchemaForCode` | Available — param: hex or UTF-8 contract code | **Not available** under this name — node exposes equivalent behavior as `gen_getContractSchema` (see below) |
+| `gen_call` | Returns bare hex string (e.g. `"818080a8..."`) | Returns object: `{"data": "818080...", "eqOutputs": [], "status": {"code": 0, "message": "success"}, "stdout": "", "stderr": "", "logs": [...]}`. Normalized in `genlayer-js` via `extractGenCallResult` |
 | `sim_call` | Simulates with full state | **Not available** — studio-only |
 | `sim_cancelTransaction` | Cancels pending tx | **Not available** — studio-only |
+| `sim_lintContract` | Lints contract source | **Not available** — studio-only |
+
+### Schema method divergence
+
+`gen_getContractSchema` and `gen_getContractSchemaForCode` share names across implementations but have different parameters and semantics:
+
+| Behavior | Studio | Node (Bradbury / Asimov) |
+|---|---|---|
+| "Give me the schema of the contract deployed at address X" | `gen_getContractSchema(address)` — 1 call | No direct method. Requires 2 calls: `gen_getContractCode({address})` → `gen_getContractSchema({code})` |
+| "Give me the schema for this source code" | `gen_getContractSchemaForCode(hex_or_utf8)` | `gen_getContractSchema({base64_code})` |
+| Studio impl | `backend/protocol_rpc/endpoints.py:817-857` (reads `ContractSnapshot`, decodes stored b64, compiles) | Node takes code directly as the input payload |
+
+**Resolution path:**
+
+1. **Short term — hide divergence in `genlayer-js`.** Patch the SDK so `getContractSchema(address)` works on any chain: on Studio, call `gen_getContractSchema(address)` directly; on the node, do the 2-call dance internally (`gen_getContractCode` → `gen_getContractSchema({code})`). Same for `getContractSchemaForCode`. Remove the existing `if (!isStudio) throw` guards. Unblocks multi-network UIs (e.g. Studio frontend running against testnet) immediately without any protocol-level change.
+2. **Long term — align at the protocol level.** Studio's address-based `gen_getContractSchema` is arguably the more useful primitive (address is what a consumer typically has; the lookup is on the server anyway). TBD whether Studio adopts node semantics or vice-versa. Once aligned, the SDK workaround in (1) is removed and both sides speak the same protocol.
 
 ## Status Enums
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -24,7 +24,7 @@
         "cross-env": "^10.0.0",
         "dexie": "^4.0.4",
         "floating-vue": "^5.2.2",
-        "genlayer-js": "^1.1.0",
+        "genlayer-js": "^1.1.1",
         "hash-sum": "^2.0.0",
         "jump.js": "^1.0.2",
         "lodash-es": "^4.17.21",
@@ -1564,9 +1564,9 @@
       "peer": true
     },
     "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -8738,14 +8738,14 @@
       }
     },
     "node_modules/call-bind": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
-      "integrity": "sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==",
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.9.tgz",
+      "integrity": "sha512-a/hy+pNsFUTR+Iz8TCJvXudKVLAnz/DyeSUo10I5yvFDQJBFU2s9uqQpoSrJlroHUKoKqzg+epxyP9lqFdzfBQ==",
       "license": "MIT",
       "dependencies": {
-        "call-bind-apply-helpers": "^1.0.0",
-        "es-define-property": "^1.0.0",
-        "get-intrinsic": "^1.2.4",
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "get-intrinsic": "^1.3.0",
         "set-function-length": "^1.2.2"
       },
       "engines": {
@@ -10055,9 +10055,9 @@
       "license": "MIT"
     },
     "node_modules/es-abstract": {
-      "version": "1.24.1",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.24.1.tgz",
-      "integrity": "sha512-zHXBLhP+QehSSbsS9Pt23Gg964240DPd6QCf8WpkqEXxQ7fhdZzYsocOr5u7apWonsS5EjZDmTF+/slGMyasvw==",
+      "version": "1.24.2",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.24.2.tgz",
+      "integrity": "sha512-2FpH9Q5i2RRwyEP1AylXe6nYLR5OhaJTZwmlcP0dL/+JCbgg7yyEo/sEK6HeGZRf3dFpWwThaRHVApXSkW3xeg==",
       "license": "MIT",
       "dependencies": {
         "array-buffer-byte-length": "^1.0.2",
@@ -10366,14 +10366,14 @@
       }
     },
     "node_modules/eslint-import-resolver-node": {
-      "version": "0.3.9",
-      "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.9.tgz",
-      "integrity": "sha512-WFj2isz22JahUv+B788TlO3N6zL3nNJGU8CcZbPZvVEkBPaJdCV4vy5wyghty5ROFbCRnm132v8BScu5/1BQ8g==",
+      "version": "0.3.10",
+      "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.10.tgz",
+      "integrity": "sha512-tRrKqFyCaKict5hOd244sL6EQFNycnMQnBe+j8uqGNXYzsImGbGUU4ibtoaBmv5FLwJwcFJNeg1GeVjQfbMrDQ==",
       "license": "MIT",
       "dependencies": {
         "debug": "^3.2.7",
-        "is-core-module": "^2.13.0",
-        "resolve": "^1.22.4"
+        "is-core-module": "^2.16.1",
+        "resolve": "^2.0.0-next.6"
       }
     },
     "node_modules/eslint-import-resolver-node/node_modules/debug": {
@@ -10383,6 +10383,29 @@
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.1"
+      }
+    },
+    "node_modules/eslint-import-resolver-node/node_modules/resolve": {
+      "version": "2.0.0-next.6",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-2.0.0-next.6.tgz",
+      "integrity": "sha512-3JmVl5hMGtJ3kMmB3zi3DL25KfkCEyy3Tw7Gmw7z5w8M9WlwoPFnIvwChzu1+cF3iaK3sp18hhPz8ANeimdJfA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "is-core-module": "^2.16.1",
+        "node-exports-info": "^1.6.0",
+        "object-keys": "^1.1.1",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/eslint-module-utils": {
@@ -11134,9 +11157,9 @@
       }
     },
     "node_modules/genlayer-js": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/genlayer-js/-/genlayer-js-1.1.0.tgz",
-      "integrity": "sha512-z84pfwc3VUhuylcO7p+RdUvrr0WDuCK9sZWKofsfDC00mzQCYI0xFjjjqg4A8gGj/RDQZhPztDt6LQjwtAU7tQ==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/genlayer-js/-/genlayer-js-1.1.1.tgz",
+      "integrity": "sha512-DNKfr/E0eDigBHZ6dUx3ViCm67UJzsA9qTEmsBBPP12EnNwslo8xBobjKG2SLEni0kWVDRo8aJGeg2TBgeUy7w==",
       "license": "MIT",
       "dependencies": {
         "eslint-plugin-import": "^2.30.0",
@@ -11249,9 +11272,9 @@
       "license": "MIT"
     },
     "node_modules/genlayer-js/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -14044,6 +14067,33 @@
         "ncp": "bin/ncp"
       }
     },
+    "node_modules/node-exports-info": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/node-exports-info/-/node-exports-info-1.6.0.tgz",
+      "integrity": "sha512-pyFS63ptit/P5WqUkt+UUfe+4oevH+bFeIiPPdfb0pFeYEu/1ELnJu5l+5EcTKYL5M7zaAa7S8ddywgXypqKCw==",
+      "license": "MIT",
+      "dependencies": {
+        "array.prototype.flatmap": "^1.3.3",
+        "es-errors": "^1.3.0",
+        "object.entries": "^1.1.9",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/node-exports-info/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
     "node_modules/node-fetch": {
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
@@ -14420,6 +14470,21 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/object.entries": {
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.9.tgz",
+      "integrity": "sha512-8u/hfXFRBD1O0hPUjioLhoWFHRmt6tKA4/vZPyckBr18l1KE9uHrFaFaUi8MDRTpi4uak2goyPTSNJLXX2k2Hw==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/object.fromentries": {
@@ -16397,14 +16462,14 @@
       "license": "0BSD"
     },
     "node_modules/safe-array-concat": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.1.3.tgz",
-      "integrity": "sha512-AURm5f0jYEOydBj7VQlVvDrjeFgthDdEF5H1dP+6mNpoXOMo1quQqJ4wvJDyRZ9+pO3kGWoOdmV08cSv2aJV6Q==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.1.4.tgz",
+      "integrity": "sha512-wtZlHyOje6OZTGqAoaDKxFkgRtkF9CnHAVnCHKfuj200wAgL+bSJhdsCD2l0Qx/2ekEXjPWcyKkfGb5CPboslg==",
       "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.8",
-        "call-bound": "^1.0.2",
-        "get-intrinsic": "^1.2.6",
+        "call-bind": "^1.0.9",
+        "call-bound": "^1.0.4",
+        "get-intrinsic": "^1.3.0",
         "has-symbols": "^1.1.0",
         "isarray": "^2.0.5"
       },

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -24,7 +24,7 @@
         "cross-env": "^10.0.0",
         "dexie": "^4.0.4",
         "floating-vue": "^5.2.2",
-        "genlayer-js": "^0.28.4",
+        "genlayer-js": "^1.1.0",
         "hash-sum": "^2.0.0",
         "jump.js": "^1.0.2",
         "lodash-es": "^4.17.21",
@@ -11134,9 +11134,9 @@
       }
     },
     "node_modules/genlayer-js": {
-      "version": "0.28.4",
-      "resolved": "https://registry.npmjs.org/genlayer-js/-/genlayer-js-0.28.4.tgz",
-      "integrity": "sha512-+WotNwT6w41eN78s0oivkrWuo/VepE/m1PxSzIYdF/91TjeJsXzh94NRc3tQkLhbDdaGj0SNM60o+4ah7OWopw==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/genlayer-js/-/genlayer-js-1.1.0.tgz",
+      "integrity": "sha512-z84pfwc3VUhuylcO7p+RdUvrr0WDuCK9sZWKofsfDC00mzQCYI0xFjjjqg4A8gGj/RDQZhPztDt6LQjwtAU7tQ==",
       "license": "MIT",
       "dependencies": {
         "eslint-plugin-import": "^2.30.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -39,7 +39,7 @@
     "cross-env": "^10.0.0",
     "dexie": "^4.0.4",
     "floating-vue": "^5.2.2",
-    "genlayer-js": "^1.1.0",
+    "genlayer-js": "^1.1.1",
     "hash-sum": "^2.0.0",
     "jump.js": "^1.0.2",
     "lodash-es": "^4.17.21",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -39,7 +39,7 @@
     "cross-env": "^10.0.0",
     "dexie": "^4.0.4",
     "floating-vue": "^5.2.2",
-    "genlayer-js": "^0.28.4",
+    "genlayer-js": "^1.1.0",
     "hash-sum": "^2.0.0",
     "jump.js": "^1.0.2",
     "lodash-es": "^4.17.21",

--- a/frontend/src/clients/rpc.ts
+++ b/frontend/src/clients/rpc.ts
@@ -1,12 +1,7 @@
 import type { JsonRPCRequest, JsonRPCResponse } from '@/types';
 import { v4 as uuidv4 } from 'uuid';
 import { useWebSocketClient } from '@/hooks';
-import { getRuntimeConfig } from '@/utils/runtimeConfig';
-
-const JSON_RPC_SERVER_URL = getRuntimeConfig(
-  'VITE_JSON_RPC_SERVER_URL',
-  'http://127.0.0.1:4000/api',
-);
+import { useNetworkStore } from '@/stores/network';
 
 export interface IRpcClient {
   call<T>(request: JsonRPCRequest): Promise<JsonRPCResponse<T>>;
@@ -17,17 +12,26 @@ export class RpcClient implements IRpcClient {
     method,
     params,
   }: JsonRPCRequest): Promise<JsonRPCResponse<T>> {
-    const webSocketClient = useWebSocketClient();
-    // Wait for the websocket client to connect
-    await new Promise<void>((resolve) => {
-      if (webSocketClient.connected) {
-        resolve();
-      } else {
-        webSocketClient.on('connect', () => {
+    const networkStore = useNetworkStore();
+    const endpoint = networkStore.rpcUrl;
+    const headers: Record<string, string> = {
+      'Content-Type': 'application/json',
+    };
+
+    // WebSocket session ID is only meaningful on Studio (no WS on testnets).
+    if (networkStore.isStudio) {
+      const webSocketClient = useWebSocketClient();
+      await new Promise<void>((resolve) => {
+        if (webSocketClient.connected) {
           resolve();
-        });
-      }
-    });
+        } else {
+          webSocketClient.on('connect', () => {
+            resolve();
+          });
+        }
+      });
+      headers['x-session-id'] = webSocketClient.id ?? '';
+    }
 
     const requestId = uuidv4();
     const data = {
@@ -36,12 +40,9 @@ export class RpcClient implements IRpcClient {
       params,
       id: requestId,
     };
-    const response = await fetch(JSON_RPC_SERVER_URL, {
+    const response = await fetch(endpoint, {
       method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        'x-session-id': webSocketClient.id ?? '',
-      },
+      headers,
       body: JSON.stringify(data),
     });
     return response.json() as Promise<JsonRPCResponse<T>>;

--- a/frontend/src/clients/rpc.ts
+++ b/frontend/src/clients/rpc.ts
@@ -1,11 +1,16 @@
 import type { JsonRPCRequest, JsonRPCResponse } from '@/types';
-import { v4 as uuidv4 } from 'uuid';
 import { useWebSocketClient } from '@/hooks';
 import { useNetworkStore } from '@/stores/network';
 
 export interface IRpcClient {
   call<T>(request: JsonRPCRequest): Promise<JsonRPCResponse<T>>;
 }
+
+// JSON-RPC 2.0 allows string or number ids, but the Go node we talk to on
+// Bradbury/Asimov rejects strings (`cannot unmarshal string into Go struct
+// field Request.id of type int`). Use a monotonic counter to stay compatible
+// with both the Studio Python backend and Go testnet nodes.
+let nextRequestId = 1;
 
 export class RpcClient implements IRpcClient {
   async call<T>({
@@ -33,12 +38,11 @@ export class RpcClient implements IRpcClient {
       headers['x-session-id'] = webSocketClient.id ?? '';
     }
 
-    const requestId = uuidv4();
     const data = {
       jsonrpc: '2.0',
       method,
       params,
-      id: requestId,
+      id: nextRequestId++,
     };
     const response = await fetch(endpoint, {
       method: 'POST',

--- a/frontend/src/components/Header.vue
+++ b/frontend/src/components/Header.vue
@@ -5,6 +5,7 @@ import { useUIStore } from '@/stores';
 import { RouterLink } from 'vue-router';
 import Logo from '@/assets/images/logo.svg';
 import GhostBtn from './global/GhostBtn.vue';
+import NetworkSelector from './global/NetworkSelector.vue';
 import AccountSelect from '@/components/Simulator/AccountSelect.vue';
 
 const uiStore = useUIStore();
@@ -34,6 +35,8 @@ const showTutorial = () => {
     </RouterLink>
 
     <div class="flex items-center gap-2 pr-2">
+      <NetworkSelector />
+
       <AccountSelect />
 
       <GhostBtn @click="toggleMode" v-tooltip="'Switch theme'">

--- a/frontend/src/components/Simulator/AccountSelect.vue
+++ b/frontend/src/components/Simulator/AccountSelect.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { useAccountsStore } from '@/stores';
+import { useAccountsStore, useNetworkStore } from '@/stores';
 import AccountItem from '@/components/Simulator/AccountItem.vue';
 import { Dropdown } from 'floating-vue';
 import { Wallet, Droplets } from 'lucide-vue-next';
@@ -9,9 +9,12 @@ import { useEventTracking, useWallet, useRpcClient } from '@/hooks';
 import { computed, ref, watch, onMounted } from 'vue';
 
 const store = useAccountsStore();
+const networkStore = useNetworkStore();
 const { trackEvent } = useEventTracking();
 const { connect, disconnect } = useWallet();
 const rpcClient = useRpcClient();
+
+const PUBLIC_TESTNET_FAUCET_URL = 'https://testnet-faucet.genlayer.foundation';
 
 const hasExternalAccount = computed(() =>
   store.accounts.some((account) => account.type === 'external'),
@@ -42,7 +45,12 @@ const refreshBalance = async () => {
 
 // Fetch balance on load and when account changes
 watch(() => store.selectedAccount?.address, refreshBalance);
+watch(() => networkStore.chainId, refreshBalance);
 onMounted(refreshBalance);
+
+const openTestnetFaucet = () => {
+  window.open(PUBLIC_TESTNET_FAUCET_URL, '_blank', 'noopener,noreferrer');
+};
 
 const handleCreateNewAccount = async () => {
   const address = store.generateNewAccount();
@@ -167,7 +175,11 @@ const disconnectWallet = async () => {
       </template>
     </Dropdown>
 
-    <Dropdown placement="bottom-end" :shown="showFaucet">
+    <Dropdown
+      v-if="networkStore.isStudio"
+      placement="bottom-end"
+      :shown="showFaucet"
+    >
       <button
         @click="showFaucet = !showFaucet"
         v-tooltip="'Fund account'"
@@ -205,5 +217,16 @@ const disconnectWallet = async () => {
         </div>
       </template>
     </Dropdown>
+
+    <button
+      v-else
+      @click="openTestnetFaucet"
+      v-tooltip="
+        'Open the testnet faucet (100 GEN / 24h, requires 0.01 ETH on mainnet)'
+      "
+      class="rounded p-1 text-gray-500 transition-colors hover:bg-gray-100 hover:text-gray-700 dark:text-gray-400 dark:hover:bg-zinc-700 dark:hover:text-gray-200"
+    >
+      <Droplets class="h-4 w-4" />
+    </button>
   </div>
 </template>

--- a/frontend/src/components/Simulator/TransactionItem.vue
+++ b/frontend/src/components/Simulator/TransactionItem.vue
@@ -239,6 +239,8 @@ const badgeColorClass = computed(() => {
     return '!bg-red-500';
   } else if (executionResult === 6) {
     return '!bg-green-500';
+  } else if (status === 'ACCEPTED') {
+    return '!bg-green-500';
   } else if (status === 'FINALIZED') {
     return '!bg-red-500';
   }

--- a/frontend/src/components/Tutorial/TutorialContainer.vue
+++ b/frontend/src/components/Tutorial/TutorialContainer.vue
@@ -103,7 +103,7 @@ const steps = ref([
       title: 'Validators',
     },
     target: '#tutorial-validators',
-    content: canUpdateValidators
+    content: canUpdateValidators.value
       ? 'Configure the number of validators and set up their parameters here.'
       : 'Here you can see the validators that are currently running on the network.',
     placement: 'right',

--- a/frontend/src/components/global/NetworkSelector.vue
+++ b/frontend/src/components/global/NetworkSelector.vue
@@ -1,0 +1,113 @@
+<script setup lang="ts">
+import { Dropdown } from 'floating-vue';
+import { CheckIcon } from '@heroicons/vue/16/solid';
+import { Network, AlertTriangle } from 'lucide-vue-next';
+import { notify } from '@kyvg/vue3-notification';
+import {
+  useNetworkStore,
+  useTransactionsStore,
+  type NetworkName,
+} from '@/stores';
+import { useChainEnforcer } from '@/hooks';
+import { ref, computed } from 'vue';
+
+const networkStore = useNetworkStore();
+const transactionsStore = useTransactionsStore();
+const { ensureCorrectChain, isExternalWallet } = useChainEnforcer();
+
+const isSwitching = ref(false);
+
+const active = computed(() =>
+  networkStore.availableNetworks.find(
+    (n) => n.name === networkStore.currentNetwork,
+  ),
+);
+
+const pendingOnCurrentNetwork = computed(
+  () =>
+    transactionsStore.transactions.filter(
+      (t) => t.statusName !== 'FINALIZED' && t.statusName !== 'CANCELED',
+    ).length,
+);
+
+async function switchNetwork(name: NetworkName) {
+  if (name === networkStore.currentNetwork || isSwitching.value) return;
+
+  const previous = networkStore.currentNetwork;
+  isSwitching.value = true;
+  try {
+    networkStore.setCurrentNetwork(name);
+
+    if (isExternalWallet.value) {
+      await ensureCorrectChain();
+    }
+
+    notify({
+      title: `Switched to ${networkStore.chainName}`,
+      type: 'success',
+    });
+  } catch (err: any) {
+    // Wallet rejected or some other failure — revert.
+    networkStore.setCurrentNetwork(previous);
+    notify({
+      title: 'Network switch canceled',
+      text:
+        err?.message ??
+        'The wallet remained on the previous network. Try again or switch manually.',
+      type: 'error',
+    });
+  } finally {
+    isSwitching.value = false;
+  }
+}
+</script>
+
+<template>
+  <Dropdown v-if="!networkStore.isLocked" placement="bottom-end">
+    <GhostBtn v-tooltip="'Switch network'">
+      <Network class="h-4 w-4" />
+      <span class="text-sm">{{ active?.label ?? networkStore.chainName }}</span>
+      <AlertTriangle
+        v-if="!networkStore.isStudio"
+        class="h-3.5 w-3.5 text-amber-500"
+        v-tooltip="
+          'Testnet — Studio features (logs, validators, faucet) are disabled.'
+        "
+      />
+    </GhostBtn>
+
+    <template #popper>
+      <div class="min-w-[260px] p-1">
+        <div class="px-2 py-1 text-xs uppercase text-gray-500">
+          Connect studio to
+        </div>
+        <button
+          v-for="n in networkStore.availableNetworks"
+          :key="n.name"
+          class="group flex w-full items-center justify-between rounded px-2 py-2 text-left text-sm hover:bg-gray-100 disabled:opacity-50 dark:hover:bg-zinc-700"
+          :disabled="isSwitching"
+          @click="switchNetwork(n.name)"
+          v-close-popper
+        >
+          <div class="flex flex-col">
+            <span class="font-medium">{{ n.label }}</span>
+            <span class="font-mono text-[10px] text-gray-500">
+              chain {{ n.chainId }} · {{ n.isStudio ? 'local' : 'testnet' }}
+            </span>
+          </div>
+          <CheckIcon
+            v-if="n.name === networkStore.currentNetwork"
+            class="h-4 w-4 text-green-500"
+          />
+        </button>
+        <div
+          v-if="!networkStore.isStudio && pendingOnCurrentNetwork > 0"
+          class="mx-1 mt-1 border-t border-gray-200 px-2 pt-2 text-[11px] text-amber-600 dark:border-gray-700"
+        >
+          {{ pendingOnCurrentNetwork }} pending transaction(s) on the current
+          network will be hidden after switching.
+        </div>
+      </div>
+    </template>
+  </Dropdown>
+</template>

--- a/frontend/src/hooks/useAppKit.ts
+++ b/frontend/src/hooks/useAppKit.ts
@@ -33,6 +33,14 @@ function makeStrictJsonRpcTransport(rpcUrl: string) {
   });
 }
 
+function getDefaultRpcUrl(network: AppKitNetwork) {
+  const rpcUrl = network.rpcUrls.default.http[0];
+  if (!rpcUrl) {
+    throw new Error(`Missing default RPC URL for ${network.name}`);
+  }
+  return rpcUrl;
+}
+
 export const wagmiAdapterRef = shallowRef<WagmiAdapter>();
 export let appKitReady = false;
 
@@ -81,10 +89,10 @@ export async function initAppKit() {
     networks,
     transports: {
       [genlayerLocalnet.id]: makeStrictJsonRpcTransport(
-        genlayerLocalnet.rpcUrls.default.http[0],
+        getDefaultRpcUrl(genlayerLocalnet),
       ),
       [genlayerBradbury.id]: makeStrictJsonRpcTransport(
-        genlayerBradbury.rpcUrls.default.http[0],
+        getDefaultRpcUrl(genlayerBradbury),
       ),
     },
     ssr: false,

--- a/frontend/src/hooks/useAppKit.ts
+++ b/frontend/src/hooks/useAppKit.ts
@@ -11,17 +11,65 @@ import { createGenlayerLocalnet, createGenlayerBradbury } from './useNetworks';
 // transport paths in viem/Wagmi/Reown surface a body without `id` (the field
 // is added by the http transport, but batching/retry can drop it on certain
 // paths). Wrap our chain RPCs in a custom transport that guarantees both.
+const RPC_REQUEST_TIMEOUT_MS = 30_000;
 let rpcIdCounter = 1;
+
+function getRpcErrorPreview(text: string) {
+  return text.length > 200 ? `${text.slice(0, 200)}...` : text;
+}
+
 function makeStrictJsonRpcTransport(rpcUrl: string) {
   return custom({
     async request({ method, params }) {
       const id = rpcIdCounter++;
-      const res = await fetch(rpcUrl, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ jsonrpc: '2.0', id, method, params }),
-      });
-      const json = await res.json();
+      const controller = new AbortController();
+      const timeout = window.setTimeout(
+        () => controller.abort(),
+        RPC_REQUEST_TIMEOUT_MS,
+      );
+
+      let res: Response;
+      try {
+        res = await fetch(rpcUrl, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ jsonrpc: '2.0', id, method, params }),
+          signal: controller.signal,
+        });
+      } catch (cause: any) {
+        const err: any = new Error(
+          cause?.name === 'AbortError'
+            ? `RPC request timed out after ${RPC_REQUEST_TIMEOUT_MS}ms`
+            : (cause?.message ?? 'RPC request failed'),
+        );
+        err.cause = cause;
+        throw err;
+      } finally {
+        window.clearTimeout(timeout);
+      }
+
+      if (!res.ok) {
+        const text = await res.text().catch(() => '');
+        throw new Error(
+          `RPC HTTP ${res.status} ${res.statusText}${
+            text ? `: ${getRpcErrorPreview(text)}` : ''
+          }`,
+        );
+      }
+
+      let json: any;
+      try {
+        json = await res.json();
+      } catch (cause: any) {
+        const err: any = new Error(
+          `RPC response was not valid JSON${
+            cause?.message ? `: ${cause.message}` : ''
+          }`,
+        );
+        err.cause = cause;
+        throw err;
+      }
+
       if (json.error) {
         const err: any = new Error(json.error.message ?? 'RPC error');
         err.code = json.error.code;

--- a/frontend/src/hooks/useAppKit.ts
+++ b/frontend/src/hooks/useAppKit.ts
@@ -4,7 +4,7 @@ import { createAppKit } from '@reown/appkit/vue';
 import type { AppKitNetwork } from '@reown/appkit/networks';
 import { mainnet, sepolia } from '@reown/appkit/networks';
 import { getRuntimeConfig } from '@/utils/runtimeConfig';
-import { createGenlayerLocalnet } from './useNetworks';
+import { createGenlayerLocalnet, createGenlayerBradbury } from './useNetworks';
 
 export const wagmiAdapterRef = shallowRef<WagmiAdapter>();
 export let appKitReady = false;
@@ -40,9 +40,11 @@ export async function initAppKit() {
   }
 
   const genlayerLocalnet = createGenlayerLocalnet();
+  const genlayerBradbury = createGenlayerBradbury();
 
   const networks: [AppKitNetwork, ...AppKitNetwork[]] = [
     genlayerLocalnet,
+    genlayerBradbury,
     mainnet,
     sepolia,
   ];

--- a/frontend/src/hooks/useAppKit.ts
+++ b/frontend/src/hooks/useAppKit.ts
@@ -3,8 +3,35 @@ import { WagmiAdapter } from '@reown/appkit-adapter-wagmi';
 import { createAppKit } from '@reown/appkit/vue';
 import type { AppKitNetwork } from '@reown/appkit/networks';
 import { mainnet, sepolia } from '@reown/appkit/networks';
+import { custom } from 'viem';
 import { getRuntimeConfig } from '@/utils/runtimeConfig';
 import { createGenlayerLocalnet, createGenlayerBradbury } from './useNetworks';
+
+// GenLayer's Go RPC server rejects requests missing `jsonrpc` or `id`. Some
+// transport paths in viem/Wagmi/Reown surface a body without `id` (the field
+// is added by the http transport, but batching/retry can drop it on certain
+// paths). Wrap our chain RPCs in a custom transport that guarantees both.
+let rpcIdCounter = 1;
+function makeStrictJsonRpcTransport(rpcUrl: string) {
+  return custom({
+    async request({ method, params }) {
+      const id = rpcIdCounter++;
+      const res = await fetch(rpcUrl, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ jsonrpc: '2.0', id, method, params }),
+      });
+      const json = await res.json();
+      if (json.error) {
+        const err: any = new Error(json.error.message ?? 'RPC error');
+        err.code = json.error.code;
+        err.data = json.error.data;
+        throw err;
+      }
+      return json.result;
+    },
+  });
+}
 
 export const wagmiAdapterRef = shallowRef<WagmiAdapter>();
 export let appKitReady = false;
@@ -52,6 +79,14 @@ export async function initAppKit() {
   const adapter = new GenlayerWagmiAdapter({
     projectId,
     networks,
+    transports: {
+      [genlayerLocalnet.id]: makeStrictJsonRpcTransport(
+        genlayerLocalnet.rpcUrls.default.http[0],
+      ),
+      [genlayerBradbury.id]: makeStrictJsonRpcTransport(
+        genlayerBradbury.rpcUrls.default.http[0],
+      ),
+    },
     ssr: false,
   });
 

--- a/frontend/src/hooks/useChainEnforcer.ts
+++ b/frontend/src/hooks/useChainEnforcer.ts
@@ -1,46 +1,56 @@
 import { computed } from 'vue';
 import { numberToHex } from 'viem';
 import { useAccountsStore } from '@/stores';
+import { useNetworkStore } from '@/stores/network';
 import { useWallet } from './useWallet';
-import { useGenlayer } from './useGenlayer';
-import {
-  getRuntimeConfig,
-  getRuntimeConfigNumber,
-} from '@/utils/runtimeConfig';
+import { getRuntimeConfig } from '@/utils/runtimeConfig';
 
 /**
  * Ensures the connected external wallet is on the correct chain
  * before sending a transaction. For local accounts this is a no-op.
  *
- * Uses VITE_CHAIN_ID for the target chain (each Studio instance has
- * its own chain ID), falling back to the SDK client's chain ID.
- * Uses VITE_JSON_RPC_SERVER_URL for the RPC URL when adding the
- * network to MetaMask.
+ * Chain info comes from the network store; an explicit `target` can be
+ * supplied when switching network via the UI selector (so we enforce
+ * the new chain before the SDK client re-inits).
  */
 export function useChainEnforcer() {
   const accountsStore = useAccountsStore();
+  const networkStore = useNetworkStore();
   const wallet = useWallet();
-  const genlayer = useGenlayer();
 
   const isExternalWallet = computed(
     () => accountsStore.selectedAccount?.type === 'external',
   );
 
-  async function ensureCorrectChain() {
+  async function ensureCorrectChain(target?: {
+    chainId: number;
+    chainName: string;
+    rpcUrl: string;
+    nativeCurrency?: {
+      name: string;
+      symbol: string;
+      decimals: number;
+    };
+  }): Promise<void> {
     if (!isExternalWallet.value) return;
 
     const provider = wallet.walletProvider.value;
     if (!provider?.request) return;
 
-    const client = genlayer.client.value;
-    if (!client?.chain) return;
-
-    // Use per-deployment chain ID (each Studio instance has its own),
-    // falling back to SDK chain ID
-    const targetChainId = getRuntimeConfigNumber(
-      'VITE_CHAIN_ID',
-      client.chain.id,
-    );
+    const chain = networkStore.chain;
+    const targetChainId = target?.chainId ?? networkStore.chainId;
+    const defaultHttpRpc = chain.rpcUrls?.default?.http?.[0] ?? '';
+    const rpcUrl =
+      target?.rpcUrl ??
+      (networkStore.isStudio
+        ? getRuntimeConfig('VITE_JSON_RPC_SERVER_URL', defaultHttpRpc)
+        : defaultHttpRpc);
+    const chainName =
+      target?.chainName ??
+      (networkStore.isStudio
+        ? getRuntimeConfig('VITE_CHAIN_NAME', chain.name)
+        : chain.name);
+    const nativeCurrency = target?.nativeCurrency ?? chain.nativeCurrency;
 
     const currentChainHex = (await provider.request({
       method: 'eth_chainId',
@@ -58,18 +68,13 @@ export function useChainEnforcer() {
       });
     } catch (switchError: any) {
       if (switchError.code === 4902) {
-        const chain = client.chain;
-        const rpcUrl = getRuntimeConfig(
-          'VITE_JSON_RPC_SERVER_URL',
-          chain.rpcUrls?.default?.http?.[0] ?? '',
-        );
         await provider.request({
           method: 'wallet_addEthereumChain',
           params: [
             {
               chainId: targetChainHex,
-              chainName: getRuntimeConfig('VITE_CHAIN_NAME', chain.name),
-              nativeCurrency: chain.nativeCurrency,
+              chainName,
+              nativeCurrency,
               rpcUrls: [rpcUrl],
             },
           ],
@@ -93,5 +98,5 @@ export function useChainEnforcer() {
     }
   }
 
-  return { ensureCorrectChain };
+  return { ensureCorrectChain, isExternalWallet };
 }

--- a/frontend/src/hooks/useConfig.ts
+++ b/frontend/src/hooks/useConfig.ts
@@ -1,12 +1,27 @@
+import { computed } from 'vue';
 import { getRuntimeConfigBoolean } from '@/utils/runtimeConfig';
+import { useNetworkStore } from '@/stores/network';
 
 export const useConfig = () => {
   const isHostedEnvironment = getRuntimeConfigBoolean('VITE_IS_HOSTED', false);
-  const canUpdateValidators = !isHostedEnvironment;
-  const canUpdateProviders = !isHostedEnvironment;
-  const canUpdateFinalityWindow = !isHostedEnvironment;
+  const networkStore = useNetworkStore();
+
+  // Studio-only features: validator / provider / finality editors depend on
+  // `sim_*` RPC methods that only the Studio backend exposes. Disabled in
+  // hosted environments and on any non-Studio network (e.g. Bradbury).
+  const isStudioNetwork = computed(() => networkStore.isStudio);
+  const canUpdateValidators = computed(
+    () => !isHostedEnvironment && isStudioNetwork.value,
+  );
+  const canUpdateProviders = computed(
+    () => !isHostedEnvironment && isStudioNetwork.value,
+  );
+  const canUpdateFinalityWindow = computed(
+    () => !isHostedEnvironment && isStudioNetwork.value,
+  );
 
   return {
+    isStudioNetwork,
     canUpdateValidators,
     canUpdateProviders,
     canUpdateFinalityWindow,

--- a/frontend/src/hooks/useContractListener.ts
+++ b/frontend/src/hooks/useContractListener.ts
@@ -1,13 +1,56 @@
-import { useContractsStore, useTransactionsStore } from '@/stores';
+import { watch } from 'vue';
+import { isAddress } from 'viem';
+import {
+  useContractsStore,
+  useTransactionsStore,
+  useNetworkStore,
+} from '@/stores';
 import { useWebSocketClient } from '@/hooks';
 
 export function useContractListener() {
   const contractsStore = useContractsStore();
   const transactionsStore = useTransactionsStore();
+  const networkStore = useNetworkStore();
   const webSocketClient = useWebSocketClient();
 
   function init() {
     webSocketClient.on('deployed_contract', handleContractDeployed);
+
+    // Non-Studio chains have no `deployed_contract` WS push. Watch the local
+    // transactions array — once a deploy tx lands with a non-zero recipient
+    // (the consensus contract emits the new ghost address there), register
+    // the contract so the user can interact with it.
+    watch(
+      () =>
+        transactionsStore.transactions.map((t) => ({
+          hash: t.hash,
+          type: t.type,
+          statusName: t.statusName,
+          localContractId: t.localContractId,
+          recipient: (t.data as any)?.recipient,
+        })),
+      (current) => {
+        if (networkStore.isStudio) return;
+        for (const tx of current) {
+          if (tx.type !== 'deploy') continue;
+          if (tx.statusName !== 'ACCEPTED' && tx.statusName !== 'FINALIZED')
+            continue;
+          if (!tx.recipient || !isAddress(tx.recipient)) continue;
+          // Skip if already registered for this localContractId+address.
+          const already = contractsStore.deployedContracts.find(
+            (c) =>
+              c.contractId === tx.localContractId && c.address === tx.recipient,
+          );
+          if (already) continue;
+          contractsStore.addDeployedContract({
+            contractId: tx.localContractId,
+            address: tx.recipient,
+            defaultState: '{}',
+          });
+        }
+      },
+      { deep: true, immediate: true },
+    );
   }
 
   async function handleContractDeployed(eventData: any) {

--- a/frontend/src/hooks/useDb.ts
+++ b/frontend/src/hooks/useDb.ts
@@ -1,5 +1,17 @@
 import type { ContractFile, DeployedContract, TransactionItem } from '@/types';
 import Dexie, { type Table } from 'dexie';
+import { localnet } from 'genlayer-js/chains';
+import { getRuntimeConfigNumber } from '@/utils/runtimeConfig';
+
+/**
+ * Chain ID used to backfill existing (pre-v5) records that were created
+ * before the frontend knew about multi-network support. Defaults to the
+ * build-time `VITE_CHAIN_ID` (operator-configured Studio instance) and
+ * falls back to the SDK's localnet chain ID.
+ */
+function getLegacyChainId(): number {
+  return getRuntimeConfigNumber('VITE_CHAIN_ID', localnet.id);
+}
 
 class GenLayerSimulatorDB extends Dexie {
   contractFiles!: Table<ContractFile>;
@@ -51,6 +63,29 @@ class GenLayerSimulatorDB extends Dexie {
               transaction.statusName = transaction.status;
               delete transaction.status;
             }
+          });
+      });
+
+    this.version(5)
+      .stores({
+        contractFiles: 'id',
+        deployedContracts: '[contractId+address], chainId',
+        transactions:
+          '++id, type, statusName, contractAddress, localContractId, hash, chainId',
+      })
+      .upgrade(async (tx) => {
+        const chainId = getLegacyChainId();
+        await tx
+          .table('deployedContracts')
+          .toCollection()
+          .modify((dc) => {
+            if (dc.chainId === undefined) dc.chainId = chainId;
+          });
+        await tx
+          .table('transactions')
+          .toCollection()
+          .modify((t) => {
+            if (t.chainId === undefined) t.chainId = chainId;
           });
       });
   }

--- a/frontend/src/hooks/useGenlayer.ts
+++ b/frontend/src/hooks/useGenlayer.ts
@@ -1,38 +1,9 @@
-import { localnet, studionet, testnetAsimov } from 'genlayer-js/chains';
 import { createClient, createAccount } from 'genlayer-js';
 import type { GenLayerClient } from 'genlayer-js/types';
 import { ref, watch, markRaw, type Ref } from 'vue';
 import { useAccountsStore } from '@/stores';
-import {
-  getRuntimeConfig,
-  getRuntimeConfigNumber,
-} from '@/utils/runtimeConfig';
+import { useNetworkStore } from '@/stores/network';
 import { useWallet } from './useWallet';
-
-const chains: Record<string, typeof localnet> = {
-  localnet,
-  studionet,
-  testnetAsimov,
-};
-
-function getChain() {
-  const networkName = getRuntimeConfig('VITE_GENLAYER_NETWORK', 'localnet');
-  const chain = chains[networkName];
-  if (!chain) {
-    throw new Error(
-      `Unknown VITE_GENLAYER_NETWORK: "${networkName}". Must be one of: ${Object.keys(chains).join(', ')}`,
-    );
-  }
-
-  // Allow per-deployment chain ID override (each Studio instance has its own).
-  // Safe now that the SDK uses isStudio instead of localnet.id for guards.
-  const chainIdOverride = getRuntimeConfigNumber('VITE_CHAIN_ID', 0);
-  if (chainIdOverride > 0 && chainIdOverride !== chain.id) {
-    return { ...chain, id: chainIdOverride };
-  }
-
-  return chain;
-}
 
 type UseGenlayerReturn = {
   client: Ref<GenLayerClient<any> | null>;
@@ -41,6 +12,7 @@ type UseGenlayerReturn = {
 
 export function useGenlayer(): UseGenlayerReturn {
   const accountsStore = useAccountsStore();
+  const networkStore = useNetworkStore();
   const wallet = useWallet();
   const client = ref<GenLayerClient<any> | null>(null);
 
@@ -52,6 +24,8 @@ export function useGenlayer(): UseGenlayerReturn {
     [
       () => accountsStore.selectedAccount?.address,
       () => wallet.walletProvider.value,
+      () => networkStore.currentNetwork,
+      () => networkStore.rpcUrl,
     ],
     () => {
       initClient();
@@ -65,11 +39,8 @@ export function useGenlayer(): UseGenlayerReturn {
         : accountsStore.selectedAccount?.address;
 
     const clientOptions: Record<string, unknown> = {
-      chain: getChain(),
-      endpoint: getRuntimeConfig(
-        'VITE_JSON_RPC_SERVER_URL',
-        'http://127.0.0.1:4000/api',
-      ),
+      chain: networkStore.chain,
+      endpoint: networkStore.rpcUrl,
       account: clientAccount,
     };
 

--- a/frontend/src/hooks/useNetworks.ts
+++ b/frontend/src/hooks/useNetworks.ts
@@ -1,19 +1,25 @@
 import { defineChain } from '@reown/appkit/networks';
 import { markRaw } from 'vue';
-import { getRuntimeConfig } from '@/utils/runtimeConfig';
+import { testnetBradbury } from 'genlayer-js/chains';
+import {
+  getRuntimeConfig,
+  getRuntimeConfigNumber,
+} from '@/utils/runtimeConfig';
 
 export function createGenlayerLocalnet() {
   const rpcUrl = getRuntimeConfig(
     'VITE_JSON_RPC_SERVER_URL',
     'http://127.0.0.1:4000/api',
   );
+  const chainId = getRuntimeConfigNumber('VITE_CHAIN_ID', 61999);
+  const chainName = getRuntimeConfig('VITE_CHAIN_NAME', 'GenLayer Localnet');
 
   return markRaw(
     defineChain({
-      id: 61999,
-      caipNetworkId: 'eip155:61999',
+      id: chainId,
+      caipNetworkId: `eip155:${chainId}`,
       chainNamespace: 'eip155',
-      name: 'GenLayer Localnet',
+      name: chainName,
       nativeCurrency: {
         name: 'GEN',
         symbol: 'GEN',
@@ -22,6 +28,22 @@ export function createGenlayerLocalnet() {
       rpcUrls: {
         default: { http: [rpcUrl] },
       },
+    }),
+  );
+}
+
+export function createGenlayerBradbury() {
+  return markRaw(
+    defineChain({
+      id: testnetBradbury.id,
+      caipNetworkId: `eip155:${testnetBradbury.id}`,
+      chainNamespace: 'eip155',
+      name: testnetBradbury.name,
+      nativeCurrency: testnetBradbury.nativeCurrency,
+      rpcUrls: {
+        default: { http: [...testnetBradbury.rpcUrls.default.http] },
+      },
+      blockExplorers: testnetBradbury.blockExplorers,
     }),
   );
 }

--- a/frontend/src/hooks/useSetupStores.ts
+++ b/frontend/src/hooks/useSetupStores.ts
@@ -51,16 +51,22 @@ export const useSetupStores = () => {
       for (const key of Object.keys(contractsBlob)) {
         const loader = contractsBlob[key];
         if (!loader) continue;
-        const raw = await loader();
-        const name = key.split('/').pop() || 'ExampleContract.py';
-        if (!contractFiles.some((c) => c.name === name)) {
-          const contract = {
-            id: uuidv4(),
-            name,
-            content: ((raw as string) || '').trim(),
-            example: true,
-          };
-          contractsStore.addContractFile(contract);
+        try {
+          const raw = await loader();
+          const name = key.split('/').pop() || 'ExampleContract.py';
+          if (!contractFiles.some((c) => c.name === name)) {
+            const contract = {
+              id: uuidv4(),
+              name,
+              content: ((raw as string) || '').trim(),
+              example: true,
+            };
+            contractsStore.addContractFile(contract);
+          }
+        } catch (err) {
+          // One bad file shouldn't block the rest — log and continue so the
+          // user still gets the other examples.
+          console.error('Failed to load example contract', key, err);
         }
       }
     } else {

--- a/frontend/src/hooks/useSetupStores.ts
+++ b/frontend/src/hooks/useSetupStores.ts
@@ -5,6 +5,7 @@ import {
   useNodeStore,
   useTutorialStore,
   useConsensusStore,
+  useNetworkStore,
 } from '@/stores';
 import {
   useDb,
@@ -20,10 +21,15 @@ export const useSetupStores = () => {
     const contractsStore = useContractsStore();
     const accountsStore = useAccountsStore();
     const tutorialStore = useTutorialStore();
+    const networkStore = useNetworkStore();
     const db = useDb();
     const genlayer = useGenlayer();
 
-    await useWebSocketClientAsync();
+    // WebSocket push events are Studio-only. On non-Studio chains, skip the
+    // async wait (the client is a no-op stub) and move on.
+    if (networkStore.isStudio) {
+      await useWebSocketClientAsync();
+    }
 
     const transactionsStore = useTransactionsStore();
     const nodeStore = useNodeStore();
@@ -61,8 +67,10 @@ export const useSetupStores = () => {
       contractsStore.contracts = await db.contractFiles.toArray();
     }
 
-    contractsStore.deployedContracts = await db.deployedContracts.toArray();
-    transactionsStore.transactions = await db.transactions.toArray();
+    contractsStore.setAllDeployedContracts(
+      await db.deployedContracts.toArray(),
+    );
+    transactionsStore.setAllTransactions(await db.transactions.toArray());
 
     transactionsStore.initSubscriptions();
     transactionsStore.refreshPendingTransactions();
@@ -70,10 +78,13 @@ export const useSetupStores = () => {
     contractListener.init();
     contractsStore.getInitialOpenedFiles();
     tutorialStore.resetTutorialState();
-    nodeStore.getValidatorsData();
-    nodeStore.getProvidersData();
-    await consensusStore.fetchFinalityWindowTime();
-    consensusStore.setupReconnectionListener();
+    // Validator / provider / finality-window RPCs are Studio-only.
+    if (networkStore.isStudio) {
+      nodeStore.getValidatorsData();
+      nodeStore.getProvidersData();
+      await consensusStore.fetchFinalityWindowTime();
+      consensusStore.setupReconnectionListener();
+    }
 
     if (accountsStore.accounts.length < 1) {
       accountsStore.generateNewAccount();

--- a/frontend/src/hooks/useWebSocketClient.ts
+++ b/frontend/src/hooks/useWebSocketClient.ts
@@ -3,7 +3,7 @@
  * Replaces Socket.IO with standard WebSockets for FastAPI compatibility
  */
 
-import { getRuntimeConfig } from '@/utils/runtimeConfig';
+import { useNetworkStore } from '@/stores/network';
 
 interface WebSocketMessage {
   event: string;
@@ -214,8 +214,62 @@ class NativeWebSocketClient {
 // Singleton instance with initialization state tracking
 let webSocketClient: NativeWebSocketClient | null = null;
 let isInitializing: boolean = false;
+let currentUrl: string | null = null;
 
-export function useWebSocketClient(): NativeWebSocketClient {
+/**
+ * A no-op stub returned when there is no WebSocket endpoint for the current
+ * network (e.g. Bradbury). Callers still get the same interface so existing
+ * `.on()` / `.emit()` / `.connected` usage compiles and runs without branches.
+ */
+const nullClient: NativeWebSocketClient = new Proxy(
+  {},
+  {
+    get(_target, prop) {
+      if (prop === 'connected') return false;
+      if (prop === 'id') return null;
+      if (prop === 'on' || prop === 'off' || prop === 'emit') {
+        return () => undefined;
+      }
+      if (
+        prop === 'disconnect' ||
+        prop === 'reconnectNow' ||
+        prop === 'connect'
+      ) {
+        return () => undefined;
+      }
+      return undefined;
+    },
+  },
+) as unknown as NativeWebSocketClient;
+
+export function useWebSocketClient(url?: string): NativeWebSocketClient {
+  // Resolve the URL: explicit argument wins; otherwise derive from the
+  // currently-selected network (non-Studio chains have no WS endpoint).
+  let resolvedUrl: string | null = url ?? null;
+  if (resolvedUrl === null) {
+    try {
+      resolvedUrl = useNetworkStore().wsUrl;
+    } catch {
+      // Pinia not yet initialized (very early boot) — caller gets the stub.
+      return nullClient;
+    }
+  }
+
+  if (!resolvedUrl) {
+    // Non-Studio network or caller opted out: ensure any existing singleton
+    // is torn down so we don't keep a stale WS alive after a network switch.
+    if (webSocketClient) {
+      disposeWebSocketClient();
+    }
+    return nullClient;
+  }
+
+  // If the URL changed since the singleton was created, tear it down and
+  // recreate against the new endpoint.
+  if (webSocketClient && currentUrl && currentUrl !== resolvedUrl) {
+    disposeWebSocketClient();
+  }
+
   // Return existing client if already created or currently initializing
   if (webSocketClient && (webSocketClient.connected || isInitializing)) {
     return webSocketClient;
@@ -224,8 +278,8 @@ export function useWebSocketClient(): NativeWebSocketClient {
   // Create new client if none exists
   if (!webSocketClient && !isInitializing) {
     isInitializing = true;
-    const wsUrl = getRuntimeConfig('VITE_WS_SERVER_URL', 'ws://localhost:4000');
-    webSocketClient = new NativeWebSocketClient(wsUrl);
+    currentUrl = resolvedUrl;
+    webSocketClient = new NativeWebSocketClient(resolvedUrl);
 
     // Reset initialization flag when connection completes (success or failure)
     webSocketClient.on('connect', () => {
@@ -240,11 +294,13 @@ export function useWebSocketClient(): NativeWebSocketClient {
     });
   }
 
-  return webSocketClient!;
+  return webSocketClient ?? nullClient;
 }
 
-export async function useWebSocketClientAsync(): Promise<NativeWebSocketClient> {
-  const client = useWebSocketClient();
+export async function useWebSocketClientAsync(
+  url?: string,
+): Promise<NativeWebSocketClient> {
+  const client = useWebSocketClient(url);
 
   if (client.connected) {
     return client;
@@ -255,4 +311,38 @@ export async function useWebSocketClientAsync(): Promise<NativeWebSocketClient> 
       resolve(client);
     });
   });
+}
+
+/**
+ * Dispose the current WebSocket singleton. Safe to call repeatedly. After
+ * dispose, `useWebSocketClient(url)` returns `nullClient` until the caller
+ * explicitly reinitializes with a URL (or calls `ensureWebSocketClient`).
+ */
+export function disposeWebSocketClient() {
+  if (webSocketClient) {
+    webSocketClient.disconnect();
+    webSocketClient = null;
+  }
+  isInitializing = false;
+  currentUrl = null;
+}
+
+/**
+ * Ensures a WebSocket is running against `url`. If the current singleton is
+ * connected to a different URL, it is torn down and replaced. Pass a falsy
+ * url to fully dispose the client (e.g. when switching to a non-Studio chain).
+ */
+export function ensureWebSocketClient(
+  url: string | null,
+): NativeWebSocketClient {
+  if (!url) {
+    disposeWebSocketClient();
+    return nullClient;
+  }
+  if (webSocketClient && currentUrl === url) {
+    return webSocketClient;
+  }
+  // URL changed or no client yet — tear down and recreate.
+  disposeWebSocketClient();
+  return useWebSocketClient(url);
 }

--- a/frontend/src/plugins/persistStore.ts
+++ b/frontend/src/plugins/persistStore.ts
@@ -1,4 +1,4 @@
-import type { ContractFile, DeployedContract } from '@/types';
+import type { ContractFile, DeployedContract, TransactionItem } from '@/types';
 import { type PiniaPluginContext } from 'pinia';
 import { useDb, useFileName } from '@/hooks';
 import { toRaw } from 'vue';
@@ -135,9 +135,13 @@ export function persistStorePlugin(context: PiniaPluginContext): void {
             break;
         }
       } else if (store.$id === 'transactionsStore') {
+        const transactions = store.allTransactions as TransactionItem[];
         switch (name) {
           case 'addTransaction':
-            await db.transactions.add(args[0]);
+            await db.transactions.add(
+              transactions.find((t) => t.hash === (args[0] as any).hash) ??
+                args[0],
+            );
             break;
           case 'removeTransaction':
             await db.transactions
@@ -146,10 +150,20 @@ export function persistStorePlugin(context: PiniaPluginContext): void {
               .delete();
             break;
           case 'updateTransaction':
-            await db.transactions
-              .where('hash')
-              .equals((args[0] as any).hash)
-              .modify({ data: args[0], statusName: args[0].statusName });
+            {
+              const hash = (args[0] as any).hash ?? (args[0] as any).txId;
+              const transaction = transactions.find((t) => t.hash === hash);
+              if (transaction) {
+                await db.transactions
+                  .where('hash')
+                  .equals(transaction.hash)
+                  .modify({
+                    data: transaction.data,
+                    statusName: transaction.statusName,
+                    addedAt: transaction.addedAt,
+                  });
+              }
+            }
             break;
           case 'clearTransactionsForContract':
             await db.transactions

--- a/frontend/src/services/monacoLinter.ts
+++ b/frontend/src/services/monacoLinter.ts
@@ -4,8 +4,18 @@
  */
 
 import * as Monaco from 'monaco-editor';
-import { RpcClient } from '@/clients/rpc';
 import type { JsonRPCResponse } from '@/types';
+import { getRuntimeConfig } from '@/utils/runtimeConfig';
+
+// Linting is a developer tool, not a chain operation. Always route it at the
+// Studio backend URL (`VITE_JSON_RPC_SERVER_URL`), regardless of whichever
+// network the user has selected in the UI — `sim_lintContract` only exists
+// on Studio. If the Studio backend is unreachable we fail soft (no markers).
+const STUDIO_RPC_URL = getRuntimeConfig(
+  'VITE_JSON_RPC_SERVER_URL',
+  'http://127.0.0.1:4000/api',
+);
+let nextLintRequestId = 1;
 
 interface LintResult {
   rule_id: string;
@@ -42,14 +52,24 @@ export async function lintGenVMCode(
   const code = editor.getValue();
 
   try {
-    const rpcClient = new RpcClient();
-    const response: JsonRPCResponse<LintResponse> = await rpcClient.call({
-      method: 'sim_lintContract',
-      params: [code, 'contract.py'], // Pass as positional arguments in array
+    const res = await fetch(STUDIO_RPC_URL, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        jsonrpc: '2.0',
+        method: 'sim_lintContract',
+        params: [code, 'contract.py'],
+        id: nextLintRequestId++,
+      }),
     });
+    const response = (await res.json()) as JsonRPCResponse<LintResponse>;
 
     if (response.error) {
-      console.error('[Monaco Linter] Error from server:', response.error);
+      // `sim_lintContract` is Studio-only; quietly disable the linter if the
+      // backend doesn't expose it (e.g. hosted deployment with no Studio).
+      if (response.error.code !== -32601) {
+        console.error('[Monaco Linter] Error from server:', response.error);
+      }
       return;
     }
 

--- a/frontend/src/stores/consensus.ts
+++ b/frontend/src/stores/consensus.ts
@@ -2,10 +2,12 @@ import { defineStore } from 'pinia';
 import { ref } from 'vue';
 import { useRpcClient, useWebSocketClient } from '@/hooks';
 import { getRuntimeConfigNumber } from '@/utils/runtimeConfig';
+import { useNetworkStore } from '@/stores/network';
 
 export const useConsensusStore = defineStore('consensusStore', () => {
   const rpcClient = useRpcClient();
   const webSocketClient = useWebSocketClient();
+  const networkStore = useNetworkStore();
   const finalityWindow = ref(
     getRuntimeConfigNumber('VITE_FINALITY_WINDOW', 10),
   );
@@ -21,6 +23,15 @@ export const useConsensusStore = defineStore('consensusStore', () => {
   };
 
   async function fetchFinalityWindowTime() {
+    // `sim_getFinalityWindowTime` is Studio-only; on testnet we keep the env-
+    // or network-configured value and stop showing a loader.
+    if (!networkStore.isStudio) {
+      if (!hasInitialized) {
+        isLoading.value = false;
+        hasInitialized = true;
+      }
+      return;
+    }
     try {
       finalityWindow.value = await rpcClient.getFinalityWindowTime(); // Assume this RPC method exists
       if (!hasInitialized) {

--- a/frontend/src/stores/contracts.ts
+++ b/frontend/src/stores/contracts.ts
@@ -3,17 +3,30 @@ import { defineStore } from 'pinia';
 import { ref, computed } from 'vue';
 import { notify } from '@kyvg/vue3-notification';
 import { useDb, useFileName } from '@/hooks';
+import { useNetworkStore } from '@/stores/network';
 
 export const useContractsStore = defineStore('contractsStore', () => {
   const contracts = ref<ContractFile[]>([]);
   const openedFiles = ref<string[]>([]);
   const db = useDb();
   const { cleanupFileName } = useFileName();
+  const networkStore = useNetworkStore();
 
   const currentContractId = ref<string | undefined>(
     localStorage.getItem('contractsStore.currentContractId') || '',
   );
-  const deployedContracts = ref<DeployedContract[]>([]);
+  // Internal flat list across all chains. UI consumers read the filtered
+  // `deployedContracts` computed below.
+  const allDeployedContracts = ref<DeployedContract[]>([]);
+  const deployedContracts = computed<DeployedContract[]>(() =>
+    allDeployedContracts.value.filter(
+      (c) => c.chainId === undefined || c.chainId === networkStore.chainId,
+    ),
+  );
+
+  function setAllDeployedContracts(items: DeployedContract[]) {
+    allDeployedContracts.value = items;
+  }
 
   function getInitialOpenedFiles() {
     const storage = localStorage.getItem('contractsStore.openedFiles');
@@ -43,9 +56,9 @@ export const useContractsStore = defineStore('contractsStore', () => {
 
   function removeContractFile(id: string): void {
     contracts.value = [...contracts.value.filter((c) => c.id !== id)];
-    deployedContracts.value = [
-      ...deployedContracts.value.filter((c) => c.contractId !== id),
-    ];
+    allDeployedContracts.value = allDeployedContracts.value.filter(
+      (c) => c.contractId !== id,
+    );
     openedFiles.value = openedFiles.value.filter(
       (contractId) => contractId !== id,
     );
@@ -107,17 +120,28 @@ export const useContractsStore = defineStore('contractsStore', () => {
     contractId,
     address,
     defaultState,
+    chainId,
   }: DeployedContract): void {
-    const index = deployedContracts.value.findIndex(
-      (c) => c.contractId === contractId,
+    const effectiveChainId = chainId ?? networkStore.chainId;
+    // Dedupe by (chainId, contractId): a contract deployed on localnet and
+    // then again on Bradbury should produce two distinct records.
+    const index = allDeployedContracts.value.findIndex(
+      (c) =>
+        c.contractId === contractId &&
+        (c.chainId ?? networkStore.chainId) === effectiveChainId,
     );
 
-    const newItem = { contractId, address, defaultState };
+    const newItem = {
+      contractId,
+      address,
+      defaultState,
+      chainId: effectiveChainId,
+    };
 
     if (index === -1) {
-      deployedContracts.value.push(newItem);
+      allDeployedContracts.value.push(newItem);
     } else {
-      deployedContracts.value.splice(index, 1, newItem);
+      allDeployedContracts.value.splice(index, 1, newItem);
     }
 
     notify({
@@ -127,9 +151,14 @@ export const useContractsStore = defineStore('contractsStore', () => {
   }
 
   function removeDeployedContract(contractId: string): void {
-    deployedContracts.value = [
-      ...deployedContracts.value.filter((c) => c.contractId !== contractId),
-    ];
+    // Only remove the record for the current chain; other chains keep theirs.
+    allDeployedContracts.value = allDeployedContracts.value.filter(
+      (c) =>
+        !(
+          c.contractId === contractId &&
+          (c.chainId ?? networkStore.chainId) === networkStore.chainId
+        ),
+    );
   }
 
   function setCurrentContractId(id?: string) {
@@ -140,6 +169,7 @@ export const useContractsStore = defineStore('contractsStore', () => {
     contracts.value = [];
     openedFiles.value = [];
     currentContractId.value = '';
+    allDeployedContracts.value = [];
 
     await db.deployedContracts.clear();
     await db.contractFiles.clear();
@@ -172,6 +202,7 @@ export const useContractsStore = defineStore('contractsStore', () => {
     openedFiles,
     currentContractId,
     deployedContracts,
+    allDeployedContracts,
 
     //getters
     currentContract,
@@ -187,6 +218,7 @@ export const useContractsStore = defineStore('contractsStore', () => {
     addDeployedContract,
     removeDeployedContract,
     setCurrentContractId,
+    setAllDeployedContracts,
     resetStorage,
     getInitialOpenedFiles,
     moveOpenedFile,

--- a/frontend/src/stores/index.ts
+++ b/frontend/src/stores/index.ts
@@ -5,3 +5,4 @@ export * from './ui';
 export * from './tutorial';
 export * from './transactions';
 export * from './consensus';
+export * from './network';

--- a/frontend/src/stores/network.ts
+++ b/frontend/src/stores/network.ts
@@ -1,0 +1,143 @@
+import { defineStore } from 'pinia';
+import { computed, ref, markRaw } from 'vue';
+import {
+  localnet,
+  studionet,
+  testnetAsimov,
+  testnetBradbury,
+} from 'genlayer-js/chains';
+import type { GenLayerChain } from 'genlayer-js/types';
+import {
+  getRuntimeConfig,
+  getRuntimeConfigBoolean,
+  getRuntimeConfigNumber,
+} from '@/utils/runtimeConfig';
+
+export type NetworkName =
+  | 'localnet'
+  | 'studionet'
+  | 'testnetAsimov'
+  | 'testnetBradbury';
+
+const CHAINS: Record<NetworkName, GenLayerChain> = {
+  localnet: localnet as GenLayerChain,
+  studionet: studionet as GenLayerChain,
+  testnetAsimov: testnetAsimov as GenLayerChain,
+  testnetBradbury: testnetBradbury as GenLayerChain,
+};
+
+const STORAGE_KEY = 'networkStore.currentNetwork';
+
+// v1 ships Studio + Bradbury as runtime-selectable options. Asimov shares
+// Bradbury's chain ID so it is not exposed as a separate dropdown entry;
+// reachable only via a deployment-time `VITE_GENLAYER_NETWORK` override.
+const SELECTABLE_NETWORKS: NetworkName[] = ['localnet', 'testnetBradbury'];
+
+function readInitialNetwork(): NetworkName {
+  const persisted = localStorage.getItem(STORAGE_KEY) as NetworkName | null;
+  if (persisted && persisted in CHAINS) return persisted;
+
+  const fromEnv = getRuntimeConfig(
+    'VITE_GENLAYER_NETWORK',
+    'localnet',
+  ) as NetworkName;
+  if (fromEnv in CHAINS) return fromEnv;
+
+  return 'localnet';
+}
+
+export const useNetworkStore = defineStore('networkStore', () => {
+  const currentNetwork = ref<NetworkName>(readInitialNetwork());
+
+  const isLocked = computed(() =>
+    getRuntimeConfigBoolean('VITE_LOCK_NETWORK', false),
+  );
+
+  const chain = computed<GenLayerChain>(() => {
+    const base = CHAINS[currentNetwork.value];
+    if (base.isStudio) {
+      // Per-deployment Studio chain-ID override (each Studio instance picks its own).
+      const override = getRuntimeConfigNumber('VITE_CHAIN_ID', 0);
+      if (override > 0 && override !== base.id) {
+        return markRaw({ ...base, id: override }) as GenLayerChain;
+      }
+    }
+    return markRaw(base) as GenLayerChain;
+  });
+
+  const chainId = computed(() => chain.value.id);
+  const isStudio = computed(() => Boolean(chain.value.isStudio));
+  const chainName = computed(() => chain.value.name);
+
+  const rpcUrl = computed(() => {
+    // On Studio, operators can override the RPC URL (e.g. hosted deployment).
+    if (isStudio.value) {
+      return getRuntimeConfig(
+        'VITE_JSON_RPC_SERVER_URL',
+        chain.value.rpcUrls?.default?.http?.[0] ?? 'http://127.0.0.1:4000/api',
+      );
+    }
+    return chain.value.rpcUrls?.default?.http?.[0] ?? '';
+  });
+
+  const wsUrl = computed<string | null>(() => {
+    // WebSocket push events only exist on Studio backends.
+    if (!isStudio.value) return null;
+    return getRuntimeConfig('VITE_WS_SERVER_URL', 'ws://localhost:4000');
+  });
+
+  const availableNetworks = computed<
+    { name: NetworkName; label: string; isStudio: boolean; chainId: number }[]
+  >(() => {
+    const list = SELECTABLE_NETWORKS.map((name) => {
+      const c = CHAINS[name];
+      return {
+        name,
+        label: c.name,
+        isStudio: Boolean(c.isStudio),
+        chainId: c.id,
+      };
+    });
+
+    // If the operator pinned a network outside the selectable list (e.g. Asimov
+    // via VITE_GENLAYER_NETWORK), surface it so the user can at least see where
+    // they are — but they cannot switch away from it via the dropdown.
+    if (!list.some((n) => n.name === currentNetwork.value)) {
+      const c = CHAINS[currentNetwork.value];
+      list.push({
+        name: currentNetwork.value,
+        label: c.name,
+        isStudio: Boolean(c.isStudio),
+        chainId: c.id,
+      });
+    }
+
+    return list;
+  });
+
+  function setCurrentNetwork(name: NetworkName) {
+    if (!(name in CHAINS)) {
+      throw new Error(`Unknown network: ${name}`);
+    }
+    if (name === currentNetwork.value) return;
+    currentNetwork.value = name;
+    try {
+      localStorage.setItem(STORAGE_KEY, name);
+    } catch {
+      // localStorage may be unavailable (SSR / privacy mode); ignore.
+    }
+  }
+
+  return {
+    currentNetwork,
+    isLocked,
+    chain,
+    chainId,
+    chainName,
+    isStudio,
+    rpcUrl,
+    wsUrl,
+    availableNetworks,
+    setCurrentNetwork,
+  };
+});

--- a/frontend/src/stores/node.ts
+++ b/frontend/src/stores/node.ts
@@ -10,10 +10,12 @@ import { defineStore } from 'pinia';
 import { computed, ref } from 'vue';
 import { notify } from '@kyvg/vue3-notification';
 import { useRpcClient, useWebSocketClient } from '@/hooks';
+import { useNetworkStore } from '@/stores/network';
 
 export const useNodeStore = defineStore('nodeStore', () => {
   const rpcClient = useRpcClient();
   const webSocketClient = useWebSocketClient();
+  const networkStore = useNetworkStore();
   const logs = ref<NodeLog[]>([]);
   const leaderTxHashes = new Set<string>();
   const nodeProviders = ref<GetProvidersAndModelsData>([]);
@@ -73,6 +75,12 @@ export const useNodeStore = defineStore('nodeStore', () => {
   }
 
   async function getValidatorsData() {
+    // `sim_getAllValidators` is Studio-only; skip cleanly on non-Studio chains.
+    if (!networkStore.isStudio) {
+      validators.value = [];
+      isLoadingValidatorData.value = false;
+      return;
+    }
     isLoadingValidatorData.value = true;
 
     try {
@@ -90,6 +98,12 @@ export const useNodeStore = defineStore('nodeStore', () => {
   }
 
   async function getProvidersData() {
+    // `sim_getProvidersAndModels` is Studio-only; skip on non-Studio chains.
+    if (!networkStore.isStudio) {
+      nodeProviders.value = [];
+      isLoadingProviders.value = false;
+      return;
+    }
     isLoadingProviders.value = true;
 
     try {

--- a/frontend/src/stores/transactions.ts
+++ b/frontend/src/stores/transactions.ts
@@ -1,16 +1,23 @@
 import { defineStore } from 'pinia';
-import { ref, computed } from 'vue';
+import { ref, computed, watch } from 'vue';
 import type { TransactionItem } from '@/types';
 import type { TransactionHash } from 'genlayer-js/types';
 import { TransactionStatus } from 'genlayer-js/types';
 import { useDb, useGenlayer, useWebSocketClient } from '@/hooks';
+import { useNetworkStore } from '@/stores/network';
 
 export const useTransactionsStore = defineStore('transactionsStore', () => {
   const genlayer = useGenlayer();
   const genlayerClient = computed(() => genlayer.client.value);
+  const networkStore = useNetworkStore();
   const webSocketClient = useWebSocketClient();
-  const transactions = ref<TransactionItem[]>([]);
-  const subscriptions = new Set();
+  const allTransactions = ref<TransactionItem[]>([]);
+  const transactions = computed<TransactionItem[]>(() =>
+    allTransactions.value.filter(
+      (t) => t.chainId === undefined || t.chainId === networkStore.chainId,
+    ),
+  );
+  const subscriptions = new Set<string>();
   const db = useDb();
 
   // Named handler for WebSocket reconnection
@@ -26,26 +33,48 @@ export const useTransactionsStore = defineStore('transactionsStore', () => {
   webSocketClient.off('connect', handleReconnection);
   webSocketClient.on('connect', handleReconnection);
 
+  // On network change, drop WS subscriptions (they are Studio-only anyway)
+  // and re-subscribe to the current network's pending-ish txs on Studio.
+  watch(
+    () => networkStore.chainId,
+    () => {
+      subscriptions.clear();
+      if (networkStore.isStudio) {
+        initSubscriptions();
+      }
+    },
+  );
+
+  function setAllTransactions(items: TransactionItem[]) {
+    allTransactions.value = items;
+  }
+
   function addTransaction(tx: TransactionItem) {
-    transactions.value.unshift(tx); // Push on top in case there's no date property yet
-    subscribe([tx.hash]);
+    const stamped = {
+      ...tx,
+      chainId: tx.chainId ?? networkStore.chainId,
+    };
+    allTransactions.value.unshift(stamped); // Push on top in case there's no date property yet
+    subscribe([stamped.hash]);
   }
 
   function removeTransaction(tx: TransactionItem) {
-    transactions.value = transactions.value.filter((t) => t.hash !== tx.hash);
+    allTransactions.value = allTransactions.value.filter(
+      (t) => t.hash !== tx.hash,
+    );
     unsubscribe(tx.hash);
   }
 
   function updateTransaction(tx: any) {
-    const currentTxIndex = transactions.value.findIndex(
+    const currentTxIndex = allTransactions.value.findIndex(
       (t) => t.hash === tx.hash,
     );
 
     if (currentTxIndex !== -1) {
-      const currentTx = transactions.value[currentTxIndex];
+      const currentTx = allTransactions.value[currentTxIndex];
       if (!currentTx) return;
 
-      transactions.value.splice(currentTxIndex, 1, {
+      allTransactions.value.splice(currentTxIndex, 1, {
         ...currentTx,
         statusName: tx.statusName,
         data: tx,
@@ -62,6 +91,8 @@ export const useTransactionsStore = defineStore('transactionsStore', () => {
   }
 
   async function refreshPendingTransactions() {
+    // Only refresh txs belonging to the current network — querying cross-network
+    // hashes would silently "not find" them and drop them from the store.
     const pendingTxs = transactions.value.filter(
       (tx: TransactionItem) => tx.statusName !== TransactionStatus.FINALIZED,
     ) as TransactionItem[];
@@ -85,13 +116,13 @@ export const useTransactionsStore = defineStore('transactionsStore', () => {
   }
 
   async function clearTransactionsForContract(contractId: string) {
-    const contractTxs = transactions.value.filter(
+    const contractTxs = allTransactions.value.filter(
       (t) => t.localContractId === contractId,
     );
 
     contractTxs.forEach((t) => unsubscribe(t.hash));
 
-    transactions.value = transactions.value.filter(
+    allTransactions.value = allTransactions.value.filter(
       (t) => t.localContractId !== contractId,
     );
 
@@ -127,17 +158,19 @@ export const useTransactionsStore = defineStore('transactionsStore', () => {
   }
 
   function initSubscriptions() {
+    // Only subscribe to the current network's txs; testnet WS is a no-op stub.
     subscribe(transactions.value.map((t) => t.hash));
   }
 
   async function resetStorage() {
-    transactions.value.forEach((t) => unsubscribe(t.hash));
-    transactions.value = [];
+    allTransactions.value.forEach((t) => unsubscribe(t.hash));
+    allTransactions.value = [];
     await db.transactions.clear();
   }
 
   return {
     transactions,
+    allTransactions,
     getTransaction,
     addTransaction,
     removeTransaction,
@@ -147,6 +180,7 @@ export const useTransactionsStore = defineStore('transactionsStore', () => {
     cancelTransaction,
     refreshPendingTransactions,
     initSubscriptions,
+    setAllTransactions,
     resetStorage,
   };
 });

--- a/frontend/src/stores/transactions.ts
+++ b/frontend/src/stores/transactions.ts
@@ -107,8 +107,11 @@ export const useTransactionsStore = defineStore('transactionsStore', () => {
   }
 
   function updateTransaction(tx: any) {
+    // SDK exposes the same id under two names — `hash` on Studio responses,
+    // `txId` on testnet (Solidity struct field). Accept either.
+    const id = tx.hash ?? tx.txId;
     const currentTxIndex = allTransactions.value.findIndex(
-      (t) => t.hash === tx.hash,
+      (t) => t.hash === id,
     );
 
     if (currentTxIndex !== -1) {

--- a/frontend/src/stores/transactions.ts
+++ b/frontend/src/stores/transactions.ts
@@ -14,6 +14,7 @@ import { useNetworkStore } from '@/stores/network';
 // emits). Poll while any tx is still undecided so CANCELED / FINALIZED /
 // TIMEOUT states actually reach the UI.
 const NON_STUDIO_POLL_INTERVAL_MS = 5_000;
+const NON_STUDIO_NOT_FOUND_GRACE_MS = 30_000;
 
 export const useTransactionsStore = defineStore('transactionsStore', () => {
   const genlayer = useGenlayer();
@@ -27,6 +28,7 @@ export const useTransactionsStore = defineStore('transactionsStore', () => {
     ),
   );
   const subscriptions = new Set<string>();
+  const missingTransactionSince = new Map<string, number>();
   const db = useDb();
 
   // Named handler for WebSocket reconnection
@@ -48,7 +50,7 @@ export const useTransactionsStore = defineStore('transactionsStore', () => {
   watch(
     () => networkStore.chainId,
     () => {
-      subscriptions.clear();
+      unsubscribeAll();
       if (networkStore.isStudio) {
         stopUndecidedPolling();
         initSubscriptions();
@@ -67,9 +69,12 @@ export const useTransactionsStore = defineStore('transactionsStore', () => {
   }
 
   function startUndecidedPolling() {
-    if (undecidedPollTimer) return;
+    if (undecidedPollTimer || !hasUndecidedTx()) return;
     undecidedPollTimer = setInterval(async () => {
-      if (!hasUndecidedTx()) return;
+      if (!hasUndecidedTx()) {
+        stopUndecidedPolling();
+        return;
+      }
       try {
         await refreshPendingTransactions();
       } catch (err) {
@@ -86,20 +91,71 @@ export const useTransactionsStore = defineStore('transactionsStore', () => {
     }
   }
 
+  function parseCreatedAt(tx: TransactionItem) {
+    const createdAt = tx.data?.created_at;
+    if (!createdAt) return null;
+
+    const parsed = new Date(createdAt).getTime();
+    return Number.isFinite(parsed) ? parsed : null;
+  }
+
+  function normalizeStoredTransaction(tx: TransactionItem): TransactionItem {
+    return {
+      ...tx,
+      addedAt: tx.addedAt ?? parseCreatedAt(tx) ?? Date.now(),
+    };
+  }
+
+  function normalizeRemoteTransaction(tx: any, fallbackHash?: string) {
+    if (!tx) return null;
+
+    const hash = tx.hash ?? tx.txId ?? fallbackHash;
+    if (!hash) return null;
+
+    return {
+      ...tx,
+      hash,
+    };
+  }
+
+  function shouldRemoveMissingTransaction(tx: TransactionItem) {
+    const now = Date.now();
+    const firstMissAt = missingTransactionSince.get(tx.hash);
+
+    if (firstMissAt === undefined) {
+      missingTransactionSince.set(tx.hash, now);
+      return false;
+    }
+
+    const addedAt = tx.addedAt ?? firstMissAt;
+    return (
+      now - addedAt >= NON_STUDIO_NOT_FOUND_GRACE_MS &&
+      now - firstMissAt >= NON_STUDIO_POLL_INTERVAL_MS
+    );
+  }
+
   function setAllTransactions(items: TransactionItem[]) {
-    allTransactions.value = items;
+    allTransactions.value = items.map(normalizeStoredTransaction);
+    if (!networkStore.isStudio) {
+      startUndecidedPolling();
+    }
   }
 
   function addTransaction(tx: TransactionItem) {
     const stamped = {
       ...tx,
       chainId: tx.chainId ?? networkStore.chainId,
+      addedAt: tx.addedAt ?? Date.now(),
     };
     allTransactions.value.unshift(stamped); // Push on top in case there's no date property yet
     subscribe([stamped.hash]);
+    if (!networkStore.isStudio) {
+      startUndecidedPolling();
+    }
   }
 
   function removeTransaction(tx: TransactionItem) {
+    missingTransactionSince.delete(tx.hash);
     allTransactions.value = allTransactions.value.filter(
       (t) => t.hash !== tx.hash,
     );
@@ -109,19 +165,25 @@ export const useTransactionsStore = defineStore('transactionsStore', () => {
   function updateTransaction(tx: any) {
     // SDK exposes the same id under two names — `hash` on Studio responses,
     // `txId` on testnet (Solidity struct field). Accept either.
-    const id = tx.hash ?? tx.txId;
+    const normalizedTx = normalizeRemoteTransaction(tx);
+    if (!normalizedTx) {
+      console.warn('Transaction missing hash', tx);
+      return;
+    }
+
     const currentTxIndex = allTransactions.value.findIndex(
-      (t) => t.hash === id,
+      (t) => t.hash === normalizedTx.hash,
     );
 
     if (currentTxIndex !== -1) {
       const currentTx = allTransactions.value[currentTxIndex];
       if (!currentTx) return;
 
+      missingTransactionSince.delete(currentTx.hash);
       allTransactions.value.splice(currentTxIndex, 1, {
         ...currentTx,
-        statusName: tx.statusName,
-        data: tx,
+        statusName: normalizedTx.statusName,
+        data: normalizedTx,
       });
     } else {
       // Temporary logging to debug always-PENDING transactions
@@ -147,14 +209,18 @@ export const useTransactionsStore = defineStore('transactionsStore', () => {
     await Promise.all(
       pendingTxs.map(async (tx) => {
         const newTx = await getTransaction(tx.hash as TransactionHash);
+        const normalizedTx = normalizeRemoteTransaction(newTx, tx.hash);
 
-        if (newTx) {
-          updateTransaction(newTx);
+        if (normalizedTx) {
+          updateTransaction(normalizedTx);
           await db.transactions.where('hash').equals(tx.hash).modify({
-            statusName: newTx.statusName,
-            data: newTx,
+            statusName: normalizedTx.statusName,
+            data: normalizedTx,
           });
-        } else {
+        } else if (
+          networkStore.isStudio ||
+          shouldRemoveMissingTransaction(tx)
+        ) {
           removeTransaction(tx);
           await db.transactions.where('hash').equals(tx.hash).delete();
         }
@@ -168,6 +234,7 @@ export const useTransactionsStore = defineStore('transactionsStore', () => {
     );
 
     contractTxs.forEach((t) => unsubscribe(t.hash));
+    contractTxs.forEach((t) => missingTransactionSince.delete(t.hash));
 
     allTransactions.value = allTransactions.value.filter(
       (t) => t.localContractId !== contractId,
@@ -204,21 +271,24 @@ export const useTransactionsStore = defineStore('transactionsStore', () => {
     }
   }
 
+  function unsubscribeAll() {
+    const topics = Array.from(subscriptions);
+    subscriptions.clear();
+    if (topics.length > 0 && webSocketClient.connected) {
+      webSocketClient.emit('unsubscribe', topics);
+    }
+  }
+
   function initSubscriptions() {
     // Only subscribe to the current network's txs; testnet WS is a no-op stub.
     subscribe(transactions.value.map((t) => t.hash));
   }
 
   async function resetStorage() {
-    allTransactions.value.forEach((t) => unsubscribe(t.hash));
+    unsubscribeAll();
+    missingTransactionSince.clear();
     allTransactions.value = [];
     await db.transactions.clear();
-  }
-
-  // Kick off non-Studio polling at store creation if the user lands directly
-  // on a testnet (chainId watcher only fires on changes, not on initial load).
-  if (!networkStore.isStudio) {
-    startUndecidedPolling();
   }
 
   return {

--- a/frontend/src/stores/transactions.ts
+++ b/frontend/src/stores/transactions.ts
@@ -2,9 +2,18 @@ import { defineStore } from 'pinia';
 import { ref, computed, watch } from 'vue';
 import type { TransactionItem } from '@/types';
 import type { TransactionHash } from 'genlayer-js/types';
-import { TransactionStatus } from 'genlayer-js/types';
+import {
+  isDecidedState,
+  transactionsStatusNameToNumber,
+} from 'genlayer-js/types';
 import { useDb, useGenlayer, useWebSocketClient } from '@/hooks';
 import { useNetworkStore } from '@/stores/network';
+
+// Non-Studio chains have no WebSocket push (tx status updates come via
+// `useTransactionListener` which is wired to WS events that only Studio
+// emits). Poll while any tx is still undecided so CANCELED / FINALIZED /
+// TIMEOUT states actually reach the UI.
+const NON_STUDIO_POLL_INTERVAL_MS = 5_000;
 
 export const useTransactionsStore = defineStore('transactionsStore', () => {
   const genlayer = useGenlayer();
@@ -35,15 +44,47 @@ export const useTransactionsStore = defineStore('transactionsStore', () => {
 
   // On network change, drop WS subscriptions (they are Studio-only anyway)
   // and re-subscribe to the current network's pending-ish txs on Studio.
+  // On non-Studio, start the polling loop.
   watch(
     () => networkStore.chainId,
     () => {
       subscriptions.clear();
       if (networkStore.isStudio) {
+        stopUndecidedPolling();
         initSubscriptions();
+      } else {
+        startUndecidedPolling();
       }
     },
   );
+
+  let undecidedPollTimer: ReturnType<typeof setInterval> | null = null;
+
+  function hasUndecidedTx() {
+    return transactions.value.some(
+      (tx) => !isDecidedState(transactionsStatusNameToNumber[tx.statusName]),
+    );
+  }
+
+  function startUndecidedPolling() {
+    if (undecidedPollTimer) return;
+    undecidedPollTimer = setInterval(async () => {
+      if (!hasUndecidedTx()) return;
+      try {
+        await refreshPendingTransactions();
+      } catch (err) {
+        // Keep polling even if a single refresh fails.
+        console.error('Failed polling transaction statuses', err);
+      }
+    }, NON_STUDIO_POLL_INTERVAL_MS);
+  }
+
+  function stopUndecidedPolling() {
+    if (undecidedPollTimer) {
+      clearInterval(undecidedPollTimer);
+      undecidedPollTimer = null;
+    }
+  }
 
   function setAllTransactions(items: TransactionItem[]) {
     allTransactions.value = items;
@@ -93,8 +134,11 @@ export const useTransactionsStore = defineStore('transactionsStore', () => {
   async function refreshPendingTransactions() {
     // Only refresh txs belonging to the current network — querying cross-network
     // hashes would silently "not find" them and drop them from the store.
+    // Skip fully-decided txs (CANCELED / FINALIZED / *_TIMEOUT / UNDETERMINED /
+    // ACCEPTED) — their status isn't going to change.
     const pendingTxs = transactions.value.filter(
-      (tx: TransactionItem) => tx.statusName !== TransactionStatus.FINALIZED,
+      (tx: TransactionItem) =>
+        !isDecidedState(transactionsStatusNameToNumber[tx.statusName]),
     ) as TransactionItem[];
 
     await Promise.all(
@@ -168,6 +212,12 @@ export const useTransactionsStore = defineStore('transactionsStore', () => {
     await db.transactions.clear();
   }
 
+  // Kick off non-Studio polling at store creation if the user lands directly
+  // on a testnet (chainId watcher only fires on changes, not on initial load).
+  if (!networkStore.isStudio) {
+    startUndecidedPolling();
+  }
+
   return {
     transactions,
     allTransactions,
@@ -182,5 +232,7 @@ export const useTransactionsStore = defineStore('transactionsStore', () => {
     initSubscriptions,
     setAllTransactions,
     resetStorage,
+    startUndecidedPolling,
+    stopUndecidedPolling,
   };
 });

--- a/frontend/src/types/store.ts
+++ b/frontend/src/types/store.ts
@@ -17,6 +17,7 @@ export interface DeployedContract {
   contractId: string;
   address: Address;
   defaultState: string;
+  chainId?: number;
 }
 
 export interface NodeLog {
@@ -34,6 +35,7 @@ export interface TransactionItem {
   statusName: TransactionStatus;
   contractAddress: string;
   localContractId: string;
+  chainId?: number;
   data?: any;
   decodedData?: {
     functionName: string;

--- a/frontend/src/types/store.ts
+++ b/frontend/src/types/store.ts
@@ -36,6 +36,7 @@ export interface TransactionItem {
   contractAddress: string;
   localContractId: string;
   chainId?: number;
+  addedAt?: number;
   data?: any;
   decodedData?: {
     functionName: string;

--- a/frontend/src/utils/explorerUrl.ts
+++ b/frontend/src/utils/explorerUrl.ts
@@ -1,19 +1,33 @@
 import { getRuntimeConfig } from './runtimeConfig';
+import { useNetworkStore } from '@/stores/network';
 
 /**
- * Get the explorer base URL.
+ * Get the explorer base URL for the currently selected network.
  *
  * Priority:
- * 1. VITE_EXPLORER_URL env var (explicit override)
- * 2. Derived from current hostname:
- *    studio.genlayer.com       → https://explorer-studio.genlayer.com
- *    studio-stage.genlayer.com → https://explorer-studio-stage.genlayer.com
- *    studio-dev.genlayer.com   → https://explorer-studio-dev.genlayer.com
- * 3. Fallback: http://localhost:3001
+ * 1. VITE_EXPLORER_URL env var (explicit override).
+ * 2. Non-Studio networks: the chain's own `blockExplorers.default.url`
+ *    (e.g. Bradbury → https://explorer-bradbury.genlayer.com).
+ * 3. Studio networks: derived from the current hostname
+ *    (studio.genlayer.com → explorer-studio.genlayer.com, etc.).
+ * 4. Fallback: http://localhost:3001
  */
 export function getExplorerUrl(): string {
   const explicit = getRuntimeConfig('VITE_EXPLORER_URL');
   if (explicit) return explicit;
+
+  // Chain-aware lookup when the network store is available (runtime).
+  try {
+    const networkStore = useNetworkStore();
+    if (!networkStore.isStudio) {
+      const chainExplorer =
+        networkStore.chain.blockExplorers?.default?.url ?? '';
+      if (chainExplorer) return chainExplorer.replace(/\/$/, '');
+    }
+  } catch {
+    // Pinia not yet initialized (e.g. very early boot) — fall through to
+    // the hostname-based heuristic.
+  }
 
   const host = window.location.hostname;
   if (host.endsWith('.genlayer.com')) {

--- a/frontend/src/utils/runtimeConfig.ts
+++ b/frontend/src/utils/runtimeConfig.ts
@@ -18,6 +18,7 @@ interface RuntimeConfig {
   VITE_PLAUSIBLE_DOMAIN?: string;
   VITE_APPKIT_PROJECT_ID?: string;
   VITE_EXPLORER_URL?: string;
+  VITE_LOCK_NETWORK?: string;
 }
 
 declare global {

--- a/frontend/src/views/Simulator/RunDebugView.vue
+++ b/frontend/src/views/Simulator/RunDebugView.vue
@@ -16,12 +16,14 @@ import {
 import ContractInfo from '@/components/Simulator/ContractInfo.vue';
 import SelectInput from '@/components/global/inputs/SelectInput.vue';
 import type { ExecutionMode } from '@/types';
+import { useConfig } from '@/hooks';
 
 const uiStore = useUIStore();
 const contractsStore = useContractsStore();
 const { isDeployed, address, contract } = useContractQueries();
 const nodeStore = useNodeStore();
 const consensusStore = useConsensusStore();
+const { isStudioNetwork } = useConfig();
 
 // Execution mode selection
 const executionMode = ref<ExecutionMode>('NORMAL');
@@ -68,7 +70,7 @@ const consensusMaxRotations = computed(() => consensusStore.maxRotations);
     <template
       v-if="contractsStore.currentContract && contractsStore.currentContractId"
     >
-      <div class="p-2">
+      <div v-if="isStudioNetwork" class="p-2">
         <label for="executionMode" class="mb-1 block text-xs font-medium">
           Execution Mode
         </label>
@@ -113,7 +115,13 @@ const consensusMaxRotations = computed(() => consensusStore.maxRotations);
         @openDeployment="isDeploymentOpen = true"
       />
 
-      <template v-if="nodeStore.hasAtLeastOneValidator || uiStore.showTutorial">
+      <template
+        v-if="
+          !isStudioNetwork ||
+          nodeStore.hasAtLeastOneValidator ||
+          uiStore.showTutorial
+        "
+      >
         <ConstructorParameters
           id="tutorial-how-to-deploy"
           v-if="isDeploymentOpen"

--- a/frontend/src/views/Simulator/SimulatorView.vue
+++ b/frontend/src/views/Simulator/SimulatorView.vue
@@ -6,6 +6,9 @@ import NodeLogs from '@/components/Simulator/NodeLogs.vue';
 import ContractsPanel from '@/components/Simulator/ContractsPanel.vue';
 import { Splitpanes, Pane } from 'splitpanes';
 import 'splitpanes/dist/splitpanes.css';
+import { useConfig } from '@/hooks';
+
+const { isStudioNetwork } = useConfig();
 
 const showLogsTerminal = ref<boolean>(true);
 
@@ -32,7 +35,11 @@ const handleLogsResize = (event: any) => {
       </Pane>
 
       <Pane>
-        <Splitpanes horizontal @resize="handleLogsResize">
+        <Splitpanes
+          v-if="isStudioNetwork"
+          horizontal
+          @resize="handleLogsResize"
+        >
           <Pane min-size="20" size="80" max-size="80">
             <ContractsPanel />
           </Pane>
@@ -40,6 +47,7 @@ const handleLogsResize = (event: any) => {
             <NodeLogs />
           </Pane>
         </Splitpanes>
+        <ContractsPanel v-else />
       </Pane>
     </Splitpanes>
   </div>

--- a/frontend/test/unit/hooks/useConfig.test.ts
+++ b/frontend/test/unit/hooks/useConfig.test.ts
@@ -1,22 +1,46 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { setActivePinia, createPinia } from 'pinia';
 import { useConfig } from '@/hooks';
+import { useNetworkStore } from '@/stores/network';
 
 describe('useConfig', () => {
   beforeEach(() => {
+    setActivePinia(createPinia());
     vi.stubEnv('VITE_IS_HOSTED', 'false');
   });
 
-  it('should return true for canUpdateValidators when not in hosted environment', () => {
+  it('returns true for canUpdateValidators in a non-hosted Studio environment', () => {
     vi.stubEnv('VITE_IS_HOSTED', 'false');
+    useNetworkStore().setCurrentNetwork('localnet');
 
     const { canUpdateValidators } = useConfig();
-    expect(canUpdateValidators).toBe(true);
+    expect(canUpdateValidators.value).toBe(true);
   });
 
-  it('should return false for canUpdateValidators when in hosted environment', () => {
+  it('returns false for canUpdateValidators when hosted', () => {
     vi.stubEnv('VITE_IS_HOSTED', 'true');
+    useNetworkStore().setCurrentNetwork('localnet');
 
     const { canUpdateValidators } = useConfig();
-    expect(canUpdateValidators).toBe(false);
+    expect(canUpdateValidators.value).toBe(false);
+  });
+
+  it('returns false for canUpdateValidators when on a non-Studio network', () => {
+    vi.stubEnv('VITE_IS_HOSTED', 'false');
+    useNetworkStore().setCurrentNetwork('testnetBradbury');
+
+    const { canUpdateValidators } = useConfig();
+    expect(canUpdateValidators.value).toBe(false);
+  });
+
+  it('exposes isStudioNetwork that reflects the current network', () => {
+    const store = useNetworkStore();
+    const { isStudioNetwork } = useConfig();
+
+    store.setCurrentNetwork('localnet');
+    expect(isStudioNetwork.value).toBe(true);
+
+    store.setCurrentNetwork('testnetBradbury');
+    expect(isStudioNetwork.value).toBe(false);
   });
 });

--- a/frontend/test/unit/hooks/useContractListener.behavioral.test.ts
+++ b/frontend/test/unit/hooks/useContractListener.behavioral.test.ts
@@ -7,12 +7,17 @@
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { useContractListener } from '@/hooks/useContractListener';
-import { useContractsStore, useTransactionsStore } from '@/stores';
+import {
+  useContractsStore,
+  useTransactionsStore,
+  useNetworkStore,
+} from '@/stores';
 import { useWebSocketClient } from '@/hooks';
 
 vi.mock('@/stores', () => ({
   useContractsStore: vi.fn(),
   useTransactionsStore: vi.fn(),
+  useNetworkStore: vi.fn(),
 }));
 
 vi.mock('@/hooks', () => ({
@@ -22,15 +27,21 @@ vi.mock('@/hooks', () => ({
 describe('useContractListener — behavioral contract', () => {
   let contractsStoreMock: any;
   let transactionsStoreMock: any;
+  let networkStoreMock: any;
   let webSocketClientMock: any;
 
   beforeEach(() => {
     contractsStoreMock = {
       addDeployedContract: vi.fn(),
+      deployedContracts: [],
     };
 
     transactionsStoreMock = {
       transactions: [],
+    };
+
+    networkStoreMock = {
+      isStudio: true,
     };
 
     webSocketClientMock = {
@@ -39,6 +50,7 @@ describe('useContractListener — behavioral contract', () => {
 
     (useContractsStore as any).mockReturnValue(contractsStoreMock);
     (useTransactionsStore as any).mockReturnValue(transactionsStoreMock);
+    (useNetworkStore as any).mockReturnValue(networkStoreMock);
     (useWebSocketClient as any).mockReturnValue(webSocketClientMock);
   });
 
@@ -146,5 +158,29 @@ describe('useContractListener — behavioral contract', () => {
     expect(contractsStoreMock.addDeployedContract).toHaveBeenCalledWith(
       expect.objectContaining({ contractId: 'b' }),
     );
+  });
+
+  it('should register accepted deploy txs on non-Studio networks without WS event', () => {
+    networkStoreMock.isStudio = false;
+    transactionsStoreMock.transactions = [
+      {
+        hash: '0xDeployHash',
+        localContractId: 'my-contract',
+        type: 'deploy',
+        statusName: 'ACCEPTED',
+        data: {
+          recipient: '0x1111111111111111111111111111111111111111',
+        },
+      },
+    ];
+
+    const { init } = useContractListener();
+    init();
+
+    expect(contractsStoreMock.addDeployedContract).toHaveBeenCalledWith({
+      contractId: 'my-contract',
+      address: '0x1111111111111111111111111111111111111111',
+      defaultState: '{}',
+    });
   });
 });

--- a/frontend/test/unit/hooks/useContractListener.test.ts
+++ b/frontend/test/unit/hooks/useContractListener.test.ts
@@ -1,11 +1,16 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { useContractListener } from '@/hooks/useContractListener';
-import { useTransactionsStore, useContractsStore } from '@/stores';
+import {
+  useTransactionsStore,
+  useContractsStore,
+  useNetworkStore,
+} from '@/stores';
 import { useWebSocketClient } from '@/hooks';
 
 vi.mock('@/stores', () => ({
   useTransactionsStore: vi.fn(),
   useContractsStore: vi.fn(),
+  useNetworkStore: vi.fn(),
 }));
 
 vi.mock('@/hooks', () => ({
@@ -15,6 +20,7 @@ vi.mock('@/hooks', () => ({
 describe('useContractListener', () => {
   let transactionsStoreMock: any;
   let contractsStoreMock: any;
+  let networkStoreMock: any;
   let webSocketClientMock: any;
 
   beforeEach(() => {
@@ -31,6 +37,10 @@ describe('useContractListener', () => {
       deployedContracts: [],
     };
 
+    networkStoreMock = {
+      isStudio: true,
+    };
+
     webSocketClientMock = {
       id: 'mocked-socket-id',
       on: vi.fn(),
@@ -38,6 +48,7 @@ describe('useContractListener', () => {
 
     (useTransactionsStore as any).mockReturnValue(transactionsStoreMock);
     (useContractsStore as any).mockReturnValue(contractsStoreMock);
+    (useNetworkStore as any).mockReturnValue(networkStoreMock);
     (useWebSocketClient as any).mockReturnValue(webSocketClientMock);
   });
 

--- a/frontend/test/unit/hooks/useGenlayer.test.ts
+++ b/frontend/test/unit/hooks/useGenlayer.test.ts
@@ -1,8 +1,8 @@
 /**
- * Behavioral snapshot tests for useGenlayer.
+ * Behavioral tests for useGenlayer.
  *
- * These tests document the current client creation/recreation behavior
- * so the multi-network refactor doesn't break existing Studio flows.
+ * Documents client creation/recreation, including reactive network switching
+ * through the network store.
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
@@ -11,40 +11,45 @@ const mockCreateAccount = vi.fn(() => ({
   address: '0xLocalAccount',
   type: 'local',
 }));
-const mockGetRuntimeConfig = vi.fn((key: string, fallback: string) => fallback);
+
+const localnetChain = {
+  id: 61127,
+  name: 'localnet',
+  isStudio: true,
+  rpcUrls: { default: { http: ['http://127.0.0.1:4000/api'] } },
+};
+const studionetChain = {
+  id: 61999,
+  name: 'studionet',
+  isStudio: true,
+  rpcUrls: { default: { http: ['https://studio.genlayer.com/api'] } },
+};
+const testnetBradburyChain = {
+  id: 4221,
+  name: 'Genlayer Bradbury Testnet',
+  isStudio: false,
+  rpcUrls: { default: { http: ['https://rpc-bradbury.genlayer.com'] } },
+};
+
+const mockNetworkStore = {
+  chain: localnetChain,
+  rpcUrl: 'http://127.0.0.1:4000/api',
+  currentNetwork: 'localnet',
+};
 
 vi.mock('genlayer-js', () => ({
   createClient: (...args: any[]) => mockCreateClient(...args),
   createAccount: (...args: any[]) => mockCreateAccount(...args),
 }));
 
-vi.mock('genlayer-js/chains', () => ({
-  localnet: {
-    id: 61127,
-    name: 'localnet',
-    rpcUrls: { default: { http: ['http://127.0.0.1:4000/api'] } },
-  },
-  studionet: {
-    id: 61999,
-    name: 'studionet',
-    rpcUrls: { default: { http: ['https://studio.genlayer.com/api'] } },
-  },
-  testnetAsimov: {
-    id: 4221,
-    name: 'testnetAsimov',
-    rpcUrls: { default: { http: ['https://asimov.genlayer.com'] } },
-  },
-}));
-
-vi.mock('@/utils/runtimeConfig', () => ({
-  getRuntimeConfig: (...args: any[]) => mockGetRuntimeConfig(...args),
-  getRuntimeConfigNumber: vi.fn((_key: string, fallback: number) => fallback),
-}));
-
 vi.mock('@/stores', () => ({
   useAccountsStore: vi.fn(() => ({
     selectedAccount: { address: '0xTest', type: 'local', privateKey: '0xkey' },
   })),
+}));
+
+vi.mock('@/stores/network', () => ({
+  useNetworkStore: vi.fn(() => mockNetworkStore),
 }));
 
 vi.mock('@/hooks/useWallet', () => ({
@@ -64,12 +69,12 @@ vi.mock('vue', async () => {
 describe('useGenlayer', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockGetRuntimeConfig.mockImplementation(
-      (key: string, fallback: string) => fallback,
-    );
+    mockNetworkStore.chain = localnetChain;
+    mockNetworkStore.rpcUrl = 'http://127.0.0.1:4000/api';
+    mockNetworkStore.currentNetwork = 'localnet';
   });
 
-  it('should create client with localnet chain by default', async () => {
+  it('creates a client using the chain from the network store', async () => {
     const { useGenlayer } = await import('@/hooks/useGenlayer');
     useGenlayer();
 
@@ -78,11 +83,10 @@ describe('useGenlayer', () => {
     expect(opts.chain.name).toBe('localnet');
   });
 
-  it('should use VITE_GENLAYER_NETWORK to select chain', async () => {
-    mockGetRuntimeConfig.mockImplementation((key: string, fallback: string) => {
-      if (key === 'VITE_GENLAYER_NETWORK') return 'studionet';
-      return fallback;
-    });
+  it('picks up studionet when the network store reports studionet', async () => {
+    mockNetworkStore.chain = studionetChain;
+    mockNetworkStore.rpcUrl = 'https://studio.genlayer.com/api';
+    mockNetworkStore.currentNetwork = 'studionet';
 
     vi.resetModules();
     const { useGenlayer } = await import('@/hooks/useGenlayer');
@@ -92,11 +96,8 @@ describe('useGenlayer', () => {
     expect(opts.chain.name).toBe('studionet');
   });
 
-  it('should pass VITE_JSON_RPC_SERVER_URL as endpoint', async () => {
-    mockGetRuntimeConfig.mockImplementation((key: string, fallback: string) => {
-      if (key === 'VITE_JSON_RPC_SERVER_URL') return 'http://custom:4000/api';
-      return fallback;
-    });
+  it('passes the network store rpc URL as the client endpoint', async () => {
+    mockNetworkStore.rpcUrl = 'http://custom:4000/api';
 
     vi.resetModules();
     const { useGenlayer } = await import('@/hooks/useGenlayer');
@@ -106,7 +107,21 @@ describe('useGenlayer', () => {
     expect(opts.endpoint).toBe('http://custom:4000/api');
   });
 
-  it('should create local account from private key for local accounts', async () => {
+  it('honors a non-Studio chain (e.g. Bradbury testnet)', async () => {
+    mockNetworkStore.chain = testnetBradburyChain;
+    mockNetworkStore.rpcUrl = 'https://rpc-bradbury.genlayer.com';
+    mockNetworkStore.currentNetwork = 'testnetBradbury';
+
+    vi.resetModules();
+    const { useGenlayer } = await import('@/hooks/useGenlayer');
+    useGenlayer();
+
+    const opts = mockCreateClient.mock.calls[0][0];
+    expect(opts.chain.isStudio).toBe(false);
+    expect(opts.endpoint).toBe('https://rpc-bradbury.genlayer.com');
+  });
+
+  it('creates a local account from the private key for local accounts', async () => {
     const { useGenlayer } = await import('@/hooks/useGenlayer');
     useGenlayer();
 

--- a/frontend/test/unit/hooks/useSetupStores.behavioral.test.ts
+++ b/frontend/test/unit/hooks/useSetupStores.behavioral.test.ts
@@ -43,6 +43,7 @@ const mockContractsStore = {
   deployedContracts: [],
   addContractFile: vi.fn(),
   getInitialOpenedFiles: vi.fn(),
+  setAllDeployedContracts: vi.fn(),
 };
 
 const mockAccountsStore = {
@@ -54,6 +55,13 @@ const mockTransactionsStore = {
   transactions: [],
   initSubscriptions: vi.fn(() => track('initSubscriptions')),
   refreshPendingTransactions: vi.fn(() => track('refreshPendingTransactions')),
+  setAllTransactions: vi.fn(),
+};
+
+const mockNetworkStore = {
+  isStudio: true,
+  chainId: 61127,
+  currentNetwork: 'localnet',
 };
 
 const mockNodeStore = {
@@ -89,6 +97,7 @@ vi.mock('@/stores', () => ({
   useUIStore: vi.fn(() => ({})),
   useConsensusStore: vi.fn(() => mockConsensusStore),
   useTutorialStore: vi.fn(() => mockTutorialStore),
+  useNetworkStore: vi.fn(() => mockNetworkStore),
 }));
 
 vi.mock('uuid', () => ({
@@ -211,5 +220,20 @@ describe('useSetupStores — behavioral contract', () => {
 
     const initIdx = callOrder.indexOf('initClient');
     expect(initIdx).toBe(callOrder.length - 1);
+  });
+
+  it('skips sim_* calls when the current network is non-Studio', async () => {
+    mockNetworkStore.isStudio = false;
+
+    const { useSetupStores } = await import('@/hooks/useSetupStores');
+    const { setupStores } = useSetupStores();
+    await setupStores();
+
+    expect(mockNodeStore.getValidatorsData).not.toHaveBeenCalled();
+    expect(mockNodeStore.getProvidersData).not.toHaveBeenCalled();
+    expect(mockConsensusStore.fetchFinalityWindowTime).not.toHaveBeenCalled();
+
+    // Reset for other tests.
+    mockNetworkStore.isStudio = true;
   });
 });

--- a/frontend/test/unit/hooks/useWebSocketClient.test.ts
+++ b/frontend/test/unit/hooks/useWebSocketClient.test.ts
@@ -16,63 +16,60 @@ Object.assign(WebSocketMock, {
 });
 (global as any).WebSocket = WebSocketMock;
 
+// Reusable mock network store so `useWebSocketClient()` (no args) can resolve
+// a URL without requiring a real Pinia instance in the test runtime.
+const mockNetworkStore = {
+  wsUrl: 'ws://localhost:4000' as string | null,
+};
+vi.mock('@/stores/network', () => ({
+  useNetworkStore: vi.fn(() => mockNetworkStore),
+}));
+
 describe('useWebSocketClient', () => {
-  it('should create a WebSocket client with the correct URL', async () => {
+  it('creates a WebSocket client using the network store URL', async () => {
     const { useWebSocketClient } = await import('@/hooks/useWebSocketClient');
-    const client = useWebSocketClient();
-    const expectedUrl = (client as unknown as { url: string }).url;
-
     WebSocketMock.mockClear();
-    client.connect();
-
-    expect(WebSocketMock).toHaveBeenCalledWith(expectedUrl);
+    const client = useWebSocketClient();
+    expect(client).toBeDefined();
+    expect(WebSocketMock).toHaveBeenCalled();
   });
 
-  it('should create a WebSocket client with the correct URL', async () => {
+  it('returns a no-op stub when the current network has no WS url', async () => {
+    mockNetworkStore.wsUrl = null;
+    vi.resetModules();
+    WebSocketMock.mockClear();
     const { useWebSocketClient } = await import('@/hooks/useWebSocketClient');
     const client = useWebSocketClient();
     expect(client).toBeDefined();
-    expect(global.WebSocket).toHaveBeenCalled();
+    expect(WebSocketMock).not.toHaveBeenCalled();
+    expect(client.connected).toBe(false);
+    // Restore for subsequent tests.
+    mockNetworkStore.wsUrl = 'ws://localhost:4000';
   });
 
-  it('should have an emit method', async () => {
+  it('accepts an explicit URL override', async () => {
+    vi.resetModules();
+    WebSocketMock.mockClear();
     const { useWebSocketClient } = await import('@/hooks/useWebSocketClient');
-    const client = useWebSocketClient();
-    expect(client.emit).toBeDefined();
+    const client = useWebSocketClient('ws://explicit:5000');
+    expect(client).toBeDefined();
+    expect(WebSocketMock).toHaveBeenCalled();
+  });
+
+  it('exposes the standard emit / on / off / disconnect surface', async () => {
+    vi.resetModules();
+    const { useWebSocketClient } = await import('@/hooks/useWebSocketClient');
+    const client = useWebSocketClient('ws://localhost:4000');
     expect(typeof client.emit).toBe('function');
-  });
-
-  it('should have an on method for event handling', async () => {
-    const { useWebSocketClient } = await import('@/hooks/useWebSocketClient');
-    const client = useWebSocketClient();
-    expect(client.on).toBeDefined();
     expect(typeof client.on).toBe('function');
-  });
-
-  it('should have an off method for removing event handlers', async () => {
-    const { useWebSocketClient } = await import('@/hooks/useWebSocketClient');
-    const client = useWebSocketClient();
-    expect(client.off).toBeDefined();
     expect(typeof client.off).toBe('function');
-  });
-
-  it('should have a connect method', async () => {
-    const { useWebSocketClient } = await import('@/hooks/useWebSocketClient');
-    const client = useWebSocketClient();
-    expect(client.connect).toBeDefined();
-    expect(typeof client.connect).toBe('function');
-  });
-
-  it('should have a disconnect method', async () => {
-    const { useWebSocketClient } = await import('@/hooks/useWebSocketClient');
-    const client = useWebSocketClient();
-    expect(client.disconnect).toBeDefined();
     expect(typeof client.disconnect).toBe('function');
   });
 
-  it('should handle event listeners', async () => {
+  it('handles event listeners without throwing', async () => {
+    vi.resetModules();
     const { useWebSocketClient } = await import('@/hooks/useWebSocketClient');
-    const client = useWebSocketClient();
+    const client = useWebSocketClient('ws://localhost:4000');
     const mockHandler = vi.fn();
 
     client.on('test-event', mockHandler);

--- a/frontend/test/unit/services/RpcClient.behavioral.test.ts
+++ b/frontend/test/unit/services/RpcClient.behavioral.test.ts
@@ -1,10 +1,10 @@
 /**
  * Behavioral snapshot tests for RpcClient.
  *
- * Documents the WS-blocking behavior and HTTP call pattern.
- * The multi-network refactor must:
- * - Preserve this behavior when isStudio=true (WS exists)
- * - Skip WS wait when isStudio=false (no WS on testnet)
+ * Documents the WS-blocking behavior and HTTP call pattern:
+ * - On Studio (isStudio=true): block on WS connect before making HTTP call,
+ *   forward session id in `x-session-id`.
+ * - On non-Studio (isStudio=false): skip WS entirely — no session header.
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
@@ -14,16 +14,19 @@ const mockWsClient = {
   id: 'test-session-id',
   on: vi.fn(),
 };
+const mockNetworkStore = {
+  rpcUrl: 'http://localhost:4000/api',
+  isStudio: true,
+};
 
 vi.mock('@/hooks', () => ({
   useWebSocketClient: vi.fn(() => mockWsClient),
 }));
 
-vi.mock('@/utils/runtimeConfig', () => ({
-  getRuntimeConfig: vi.fn(() => 'http://localhost:4000/api'),
+vi.mock('@/stores/network', () => ({
+  useNetworkStore: vi.fn(() => mockNetworkStore),
 }));
 
-// Mock uuid
 vi.mock('uuid', () => ({
   v4: vi.fn(() => 'test-uuid'),
 }));
@@ -34,29 +37,29 @@ describe('RpcClient — behavioral contract', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockWsClient.connected = false;
+    mockWsClient.id = 'test-session-id';
+    mockNetworkStore.rpcUrl = 'http://localhost:4000/api';
+    mockNetworkStore.isStudio = true;
     mockFetch.mockResolvedValue({
       ok: true,
       json: () => Promise.resolve({ result: 'ok', error: null }),
     });
   });
 
-  it('should block on WS connect before making HTTP call', async () => {
+  it('on Studio: blocks on WS connect before making HTTP call', async () => {
     vi.resetModules();
     const { RpcClient } = await import('@/clients/rpc');
     const client = new RpcClient();
 
-    // Start the call — should be blocked waiting for WS
     let resolved = false;
     const callPromise = client.call({ method: 'ping', params: [] }).then(() => {
       resolved = true;
     });
 
-    // Give microtasks a chance
     await new Promise((r) => setTimeout(r, 50));
     expect(resolved).toBe(false);
     expect(mockFetch).not.toHaveBeenCalled();
 
-    // Simulate WS connect
     const connectCallback = mockWsClient.on.mock.calls.find(
       (c: any[]) => c[0] === 'connect',
     )?.[1];
@@ -67,7 +70,7 @@ describe('RpcClient — behavioral contract', () => {
     expect(mockFetch).toHaveBeenCalled();
   });
 
-  it('should not block if WS is already connected', async () => {
+  it('on Studio: does not block if WS is already connected', async () => {
     mockWsClient.connected = true;
 
     vi.resetModules();
@@ -79,7 +82,7 @@ describe('RpcClient — behavioral contract', () => {
     expect(mockFetch).toHaveBeenCalled();
   });
 
-  it('should send x-session-id header from WS client id', async () => {
+  it('on Studio: sends x-session-id header from WS client id', async () => {
     mockWsClient.connected = true;
     mockWsClient.id = 'my-session-123';
 
@@ -94,7 +97,25 @@ describe('RpcClient — behavioral contract', () => {
     expect(headers['x-session-id']).toBe('my-session-123');
   });
 
-  it('should send JSON-RPC 2.0 formatted request', async () => {
+  it('on non-Studio: skips WS entirely and omits the session header', async () => {
+    mockNetworkStore.isStudio = false;
+
+    vi.resetModules();
+    const { RpcClient } = await import('@/clients/rpc');
+    const client = new RpcClient();
+
+    await client.call({ method: 'ping', params: [] });
+
+    // No WS interactions at all
+    expect(mockWsClient.on).not.toHaveBeenCalled();
+
+    const fetchCall = mockFetch.mock.calls[0];
+    const headers = fetchCall[1].headers;
+    expect(headers['x-session-id']).toBeUndefined();
+    expect(mockFetch).toHaveBeenCalled();
+  });
+
+  it('sends JSON-RPC 2.0 formatted request', async () => {
     mockWsClient.connected = true;
 
     vi.resetModules();
@@ -111,8 +132,10 @@ describe('RpcClient — behavioral contract', () => {
     expect(body.id).toBeDefined();
   });
 
-  it('should POST to the configured RPC URL', async () => {
+  it('POSTs to the RPC URL resolved from the network store', async () => {
     mockWsClient.connected = true;
+    mockNetworkStore.rpcUrl = 'https://rpc-bradbury.genlayer.com';
+    mockNetworkStore.isStudio = false;
 
     vi.resetModules();
     const { RpcClient } = await import('@/clients/rpc');
@@ -121,6 +144,6 @@ describe('RpcClient — behavioral contract', () => {
     await client.call({ method: 'ping', params: [] });
 
     const url = mockFetch.mock.calls[0][0];
-    expect(url).toBe('http://localhost:4000/api');
+    expect(url).toBe('https://rpc-bradbury.genlayer.com');
   });
 });

--- a/frontend/test/unit/stores/consensus.behavioral.test.ts
+++ b/frontend/test/unit/stores/consensus.behavioral.test.ts
@@ -25,16 +25,22 @@ vi.mock('@/hooks', () => ({
 }));
 
 vi.mock('@/utils/runtimeConfig', () => ({
+  getRuntimeConfig: vi.fn((_key: string, fallback: string) => fallback),
   getRuntimeConfigNumber: vi.fn((_key: string, fallback: number) => fallback),
+  getRuntimeConfigBoolean: vi.fn((_key: string, fallback: boolean) => fallback),
 }));
 
 describe('consensusStore — Studio-only sim_* calls', () => {
-  beforeEach(() => {
+  beforeEach(async () => {
     setActivePinia(createPinia());
     vi.clearAllMocks();
+    // Ensure we're on a Studio network for the existing cases (Bradbury is
+    // covered by the non-Studio guard test below).
+    const { useNetworkStore } = await import('@/stores/network');
+    useNetworkStore().setCurrentNetwork('localnet');
   });
 
-  it('fetchFinalityWindowTime calls sim_getFinalityWindowTime', async () => {
+  it('fetchFinalityWindowTime calls sim_getFinalityWindowTime on Studio', async () => {
     const store = useConsensusStore();
     await store.fetchFinalityWindowTime();
     expect(mockRpcService.getFinalityWindowTime).toHaveBeenCalled();
@@ -51,5 +57,13 @@ describe('consensusStore — Studio-only sim_* calls', () => {
     const store = useConsensusStore();
     await store.setFinalityWindowTime(120);
     expect(mockRpcService.setFinalityWindowTime).toHaveBeenCalledWith(120);
+  });
+
+  it('fetchFinalityWindowTime skips the RPC on non-Studio networks', async () => {
+    const { useNetworkStore } = await import('@/stores/network');
+    useNetworkStore().setCurrentNetwork('testnetBradbury');
+    const store = useConsensusStore();
+    await store.fetchFinalityWindowTime();
+    expect(mockRpcService.getFinalityWindowTime).not.toHaveBeenCalled();
   });
 });

--- a/frontend/test/unit/stores/contracts.behavioral.test.ts
+++ b/frontend/test/unit/stores/contracts.behavioral.test.ts
@@ -65,7 +65,7 @@ describe('contractsStore — deployed contract behavior', () => {
     );
   });
 
-  it('deployed contracts have NO chainId field (current limitation)', () => {
+  it('deployed contracts are stamped with the current network chainId', () => {
     const store = useContractsStore();
     store.addDeployedContract({
       contractId: 'test',
@@ -77,8 +77,7 @@ describe('contractsStore — deployed contract behavior', () => {
       (d: any) => d.contractId === 'test',
     );
     expect(deployed).toBeDefined();
-    // This documents the current state — no chainId scoping
-    expect((deployed as any).chainId).toBeUndefined();
+    expect((deployed as any).chainId).toBeTypeOf('number');
   });
 
   it('removeDeployedContract removes by contractId', () => {

--- a/frontend/test/unit/stores/contracts.test.ts
+++ b/frontend/test/unit/stores/contracts.test.ts
@@ -120,7 +120,7 @@ describe('useContractsStore', () => {
 
     contractsStore.addDeployedContract(testDeployedContract);
     expect(contractsStore.deployedContracts).toContainEqual(
-      testDeployedContract,
+      expect.objectContaining(testDeployedContract),
     );
     expect(notify).toHaveBeenCalledWith({
       title: 'Contract deployed',
@@ -129,7 +129,7 @@ describe('useContractsStore', () => {
 
     contractsStore.removeDeployedContract(testDeployedContract.contractId);
     expect(contractsStore.deployedContracts).not.toContainEqual(
-      deployedContract,
+      expect.objectContaining({ contractId: deployedContract.contractId }),
     );
   });
 

--- a/frontend/test/unit/stores/transactions.behavioral.test.ts
+++ b/frontend/test/unit/stores/transactions.behavioral.test.ts
@@ -63,7 +63,7 @@ describe('transactionsStore — behavioral contract', () => {
     );
   });
 
-  it('transactions have NO chainId field (current limitation)', () => {
+  it('transactions are stamped with the current network chainId on add', () => {
     const store = useTransactionsStore();
     store.addTransaction({
       hash: '0xTx2',
@@ -76,7 +76,7 @@ describe('transactionsStore — behavioral contract', () => {
 
     const tx = store.transactions.find((t: any) => t.hash === '0xTx2');
     expect(tx).toBeDefined();
-    expect((tx as any).chainId).toBeUndefined();
+    expect((tx as any).chainId).toBeTypeOf('number');
   });
 
   it('updateTransaction replaces existing by hash', () => {

--- a/frontend/test/unit/stores/transactions.test.ts
+++ b/frontend/test/unit/stores/transactions.test.ts
@@ -1,6 +1,15 @@
-import { describe, it, expect, beforeEach, vi, type Mock } from 'vitest';
+import {
+  describe,
+  it,
+  expect,
+  beforeEach,
+  afterEach,
+  vi,
+  type Mock,
+} from 'vitest';
 import { setActivePinia, createPinia } from 'pinia';
-import { useTransactionsStore } from '@/stores';
+import { nextTick } from 'vue';
+import { useNetworkStore, useTransactionsStore } from '@/stores';
 import { useDb, useGenlayer } from '@/hooks';
 import type { TransactionItem } from '@/types';
 import type { Address, TransactionHash } from 'genlayer-js/types';
@@ -63,6 +72,10 @@ describe('useTransactionsStore', () => {
   };
 
   beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useRealTimers();
+    localStorage.removeItem('networkStore.currentNetwork');
+
     // Set up mocks BEFORE creating the store
     mockWebSocketClient = {
       connected: true,
@@ -90,6 +103,12 @@ describe('useTransactionsStore', () => {
     transactionsStore.setAllTransactions([]);
   });
 
+  afterEach(() => {
+    transactionsStore.stopUndecidedPolling();
+    vi.useRealTimers();
+    localStorage.removeItem('networkStore.currentNetwork');
+  });
+
   it('should add a transaction', () => {
     transactionsStore.addTransaction(testTransaction);
     expect(transactionsStore.transactions).toContainEqual(
@@ -113,6 +132,21 @@ describe('useTransactionsStore', () => {
     transactionsStore.updateTransaction(updatedTransactionPayload);
     expect(transactionsStore.transactions[0].statusName).toBe(
       TransactionStatus.FINALIZED,
+    );
+  });
+
+  it('should normalize txId-only transaction updates to hash', () => {
+    transactionsStore.addTransaction(testTransaction);
+    transactionsStore.updateTransaction({
+      txId: testTransaction.hash,
+      statusName: TransactionStatus.ACCEPTED,
+    });
+
+    expect(transactionsStore.transactions[0].statusName).toBe(
+      TransactionStatus.ACCEPTED,
+    );
+    expect(transactionsStore.transactions[0].data).toEqual(
+      expect.objectContaining({ hash: testTransaction.hash }),
     );
   });
 
@@ -188,6 +222,51 @@ describe('useTransactionsStore', () => {
     expect(transactionsStore.transactions[0].statusName).toBe(
       TransactionStatus.FINALIZED,
     );
+  });
+
+  it('should keep missing pending transactions during the non-Studio grace window', async () => {
+    useNetworkStore().setCurrentNetwork('testnetBradbury');
+    await nextTick();
+    const pendingTransaction = {
+      ...testTransaction,
+      statusName: TransactionStatus.PENDING,
+      addedAt: Date.now(),
+    };
+
+    transactionsStore.addTransaction(pendingTransaction);
+    mockGenlayerClient.getTransaction.mockResolvedValue(undefined);
+
+    await transactionsStore.refreshPendingTransactions();
+
+    expect(transactionsStore.transactions).toContainEqual(
+      expect.objectContaining({ hash: pendingTransaction.hash }),
+    );
+    expect(mockDb.transactions.delete).not.toHaveBeenCalled();
+  });
+
+  it('should remove missing pending transactions after grace and a repeated miss', async () => {
+    vi.useFakeTimers();
+    useNetworkStore().setCurrentNetwork('testnetBradbury');
+    await nextTick();
+    const now = Date.now();
+    vi.setSystemTime(now);
+    const pendingTransaction = {
+      ...testTransaction,
+      statusName: TransactionStatus.PENDING,
+      addedAt: now - 30_000,
+    };
+
+    transactionsStore.addTransaction(pendingTransaction);
+    mockGenlayerClient.getTransaction.mockResolvedValue(undefined);
+
+    await transactionsStore.refreshPendingTransactions();
+    vi.advanceTimersByTime(5_000);
+    await transactionsStore.refreshPendingTransactions();
+
+    expect(transactionsStore.transactions).not.toContainEqual(
+      expect.objectContaining({ hash: pendingTransaction.hash }),
+    );
+    expect(mockDb.transactions.delete).toHaveBeenCalled();
   });
 
   describe('cancelTransaction', () => {
@@ -291,6 +370,19 @@ describe('useTransactionsStore', () => {
 
       // Remove transaction
       transactionsStore.removeTransaction(testTransaction);
+
+      expect(mockWebSocketClient.emit).toHaveBeenCalledWith('unsubscribe', [
+        testTransaction.hash,
+      ]);
+    });
+
+    it('should unsubscribe existing topics when the network changes', async () => {
+      const networkStore = useNetworkStore();
+      transactionsStore.addTransaction(testTransaction);
+      mockWebSocketClient.emit.mockClear();
+
+      networkStore.setCurrentNetwork('testnetBradbury');
+      await nextTick();
 
       expect(mockWebSocketClient.emit).toHaveBeenCalledWith('unsubscribe', [
         testTransaction.hash,

--- a/frontend/test/unit/stores/transactions.test.ts
+++ b/frontend/test/unit/stores/transactions.test.ts
@@ -87,19 +87,25 @@ describe('useTransactionsStore', () => {
 
     // Now create the store - this will trigger the WebSocket setup
     transactionsStore = useTransactionsStore();
-    transactionsStore.transactions = [];
+    transactionsStore.setAllTransactions([]);
   });
 
   it('should add a transaction', () => {
     transactionsStore.addTransaction(testTransaction);
-    expect(transactionsStore.transactions).to.deep.include(testTransaction);
+    expect(transactionsStore.transactions).toContainEqual(
+      expect.objectContaining({ hash: testTransaction.hash }),
+    );
   });
 
   it('should remove an added transaction', () => {
     transactionsStore.addTransaction(testTransaction);
-    expect(transactionsStore.transactions).to.deep.include(testTransaction);
+    expect(transactionsStore.transactions).toContainEqual(
+      expect.objectContaining({ hash: testTransaction.hash }),
+    );
     transactionsStore.removeTransaction(testTransaction);
-    expect(transactionsStore.transactions).not.to.deep.include(testTransaction);
+    expect(transactionsStore.transactions).not.toContainEqual(
+      expect.objectContaining({ hash: testTransaction.hash }),
+    );
   });
 
   it('should update a transaction', () => {
@@ -148,7 +154,9 @@ describe('useTransactionsStore', () => {
     expect(mockDb.transactions.equals).toHaveBeenCalledWith('contract-1');
     expect(mockDb.transactions.delete).toHaveBeenCalled();
 
-    expect(transactionsStore.transactions).toEqual([tx2]);
+    expect(transactionsStore.transactions).toEqual([
+      expect.objectContaining({ hash: tx2.hash }),
+    ]);
   });
 
   it('should refresh pending transactions', async () => {

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -45,6 +45,15 @@ export default defineConfig(({ mode }) => {
       strictPort: true,
       host: true,
       origin: 'http://0.0.0.0:8080',
+      fs: {
+        // examples/contracts lives at the repo root and is symlinked under
+        // src/assets/examples; allow Vite's dev server to follow into it
+        // (without this, the dynamic `?raw` glob only transforms files the
+        // static module graph already knows about — e.g. storage.py — and
+        // the rest load as plain text, which the browser rejects when
+        // `import()`ed).
+        allow: ['..'],
+      },
     },
   };
 

--- a/tests/unit/protocol_rpc/test_log_event_redaction.py
+++ b/tests/unit/protocol_rpc/test_log_event_redaction.py
@@ -1,0 +1,86 @@
+from backend.protocol_rpc.message_handler.types import (
+    EventScope,
+    EventType,
+    LogEvent,
+    sanitize_log_data,
+)
+
+
+def test_log_event_to_dict_removes_private_key_fields_recursively():
+    original = {
+        "node_config": {
+            "address": "0xvalidator",
+            "private_key": "0xabc123",
+            "primary_model": {"provider": "openai"},
+        },
+        "validators": [
+            {
+                "address": "0xvalidator2",
+                "privateKey": "0xdef456",
+            }
+        ],
+        "account_private_key": "0x789",
+    }
+
+    event = LogEvent(
+        name="consensus_event",
+        type=EventType.INFO,
+        scope=EventScope.CONSENSUS,
+        message="Reached consensus",
+        data=original,
+    )
+
+    payload = event.to_dict()
+
+    assert payload["data"] == {
+        "node_config": {
+            "address": "0xvalidator",
+            "primary_model": {"provider": "openai"},
+        },
+        "validators": [{"address": "0xvalidator2"}],
+    }
+    # The execution object handed to LogEvent is not mutated.
+    assert original["node_config"]["private_key"] == "0xabc123"
+    assert original["validators"][0]["privateKey"] == "0xdef456"
+
+
+def test_log_event_to_dict_can_show_private_keys_for_local_debug(monkeypatch):
+    monkeypatch.setenv("SHOW_VALIDATOR_PRIVATE_KEYS_IN_LOGS", "true")
+    original = {
+        "node_config": {
+            "address": "0xvalidator",
+            "private_key": "0xabc123",
+        }
+    }
+
+    event = LogEvent(
+        name="consensus_event",
+        type=EventType.INFO,
+        scope=EventScope.CONSENSUS,
+        message="Reached consensus",
+        data=original,
+    )
+
+    assert event.to_dict()["data"] == original
+
+
+def test_sanitize_log_data_handles_nested_lists_and_tuples():
+    result = sanitize_log_data(
+        [
+            {"private-key": "0xabc", "address": "0x1"},
+            ({"private_key": "0xdef", "address": "0x2"},),
+        ]
+    )
+
+    assert result == [{"address": "0x1"}, ({"address": "0x2"},)]
+
+
+def test_sanitize_log_data_removes_private_key_attributes_from_objects():
+    class ValidatorLike:
+        def __init__(self):
+            self.address = "0xvalidator"
+            self.private_key = "0xabc"
+
+    assert sanitize_log_data({"validator": ValidatorLike()}) == {
+        "validator": {"address": "0xvalidator"}
+    }


### PR DESCRIPTION
## Summary

Adds a header dropdown that lets the hosted Studio frontend target either the local Studio backend or the Bradbury testnet at runtime, instead of being pinned to a single backend at build time. Contract deploy, read, write, simulate, and attach all work on both targets. Studio-only features (node logs, validators, providers, finality tuning, internal faucet) hide cleanly on testnet.

Full plan: `docs/plans/studio-network-selector.md`.

## What's in it

**Foundations**
- New `networkStore` (Pinia, persisted): exposes `currentNetwork`, `chain`, `rpcUrl`, `wsUrl`, `chainId`, `isStudio`, `availableNetworks`, `isLocked`.
- Reactive RPC URL — `rpc.ts` resolves the URL from the store per call; on non-Studio networks it skips the WS session header entirely.
- `useGenlayer` watches `currentNetwork`/`rpcUrl` and re-inits the genlayer-js client on change.
- WebSocket singleton gains teardown + URL-change reconnect; non-Studio returns a no-op stub (testnets have no push events).
- `useAppKit` registers Bradbury alongside the Studio localnet so MetaMask can switch without a manual add step.
- `useChainEnforcer` reads chain info from the network store and accepts an explicit target override (used by the selector on switch).

**Data scoping (Dexie v5)**
- `deployedContracts` and `transactions` gain a `chainId` column; existing rows backfill to the build-time `VITE_CHAIN_ID` via the upgrade hook.
- Stores expose filtered `deployedContracts` / `transactions` computeds scoped to the current chain; internal flat state stays accessible via `allDeployedContracts` / `allTransactions` + setter actions.
- Pending transactions are no longer silently dropped on network switch — they stay in storage scoped to their original chain.

**Graceful degradation on non-Studio networks**
- `useConfig` adds `isStudioNetwork`; validator / provider / finality-window gates now require both `!hosted` AND `isStudioNetwork`.
- Node Logs pane hides on testnet (Splitpanes collapse to contracts-only).
- `nodeStore.getValidatorsData` / `getProvidersData` and `consensusStore.fetchFinalityWindowTime` bail early on testnet.
- `useSetupStores` skips the WS wait and sim_* warmup when non-Studio.
- Faucet button swaps to an external link to `https://testnet-faucet.genlayer.foundation` on testnet (100 GEN / 24h, gated on 0.01 ETH mainnet).

**Also**
- Bumps `genlayer-js` `^0.28.4` → `^1.1.0` (picks up the SDK patch that hides the `gen_getContractSchema` semantic divergence between Studio and the node — see `docs/plans/studio-testnet-format-alignment.md` § Schema method divergence).

## Open resolutions captured in the plan

- **Chain ID collision Asimov/Bradbury (4221):** intentional, same underlying network. v1 ships Bradbury only; Asimov reachable via `VITE_GENLAYER_NETWORK=testnetAsimov` deployment override.
- **Monaco linter (`sim_lintContract`):** stays pointed at the Studio backend regardless of target (linter is a developer tool, not a chain operation).
- **WebSocket on testnet:** dropped entirely; tx status falls back to polling `eth_getTransactionByHash` via the existing `refreshPendingTransactions` path.

## Test plan

Automated:
- [x] `npm run build` — clean (vue-tsc passes)
- [x] `npm run lint` — 0 errors (pre-existing warnings only)
- [x] `npm test` — 189/189 pass, including 5 new cases:
  - `RpcClient.behavioral`: non-Studio skips WS, resolves URL from store
  - `useGenlayer`: picks chain from network store; honors Bradbury
  - `useConfig`: `isStudioNetwork` flip; `canUpdateValidators` false on testnet
  - `useSetupStores`: sim_* warmup skipped on non-Studio
  - `consensusStore`: `fetchFinalityWindowTime` no-op on non-Studio

Manual (to run before merge):
- [ ] Fresh load on Studio localnet — deploy / read / write / simulate / attach
- [ ] Switch to Bradbury via dropdown — MetaMask prompt fires, wallet chain switches, contract interactions route to Bradbury
- [ ] Reject the MetaMask switch — dropdown reverts, toast shows
- [ ] Reload — last-selected network is restored
- [ ] Contract attach on Bradbury (requires `genlayer-js@1.1.0` patch to be deployed)
- [ ] Faucet button on Bradbury opens `testnet-faucet.genlayer.foundation` in a new tab
- [ ] Dexie v5 upgrade on existing users — contracts and pending txs stay visible and scoped to localnet
- [ ] `VITE_LOCK_NETWORK=true` hides the dropdown

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Header network selector with persisted runtime network switching, wallet chain enforcement, and reactive RPC/WebSocket/client behavior.
  * Multi-network support: per-network scoping for contracts/transactions, DB migration/backfill, and network-aware UI/layout and simulator behavior.
  * Testnet flow: external faucet link and gated Studio-only tooling.

* **Bug Fixes**
  * Prevent cross-network transaction collisions, preserve pending txs per network, and revert UI on wallet switch rejection.

* **Documentation**
  * Added network selector implementation plan and updated RPC method availability/divergence docs.

* **Chores**
  * Updated client dependency to a newer genlayer-js release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->