### PR TITLE
feat: add post-deployment success panel with explorer link

### DIFF
--- a/frontend/src/components/Simulator/ContractItem.vue
+++ b/frontend/src/components/Simulator/ContractItem.vue
@@ -10,6 +10,10 @@ import {
 } from '@heroicons/vue/16/solid';
 import { ref, onMounted, nextTick } from 'vue';
 import { notify } from '@kyvg/vue3-notification';
+import { computed } from 'vue';
+import { useShortAddress } from '@/hooks';
+
+const { shorten } = useShortAddress();
 
 const store = useContractsStore();
 const defaultContractName = 'New Contract.py';
@@ -21,6 +25,11 @@ const props = defineProps<{
 }>();
 
 const emit = defineEmits(['save', 'cancel']);
+
+const deployedContract = computed(() => {
+  if (!props.contract) return null;
+  return store.deployedContracts.find((c) => c.contractId === props.contract?.id);
+});
 
 const isEditing = ref(false);
 const editInput = ref<HTMLInputElement | null>(null);
@@ -137,33 +146,41 @@ const handleDownloadFile = (e: Event) => {
 
       <div
         v-else-if="contract"
-        class="flex w-full items-center justify-between truncate"
+        class="flex w-full flex-col truncate"
       >
-        <div data-testid="contract-file" class="truncate font-semibold">
-          {{ contract.name }}
+        <div class="flex w-full items-center justify-between truncate">
+          <div data-testid="contract-file" class="truncate font-semibold">
+            {{ contract.name }}
+          </div>
+
+          <div class="hidden flex-row gap-1 group-hover:flex">
+            <button @click.stop="handleEditFile" v-tooltip="'Edit Name'">
+              <PencilSquareIcon
+                class="h-[16px] w-[16px] p-[2px] text-gray-400 transition-all hover:text-gray-800 active:scale-90 dark:hover:text-white"
+              />
+            </button>
+
+            <button @click.stop="handleDownloadFile" v-tooltip="'Download file'">
+              <ArrowDownOnSquareIcon
+                class="h-[16px] w-[16px] p-[2px] text-gray-400 transition-all hover:text-gray-800 active:scale-90 dark:hover:text-white"
+              />
+            </button>
+
+            <button
+              @click.stop="deleteModalOpen = true"
+              v-tooltip="'Delete file'"
+            >
+              <TrashIcon
+                class="h-[16px] w-[16px] p-[2px] text-gray-400 transition-all hover:text-gray-800 active:scale-90 dark:hover:text-white"
+              />
+            </button>
+          </div>
         </div>
-
-        <div class="hidden flex-row gap-1 group-hover:flex">
-          <button @click.stop="handleEditFile" v-tooltip="'Edit Name'">
-            <PencilSquareIcon
-              class="h-[16px] w-[16px] p-[2px] text-gray-400 transition-all hover:text-gray-800 active:scale-90 dark:hover:text-white"
-            />
-          </button>
-
-          <button @click.stop="handleDownloadFile" v-tooltip="'Download file'">
-            <ArrowDownOnSquareIcon
-              class="h-[16px] w-[16px] p-[2px] text-gray-400 transition-all hover:text-gray-800 active:scale-90 dark:hover:text-white"
-            />
-          </button>
-
-          <button
-            @click.stop="deleteModalOpen = true"
-            v-tooltip="'Delete file'"
-          >
-            <TrashIcon
-              class="h-[16px] w-[16px] p-[2px] text-gray-400 transition-all hover:text-gray-800 active:scale-90 dark:hover:text-white"
-            />
-          </button>
+        <div
+          v-if="deployedContract"
+          class="truncate text-[10px] text-gray-400 dark:text-gray-500"
+        >
+          {{ shorten(deployedContract.address) }}
         </div>
       </div>
 

--- a/frontend/src/components/Simulator/DeploymentSuccessPanel.vue
+++ b/frontend/src/components/Simulator/DeploymentSuccessPanel.vue
@@ -1,0 +1,76 @@
+<script setup lang="ts">
+import { computed } from 'vue';
+import { getExplorerUrl } from '@/utils/explorerUrl';
+import CopyTextButton from '@/components/global/CopyTextButton.vue';
+import { ExternalLink, CheckCircle2, Zap, X } from 'lucide-vue-next';
+
+const props = defineProps<{
+  contractAddress: string;
+  txHash: string;
+}>();
+
+const emit = defineEmits(['close', 'interact']);
+
+const explorerUrl = computed(() => getExplorerUrl());
+</script>
+
+<template>
+  <div
+    class="relative mb-4 flex flex-col overflow-hidden rounded-xl border border-emerald-200 bg-gradient-to-b from-emerald-50/50 to-white shadow-sm dark:border-emerald-900/30 dark:from-emerald-950/20 dark:to-zinc-900"
+    data-testid="deployment-success-panel"
+  >
+    <button
+      @click="emit('close')"
+      class="absolute right-3 top-3 text-emerald-600/50 hover:text-emerald-600 dark:text-emerald-400/50 dark:hover:text-emerald-400"
+      aria-label="Close success panel"
+    >
+      <X class="h-4 w-4" />
+    </button>
+
+    <div class="flex items-center gap-2 border-b border-emerald-100 bg-emerald-50 px-4 py-3 dark:border-emerald-900/30 dark:bg-emerald-900/10">
+      <CheckCircle2 class="h-5 w-5 text-emerald-500 dark:text-emerald-400" />
+      <h3 class="font-semibold text-emerald-800 dark:text-emerald-300">Contract Deployed Successfully</h3>
+    </div>
+
+    <div class="flex flex-col gap-3 p-4">
+      <div class="flex flex-col gap-1">
+        <span class="text-[10px] font-medium uppercase tracking-wider text-slate-500 dark:text-zinc-400">Contract Address</span>
+        <div class="flex items-center justify-between rounded-lg border border-slate-200 bg-slate-50 px-3 py-2 dark:border-zinc-700 dark:bg-zinc-800/50">
+          <span class="font-mono text-xs text-slate-700 break-all dark:text-zinc-300">{{ contractAddress }}</span>
+          <CopyTextButton :text="contractAddress" class="ml-2" />
+        </div>
+      </div>
+
+      <div class="flex flex-col gap-1">
+        <span class="text-[10px] font-medium uppercase tracking-wider text-slate-500 dark:text-zinc-400">Transaction Hash</span>
+        <div class="flex items-center justify-between rounded-lg border border-slate-200 bg-slate-50 px-3 py-2 dark:border-zinc-700 dark:bg-zinc-800/50">
+          <span class="font-mono text-xs text-slate-700 break-all dark:text-zinc-300">{{ txHash }}</span>
+          <CopyTextButton :text="txHash" class="ml-2" />
+        </div>
+      </div>
+
+      <div class="mt-2 flex flex-row flex-wrap gap-2">
+        <a
+          v-if="explorerUrl"
+          :href="`${explorerUrl}/tx/${txHash}`"
+          target="_blank"
+          class="inline-flex items-center gap-1.5 rounded-lg bg-white px-4 py-2 text-xs font-medium text-slate-700 shadow-sm ring-1 ring-inset ring-slate-300 transition-colors hover:bg-slate-50 dark:bg-zinc-800 dark:text-zinc-200 dark:ring-zinc-600 dark:hover:bg-zinc-700"
+        >
+          <ExternalLink class="h-3.5 w-3.5" />
+          View on Explorer
+        </a>
+        <button
+          @click="emit('interact')"
+          class="inline-flex items-center gap-1.5 rounded-lg bg-emerald-500 px-4 py-2 text-xs font-medium text-white shadow-sm transition-colors hover:bg-emerald-600 dark:bg-emerald-600 dark:hover:bg-emerald-500"
+        >
+          <Zap class="h-3.5 w-3.5" />
+          Interact Now
+        </button>
+      </div>
+
+      <div class="mt-1 text-[11px] text-slate-500 dark:text-zinc-400">
+        ℹ Save your contract address — you'll need it to call this contract from outside the Studio.
+      </div>
+    </div>
+  </div>
+</template>

--- a/frontend/src/hooks/useContractListener.ts
+++ b/frontend/src/hooks/useContractListener.ts
@@ -23,6 +23,7 @@ export function useContractListener() {
         contractId: localDeployTx.localContractId,
         address: eventData.data.id,
         defaultState: eventData.data.data.state,
+        deployTxHash: localDeployTx.hash,
       });
     }
   }

