### PR TITLE
chore(release): cap auto-bumps at minor to avoid accidental majors

### DIFF
--- a/release.config.js
+++ b/release.config.js
@@ -5,7 +5,19 @@ module.exports = {
             "@semantic-release/commit-analyzer",
             {
                 "preset": "conventionalcommits",
+                // The first rule caps commits with a BREAKING CHANGE footer or `!:`
+                // marker at `minor`. Without it, semantic-release's built-in default
+                // rule `{ breaking: true, release: 'major' }` kicks in and auto-ships
+                // a major release the moment any commit body contains the words
+                // "BREAKING CHANGE". That's almost never what we want on 0.x — one
+                // stray commit would jump us straight to 1.0.0. Run semantic-release
+                // with an explicit `--release major` override for genuine major bumps.
+                //
+                // User rules are evaluated before the defaults; defaults only apply
+                // when no user rule matches. So capturing `breaking: true` here
+                // prevents the default major rule from being consulted at all.
                 "releaseRules": [
+                    { "breaking": true, "release": "minor" },
                     { "type": "feat", "release": "minor" },
                     { "type": "*", "release": "patch" },
                 ],


### PR DESCRIPTION
## Summary

Add `{ breaking: true, release: "minor" }` as the first entry in `releaseRules` so that commits with a `BREAKING CHANGE` footer or `!:` marker produce a **minor** bump instead of a major one.

## Why

`@semantic-release/commit-analyzer` ships with a built-in default rule `{ breaking: true, release: "major" }`. That default is consulted whenever the user-provided `releaseRules` don't cover a commit. The existing user rules (`feat → minor`, `* → patch`) do not match on the `breaking` flag, so a stray "BREAKING CHANGE:" line in any commit body would immediately ship a major release.

At the current 0.117.x state, that means the next accidental breaking footer would jump the project to 1.0.0 — not as a deliberate stability declaration, but as a side effect of commit-message parsing. `genlayer-js` hit exactly that trap yesterday (0.28.7 → 1.0.0 unintentionally); this PR prevents the same thing here.

Mirrors the equivalent fixes in:
- `genlayer-js` (PR #159, `release-it` + `whatBump`)
- `genlayer-cli` (PR #295, `release-it` + `whatBump`)

## How it works

Per `@semantic-release/commit-analyzer` docs: user rules in `releaseRules` are evaluated first; the default release rules are only consulted when no user rule matches. By explicitly matching `breaking: true` at the top of our rules, we keep the default `major` rule from firing for those commits.

## Effect

| Commit type | Before | After |
|---|---|---|
| `BREAKING CHANGE` footer / `!:` marker | major | **minor** |
| `feat:` | minor | minor |
| Everything else (`fix:`, `chore:`, `docs:`, …) | patch | patch |
| Explicit `semantic-release --release major` | major | major (unchanged) |

## Test plan

- [x] `node -e 'require(\"./release.config.js\")'` parses clean
- [ ] After merge, verify that the next merged PR produces the expected bump level via the auto-release logs. If a `BREAKING CHANGE:` footer happens to land, it should produce a minor version, not a major.