--- a/frontend/src/types/store.ts
+++ b/frontend/src/types/store.ts
@@ -17,6 +17,7 @@ export interface DeployedContract {
   contractId: string;
   address: Address;
   defaultState: string;
+  deployTxHash?: `0x${string}`;
 }
 
 export interface NodeLog {

--- a/frontend/src/views/Simulator/RunDebugView.vue
+++ b/frontend/src/views/Simulator/RunDebugView.vue
@@ -3,6 +3,7 @@ import ConstructorParameters from '@/components/Simulator/ConstructorParameters.
 import ContractReadMethods from '@/components/Simulator/ContractReadMethods.vue';
 import ContractWriteMethods from '@/components/Simulator/ContractWriteMethods.vue';
 import TransactionsList from '@/components/Simulator/TransactionsList.vue';
+import DeploymentSuccessPanel from '@/components/Simulator/DeploymentSuccessPanel.vue';
 import { useContractQueries } from '@/hooks';
 import MainTitle from '@/components/Simulator/MainTitle.vue';
 import { ref, watch, computed } from 'vue';
@@ -59,6 +60,33 @@ function isFinalityWindowValid(value: number) {
 }
 
 const consensusMaxRotations = computed(() => consensusStore.maxRotations);
+
+const showDeploymentSuccessPanel = ref(false);
+const newlyDeployedTxHash = ref('');
+
+watch(
+  [() => isDeployed.value, () => contract.value?.id],
+  ([newIsDeployed, newId], [oldIsDeployed, oldId]) => {
+    if (newIsDeployed && !oldIsDeployed && newId === oldId) {
+      showDeploymentSuccessPanel.value = true;
+      const deployedContract = contractsStore.deployedContracts.find(
+        (c) => c.contractId === newId,
+      );
+      newlyDeployedTxHash.value = deployedContract?.deployTxHash || '';
+    } else if (newId !== oldId) {
+      showDeploymentSuccessPanel.value = false;
+    }
+  },
+);
+
+const scrollToInteract = () => {
+  const el =
+    document.getElementById('tutorial-read-methods') ||
+    document.getElementById('tutorial-write-methods');
+  if (el) {
+    el.scrollIntoView({ behavior: 'smooth', block: 'center' });
+  }
+};
 </script>
 
 <template>
@@ -112,6 +140,16 @@ const consensusMaxRotations = computed(() => consensusStore.maxRotations);
         :showNewDeploymentButton="!isDeploymentOpen"
         @openDeployment="isDeploymentOpen = true"
       />
+
+      <div class="px-2">
+        <DeploymentSuccessPanel
+          v-if="showDeploymentSuccessPanel && isDeployed"
+          :contractAddress="address"
+          :txHash="newlyDeployedTxHash"
+          @close="showDeploymentSuccessPanel = false"
+          @interact="scrollToInteract"
+        />
+      </div>
 
       <template v-if="nodeStore.hasAtLeastOneValidator || uiStore.showTutorial">
         <ConstructorParameters


### PR DESCRIPTION
Resolves #1610

## What this does
This PR improves the post-deployment experience in GenLayer Studio by giving developers an immediate, clear path forward once a contract successfully deploys.

Previously, users had to manually find the Explorer, search for the transaction hash, and figure out how to interact with their contract. This creates a friction point, especially during onboarding.

This PR introduces a **Deployment Success Panel** that appears automatically when a deployment transaction reaches `FINALIZED` + `SUCCESS`.

## Changes
- **New Component:** `DeploymentSuccessPanel.vue` shows the deployed contract address and transaction hash with one-click copy buttons.
- **Explorer Deep-link:** Added a "View on Explorer" button that directly opens the transaction on the GenLayer Explorer (resolves based on connected network).
- **Smooth Flow:** Added an "Interact Now" button that scrolls the developer directly down to the Read/Write methods.
- **Store Updates:** `useContractListener` now extracts and stores the `deployTxHash` when a deployment finalizes, allowing the UI to link directly to the transaction.
- **Sidebar Context:** The shortened contract address is now displayed directly under the contract file name in the sidebar for quick visual reference.

## Acceptance Criteria Met
- [x] Post-deployment success panel renders when a contract reaches FINALIZED + SUCCESS
- [x] Contract address is displayed and has a working one-click copy button
- [x] Transaction hash is displayed and has a working one-click copy button
- [x] "View on Explorer" button opens the correct explorer URL in a new tab
- [x] "Interact Now" button scrolls to / focuses the Read/Write methods section
- [x] Panel persists until manually dismissed — does not auto-hide
- [x] Contract address is shown in the sidebar under the contract filename after deployment
- [x] Explorer link resolves correctly based on connected network (no link for local networks)

## Testing
1. Deploy any contract.
2. Observe the success panel appearing at the top of the `Run & Debug` view once finalized.
3. Verify the Explorer deep link resolves to the correct transaction hash.
4. Verify the `Interact Now` button smoothly scrolls to the method execution section.
5. Check the `Files` sidebar to see the shortened address under the contract file name.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Deployment success panel showing contract address and transaction hash with copy controls, dismiss, and external explorer link.
  * "Interact Now" button that navigates to the contract interaction section and triggers smooth scrolling.

* **Style / UI**
  * Contract list items now show deployed addresses in muted secondary text and use a two-line layout with hover-revealed actions.
* **Behavior**
  * Success panel appears after deployment and can be closed.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/genlayerlabs/genlayer-studio/pull/1613?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->