### PR TITLE
fix(consensus): unblock finalization starved by continuous PENDING inflow

### DIFF
--- a/backend/consensus/worker.py
+++ b/backend/consensus/worker.py
@@ -7,7 +7,7 @@ import uuid
 from contextlib import asynccontextmanager
 from typing import Callable, Optional, Any
 from sqlalchemy.orm import Session
-from sqlalchemy import text
+from sqlalchemy import text, bindparam
 
 from backend.database_handler.models import Transactions, TransactionStatus
 from backend.database_handler.transactions_processor import TransactionsProcessor
@@ -143,6 +143,13 @@ class ConsensusWorker:
         # the per-contract queue can advance past a poisoned head.
         self._max_recovery_cycles = int(
             os.environ.get("RECOVERY_MAX_CYCLES", str(self.MAX_RECOVERY_CYCLES))
+        )
+
+        # Multiplier (× finality_window_time) past which a finalization-eligible
+        # tx is considered "stuck" and worth a warning log. Default 10× catches
+        # genuine starvation while ignoring routine waiting.
+        self._stuck_finalization_window_multiplier = int(
+            os.environ.get("STUCK_FINALIZATION_WINDOW_MULTIPLIER", "10")
         )
 
         # Initialize usage metrics service for reporting transaction metrics
@@ -428,6 +435,29 @@ class ConsensusWorker:
                             AND t2.blocked_at > NOW() - CAST(:timeout AS INTERVAL)
                             AND t2.hash != t.hash
                     )
+                    -- Defer to eligible finalizations on the same contract.
+                    -- Both this query and claim_next_finalization gate on the
+                    -- same per-contract serialization (NOT EXISTS + advisory
+                    -- lock). With continuous PENDING inflow, claim_next_transaction
+                    -- can keep winning the slot and starve finalization for days.
+                    -- This clause makes PENDING/ACTIVATED claims defer when an
+                    -- ACCEPTED-class tx for the same contract is past its
+                    -- finality window — letting finalization drain the queue.
+                    AND NOT EXISTS (
+                        SELECT 1 FROM transactions t3
+                        WHERE t3.to_address IS NOT DISTINCT FROM t.to_address
+                            AND t3.status IN ('ACCEPTED', 'UNDETERMINED', 'LEADER_TIMEOUT', 'VALIDATORS_TIMEOUT')
+                            AND t3.appealed = false
+                            AND t3.timestamp_awaiting_finalization IS NOT NULL
+                            AND (
+                                t3.execution_mode IN ('LEADER_ONLY', 'LEADER_SELF_VALIDATOR')
+                                OR (
+                                    EXTRACT(EPOCH FROM NOW()) - t3.timestamp_awaiting_finalization - COALESCE(t3.appeal_processing_time, 0)
+                                ) > :finality_window_seconds * POWER(1 - :appeal_failed_reduction, COALESCE(t3.appeal_failed, 0))
+                            )
+                            AND (t3.blocked_at IS NULL
+                                 OR t3.blocked_at < NOW() - CAST(:timeout AS INTERVAL))
+                    )
                     -- Atomic per-contract lock to close TOCTOU window in NOT EXISTS.
                     -- Under READ COMMITTED, two workers can both pass NOT EXISTS before
                     -- either commits blocked_at. This advisory lock prevents that race.
@@ -474,6 +504,8 @@ class ConsensusWorker:
             {
                 "worker_id": self.worker_id,
                 "timeout": f"{self.transaction_timeout_minutes} minutes",
+                "finality_window_seconds": self.consensus_algorithm.finality_window_time,
+                "appeal_failed_reduction": self.consensus_algorithm.finality_window_appeal_failed_reduction,
             },
         ).first()
         duration = time.perf_counter() - start_time
@@ -724,6 +756,28 @@ class ConsensusWorker:
                         exc_info=True,
                     )
 
+    # Statuses where the consensus result has been agreed and the tx is
+    # awaiting finalization. Recovery must NOT wipe consensus_data /
+    # consensus_history for these — that state is what gets promoted to
+    # FINALIZED. An orphaned finalization just needs blocked_at cleared
+    # so another worker can resume.
+    _FINALIZATION_ELIGIBLE_STATUSES = (
+        "ACCEPTED",
+        "UNDETERMINED",
+        "LEADER_TIMEOUT",
+        "VALIDATORS_TIMEOUT",
+    )
+
+    # Statuses where consensus is mid-flight. If a worker dies here,
+    # full reset to PENDING is correct — consensus will re-run.
+    _CONSENSUS_RECOVERABLE_STATUSES = (
+        "PENDING",
+        "ACTIVATED",
+        "PROPOSING",
+        "COMMITTING",
+        "REVEALING",
+    )
+
     async def recover_stuck_transactions(self, session: Session) -> int:
         """
         Recover transactions that have been stuck for too long.
@@ -743,6 +797,9 @@ class ConsensusWorker:
         # Step 1: escalate txs that have already hit the recovery limit.
         # These have been reset N times and keep getting stuck — cancel
         # them so the per-contract queue can drain.
+        # Restricted to consensus-recoverable statuses: ACCEPTED-class txs
+        # have agreed consensus and shouldn't be canceled by recovery
+        # (Step 1b handles their orphan case via release-only).
         escalate_query = text(
             """
             UPDATE transactions
@@ -755,7 +812,7 @@ class ConsensusWorker:
                                     'recovery_count', recovery_count
                                  )
             WHERE recovery_count >= :max_cycles
-              AND status NOT IN ('FINALIZED', 'CANCELED')
+              AND status IN :consensus_statuses
               AND (
                   (blocked_at IS NOT NULL
                    AND blocked_at < NOW() - CAST(:timeout AS INTERVAL))
@@ -766,13 +823,14 @@ class ConsensusWorker:
               )
             RETURNING hash, recovery_count;
             """
-        )
+        ).bindparams(bindparam("consensus_statuses", expanding=True))
         escalated = session.execute(
             escalate_query,
             {
                 "max_cycles": self._max_recovery_cycles,
                 "timeout": f"{self.transaction_timeout_minutes} minutes",
                 "orphan_timeout": "5 minutes",
+                "consensus_statuses": list(self._CONSENSUS_RECOVERABLE_STATUSES),
             },
         ).fetchall()
         if escalated:
@@ -783,7 +841,43 @@ class ConsensusWorker:
                     f"after {row.recovery_count} recovery cycles (stuck repeatedly)"
                 )
 
+        # Step 1b: release orphaned finalization-eligible txs.
+        # If a worker dies mid-finalization on an ACCEPTED-class tx, its
+        # blocked_at goes stale. The tx has agreed consensus_data that
+        # MUST survive — finalization will resume from it. Just clear
+        # blocked_at + worker_id; do NOT wipe state or change status, do
+        # NOT bump recovery_count (this isn't a consensus failure, just a
+        # released claim).
+        release_finalization_query = text(
+            """
+            UPDATE transactions
+            SET blocked_at = NULL,
+                worker_id = NULL
+            WHERE blocked_at IS NOT NULL
+              AND blocked_at < NOW() - CAST(:timeout AS INTERVAL)
+              AND status IN :finalization_statuses
+            RETURNING hash, status;
+            """
+        ).bindparams(bindparam("finalization_statuses", expanding=True))
+        released = session.execute(
+            release_finalization_query,
+            {
+                "timeout": f"{self.transaction_timeout_minutes} minutes",
+                "finalization_statuses": list(self._FINALIZATION_ELIGIBLE_STATUSES),
+            },
+        ).fetchall()
+        if released:
+            session.commit()
+            for row in released:
+                logger.info(
+                    f"[Worker {self.worker_id}] Released orphaned finalization "
+                    f"{row.hash} (status={row.status}, state preserved)"
+                )
+
         # Step 2: reset txs under the limit and bump their counter.
+        # Restricted to consensus-recoverable statuses to avoid wiping
+        # consensus_data / consensus_history for ACCEPTED-class txs
+        # (those are handled by Step 1b above).
         recovery_query = text(
             """
             UPDATE transactions
@@ -794,11 +888,11 @@ class ConsensusWorker:
                 status = 'PENDING',
                 recovery_count = recovery_count + 1
             WHERE recovery_count < :max_cycles
+              AND status IN :consensus_statuses
               AND (
                   -- Case 1: Transactions with expired blocks
                   (blocked_at IS NOT NULL
-                   AND blocked_at < NOW() - CAST(:timeout AS INTERVAL)
-                   AND status NOT IN ('FINALIZED', 'CANCELED'))
+                   AND blocked_at < NOW() - CAST(:timeout AS INTERVAL))
                   OR
                   -- Case 2: Orphaned transactions in processing states with no block
                   (blocked_at IS NULL
@@ -807,7 +901,7 @@ class ConsensusWorker:
               )
             RETURNING hash, status, recovery_count;
             """
-        )
+        ).bindparams(bindparam("consensus_statuses", expanding=True))
 
         result = session.execute(
             recovery_query,
@@ -815,6 +909,7 @@ class ConsensusWorker:
                 "max_cycles": self._max_recovery_cycles,
                 "timeout": f"{self.transaction_timeout_minutes} minutes",
                 "orphan_timeout": "5 minutes",  # Shorter timeout for orphaned transactions
+                "consensus_statuses": list(self._CONSENSUS_RECOVERABLE_STATUSES),
             },
         )
         recovered = result.fetchall()
@@ -825,6 +920,49 @@ class ConsensusWorker:
                     f"[Worker {self.worker_id}] Recovered stuck transaction {row.hash} "
                     f"(was {row.status}, now PENDING, cycle {row.recovery_count}/"
                     f"{self._max_recovery_cycles})"
+                )
+
+        # Step 3: safety-net detector for finalization-eligible txs that
+        # have been waiting far longer than the finality window. If
+        # finalization scheduling is healthy these never appear; if they
+        # do, something is starving finalization (e.g., the scheduler
+        # bug this comment exists because of) and we want loud signal,
+        # not 5 days of silent backlog.
+        finality_window = self.consensus_algorithm.finality_window_time
+        stuck_threshold_seconds = (
+            finality_window * self._stuck_finalization_window_multiplier
+        )
+        stuck_finalization_query = text(
+            """
+            SELECT hash, status, to_address,
+                   EXTRACT(EPOCH FROM NOW())::bigint
+                       - timestamp_awaiting_finalization AS waiting_seconds
+            FROM transactions
+            WHERE status IN :finalization_statuses
+              AND blocked_at IS NULL
+              AND timestamp_awaiting_finalization IS NOT NULL
+              AND (
+                  EXTRACT(EPOCH FROM NOW()) - timestamp_awaiting_finalization
+              ) > :threshold_seconds
+            ORDER BY timestamp_awaiting_finalization ASC
+            LIMIT 50
+            """
+        ).bindparams(bindparam("finalization_statuses", expanding=True))
+        stuck = session.execute(
+            stuck_finalization_query,
+            {
+                "finalization_statuses": list(self._FINALIZATION_ELIGIBLE_STATUSES),
+                "threshold_seconds": stuck_threshold_seconds,
+            },
+        ).fetchall()
+        if stuck:
+            for row in stuck:
+                logger.warning(
+                    f"[Worker {self.worker_id}] Finalization-eligible tx "
+                    f"{row.hash} (status={row.status}, contract={row.to_address}) "
+                    f"has been awaiting finalization for {row.waiting_seconds}s "
+                    f"(>{int(stuck_threshold_seconds)}s threshold). "
+                    f"Likely finalization-starvation — investigate."
                 )
 
         return len(recovered)

--- a/tests/db-sqlalchemy/test_finalization_starvation.py
+++ b/tests/db-sqlalchemy/test_finalization_starvation.py
@@ -1,0 +1,354 @@
+"""
+Regression tests for finalization-starvation in ConsensusWorker scheduling.
+
+Bug history (May 2026): on contracts with continuous PENDING inflow, ACCEPTED
+txs sat 5+ days waiting for finalization. Root cause: claim_next_transaction
+and claim_next_finalization shared per-contract serialization (NOT EXISTS +
+advisory lock). With ~16 PENDINGs/hr arriving and consensus taking ~3 min,
+PENDING-processing continuously held the slot — finalization windows of 30s
+rarely opened. Compounded by recover_stuck_transactions wiping consensus_data
+for ACCEPTED txs whose finalization worker died (treating them as stuck
+consensus).
+
+These tests cover:
+1. claim_next_transaction defers when an eligible finalization exists.
+2. claim_next_transaction proceeds when finalization for the contract is
+   already in flight (preserves liveness — no infinite defer loop).
+3. recover_stuck_transactions preserves consensus_data for finalization-
+   eligible statuses (ACCEPTED/UNDETERMINED/*_TIMEOUT).
+4. Safety-net log fires when an ACCEPTED tx's wait exceeds N×finality_window.
+"""
+
+import time
+import os
+import pytest
+from unittest.mock import MagicMock
+from sqlalchemy import Engine, text
+from sqlalchemy.orm import sessionmaker, Session
+from contextlib import contextmanager
+from typing import Iterable
+
+# Ensure consensus env vars are set before ConsensusWorker imports
+# ConsensusAlgorithm (which reads them at __init__).
+os.environ.setdefault("VITE_FINALITY_WINDOW", "30")
+os.environ.setdefault("VITE_FINALITY_WINDOW_APPEAL_FAILED_REDUCTION", "0.2")
+
+from backend.database_handler.models import CurrentState, TransactionStatus
+from backend.consensus.worker import ConsensusWorker
+
+
+CONTRACT_ADDRESS = "0xfinalization_starvation_test_contract"
+SENDER = "0x" + "ab" * 20
+
+
+def _setup_contract(engine: Engine):
+    Session_ = sessionmaker(bind=engine)
+    with Session_() as s:
+        s.add(
+            CurrentState(
+                id=CONTRACT_ADDRESS,
+                data={
+                    "state": {
+                        "accepted": {"slot": "init"},
+                        "finalized": {"slot": "init"},
+                    }
+                },
+            )
+        )
+        s.commit()
+
+
+def _insert_tx(
+    session: Session,
+    *,
+    tx_hash: str,
+    status: str,
+    nonce: int,
+    to_address: str = CONTRACT_ADDRESS,
+    timestamp_awaiting_finalization: int | None = None,
+    consensus_data: dict | None = None,
+    consensus_history: dict | None = None,
+    blocked_at_offset_seconds: int | None = None,  # negative = past
+):
+    """Insert a transaction directly, bypassing TransactionsProcessor's
+    PENDING-default and other defaults — we want full control over the row
+    state for these scheduling tests."""
+    blocked_at_clause = "NULL"
+    if blocked_at_offset_seconds is not None:
+        blocked_at_clause = f"NOW() + INTERVAL '{blocked_at_offset_seconds} seconds'"
+    session.execute(
+        text(
+            f"""
+            INSERT INTO transactions (
+                hash, status, from_address, to_address,
+                data, value, type, nonce,
+                leader_only, execution_mode,
+                appealed, appeal_failed, appeal_undetermined,
+                appeal_leader_timeout, appeal_validators_timeout,
+                appeal_processing_time,
+                timestamp_awaiting_finalization,
+                consensus_data, consensus_history,
+                blocked_at, recovery_count, value_credited
+            ) VALUES (
+                :hash, CAST(:status AS transaction_status), :from_addr, :to_addr,
+                CAST(:data AS jsonb), 0, 2, :nonce,
+                false, 'NORMAL',
+                false, 0, false,
+                false, false,
+                0,
+                :timestamp_awaiting_finalization,
+                CAST(:consensus_data AS jsonb), CAST(:consensus_history AS jsonb),
+                {blocked_at_clause}, 0, false
+            )
+            """
+        ),
+        {
+            "hash": tx_hash,
+            "status": status,
+            "from_addr": SENDER,
+            "to_addr": to_address,
+            "data": '{"calldata": "test"}',
+            "nonce": nonce,
+            "timestamp_awaiting_finalization": timestamp_awaiting_finalization,
+            "consensus_data": (
+                None
+                if consensus_data is None
+                else __import__("json").dumps(consensus_data)
+            ),
+            "consensus_history": (
+                None
+                if consensus_history is None
+                else __import__("json").dumps(consensus_history)
+            ),
+        },
+    )
+    session.commit()
+
+
+@pytest.fixture
+def worker(engine: Engine) -> Iterable[ConsensusWorker]:
+    """Minimal ConsensusWorker wired to the test DB. Uses MagicMock for
+    everything that's not exercised by claim/recover paths."""
+    Session_ = sessionmaker(bind=engine, expire_on_commit=False)
+
+    @contextmanager
+    def get_session():
+        s = Session_()
+        try:
+            yield s
+        finally:
+            s.close()
+
+    w = ConsensusWorker(
+        get_session=get_session,
+        msg_handler=MagicMock(),
+        consensus_service=MagicMock(),
+        validators_manager=MagicMock(),
+        genvm_manager=MagicMock(),
+        worker_id="test-worker",
+        transaction_timeout_minutes=20,
+    )
+    yield w
+
+
+@pytest.fixture
+def session(engine: Engine) -> Iterable[Session]:
+    Session_ = sessionmaker(bind=engine, expire_on_commit=False)
+    s = Session_()
+    yield s
+    s.close()
+
+
+@pytest.mark.asyncio
+async def test_claim_next_transaction_defers_to_eligible_finalization(
+    engine: Engine, worker: ConsensusWorker, session: Session
+):
+    """A PENDING tx is NOT claimed when an eligible finalization exists for
+    the same contract — this is the fix for finalization starvation."""
+    _setup_contract(engine)
+
+    # Eligible finalization: ACCEPTED, NULL blocked_at, finality window past.
+    _insert_tx(
+        session,
+        tx_hash="0x" + "11" * 32,
+        status="ACCEPTED",
+        nonce=0,
+        timestamp_awaiting_finalization=int(time.time()) - 600,  # 10 min ago
+        consensus_data={
+            "votes": {},
+            "leader_receipt": [{"vote": "agree"}],
+            "validators": [],
+        },
+    )
+    # Newer PENDING for same contract.
+    _insert_tx(session, tx_hash="0x" + "22" * 32, status="PENDING", nonce=1)
+
+    claimed = await worker.claim_next_transaction(session)
+
+    assert claimed is None, (
+        "claim_next_transaction must defer to eligible finalization on the "
+        "same contract — got "
+        f"{claimed}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_claim_next_transaction_proceeds_when_no_eligible_finalization(
+    engine: Engine, worker: ConsensusWorker, session: Session
+):
+    """Without an eligible finalization, claim_next_transaction works
+    normally. Sanity check that the new gate doesn't break the happy path."""
+    _setup_contract(engine)
+    _insert_tx(session, tx_hash="0x" + "33" * 32, status="PENDING", nonce=0)
+
+    claimed = await worker.claim_next_transaction(session)
+
+    assert claimed is not None
+    assert claimed["hash"] == "0x" + "33" * 32
+
+
+@pytest.mark.asyncio
+async def test_claim_next_transaction_proceeds_when_finalization_window_not_yet_elapsed(
+    engine: Engine, worker: ConsensusWorker, session: Session
+):
+    """If an ACCEPTED tx exists but its finality window hasn't elapsed yet,
+    PENDING claims should still proceed — only ELIGIBLE finalizations gate."""
+    _setup_contract(engine)
+    # ACCEPTED tx that JUST became eligible-for-waiting; window not yet up
+    # (default VITE_FINALITY_WINDOW=30s; set timestamp to 1s ago).
+    _insert_tx(
+        session,
+        tx_hash="0x" + "44" * 32,
+        status="ACCEPTED",
+        nonce=0,
+        timestamp_awaiting_finalization=int(time.time()) - 1,
+        consensus_data={"leader_receipt": [{}], "votes": {}, "validators": []},
+    )
+    _insert_tx(session, tx_hash="0x" + "55" * 32, status="PENDING", nonce=1)
+
+    claimed = await worker.claim_next_transaction(session)
+
+    assert claimed is not None
+    assert claimed["hash"] == "0x" + "55" * 32
+
+
+@pytest.mark.asyncio
+async def test_recover_does_not_wipe_consensus_data_for_accepted(
+    engine: Engine, worker: ConsensusWorker, session: Session
+):
+    """When an ACCEPTED tx's blocked_at expires (worker died mid-
+    finalization), recovery must release blocked_at WITHOUT wiping
+    consensus_data — that state is what finalization promotes."""
+    _setup_contract(engine)
+    consensus_data = {
+        "votes": {"0xabc": "agree"},
+        "leader_receipt": [{"vote": "agree", "execution_result": "SUCCESS"}],
+        "validators": [],
+    }
+    consensus_history = {"consensus_results": [{"monitoring": {"PENDING": 123}}]}
+    tx_hash = "0x" + "66" * 32
+
+    # blocked_at 25 minutes ago (worker.transaction_timeout_minutes=20)
+    _insert_tx(
+        session,
+        tx_hash=tx_hash,
+        status="ACCEPTED",
+        nonce=0,
+        timestamp_awaiting_finalization=int(time.time()) - 600,
+        consensus_data=consensus_data,
+        consensus_history=consensus_history,
+        blocked_at_offset_seconds=-25 * 60,
+    )
+
+    await worker.recover_stuck_transactions(session)
+
+    row = session.execute(
+        text(
+            "SELECT status, blocked_at, worker_id, consensus_data, consensus_history "
+            "FROM transactions WHERE hash = :h"
+        ),
+        {"h": tx_hash},
+    ).one()
+    assert row.status == TransactionStatus.ACCEPTED.value
+    assert row.blocked_at is None
+    assert row.worker_id is None
+    assert row.consensus_data == consensus_data, (
+        "Recovery must NOT wipe consensus_data for ACCEPTED-class txs — that "
+        "state is what FinalizingState promotes to FINALIZED."
+    )
+    assert row.consensus_history == consensus_history
+
+
+@pytest.mark.asyncio
+async def test_recover_still_resets_stuck_consensus_txs(
+    engine: Engine, worker: ConsensusWorker, session: Session
+):
+    """A tx genuinely stuck in PROPOSING/COMMITTING/REVEALING with expired
+    blocked_at must still be reset to PENDING. The new restriction must
+    not break consensus-recovery."""
+    _setup_contract(engine)
+    tx_hash = "0x" + "77" * 32
+
+    _insert_tx(
+        session,
+        tx_hash=tx_hash,
+        status="COMMITTING",
+        nonce=0,
+        consensus_data={"leader_receipt": [{}]},
+        consensus_history={"consensus_results": [{}]},
+        blocked_at_offset_seconds=-25 * 60,
+    )
+
+    await worker.recover_stuck_transactions(session)
+
+    row = session.execute(
+        text(
+            "SELECT status, recovery_count, consensus_data, consensus_history "
+            "FROM transactions WHERE hash = :h"
+        ),
+        {"h": tx_hash},
+    ).one()
+    assert row.status == TransactionStatus.PENDING.value
+    assert row.recovery_count == 1
+    assert row.consensus_data is None
+    assert row.consensus_history is None
+
+
+@pytest.mark.asyncio
+async def test_safety_net_warns_on_long_stuck_finalization(
+    engine: Engine, worker: ConsensusWorker, session: Session, caplog
+):
+    """An ACCEPTED tx with NULL blocked_at and a timestamp older than
+    N×finality_window must emit a warning log so we catch starvation
+    early instead of going days unnoticed."""
+    import logging
+
+    _setup_contract(engine)
+    tx_hash = "0x" + "88" * 32
+    # finality_window=30s, multiplier=10 → threshold 300s. Use 600s.
+    _insert_tx(
+        session,
+        tx_hash=tx_hash,
+        status="ACCEPTED",
+        nonce=0,
+        timestamp_awaiting_finalization=int(time.time()) - 600,
+        consensus_data={"leader_receipt": [{}]},
+    )
+
+    # loguru → standard logging bridge for caplog
+    from loguru import logger as loguru_logger
+
+    handler_id = loguru_logger.add(
+        lambda msg: logging.getLogger("loguru").warning(msg.record["message"]),
+        level="WARNING",
+    )
+    try:
+        with caplog.at_level(logging.WARNING, logger="loguru"):
+            await worker.recover_stuck_transactions(session)
+    finally:
+        loguru_logger.remove(handler_id)
+
+    assert any(
+        tx_hash in record.getMessage() and "starvation" in record.getMessage().lower()
+        for record in caplog.records
+    ), f"Expected starvation warning for {tx_hash}; got {[r.getMessage() for r in caplog.records]}"


### PR DESCRIPTION
## Summary

In Studio Prod, contracts with steady PENDING inflow (e.g., one tx every ~4 min) had ACCEPTED transactions sit unfinalized for **5+ days**. Root cause: per-contract serialization in worker scheduling means PENDING-processing and finalization compete for one slot. With PENDING arriving faster than consensus completes, finalization is starved indefinitely.

This is **PR 1 of 2**. It's the immediate stabilizer that prevents the starvation pattern. Part 2 will tackle the underlying coupling (finalization reads fresh contract state instead of the tx's own stored leader receipt; nonce assignment for triggered children is racy) so finalization can run truly concurrently with new consensus.

## What changed

1. **`claim_next_transaction` now defers to eligible finalizations on the same contract.** Workers fall through to other contracts so cluster-wide PENDING throughput is preserved while the affected contract drains its finalization queue.

2. **`recover_stuck_transactions` no longer wipes consensus state for ACCEPTED-class txs.** Previously, if a worker died mid-finalization on an ACCEPTED tx, recovery silently destroyed the agreed leader receipt and demoted to PENDING — masking the starvation problem and re-running consensus from scratch. Now those txs get release-only treatment (clear `blocked_at`/`worker_id`, preserve `consensus_data`/`consensus_history`, no `recovery_count` bump).

3. **New safety-net detector** logs a warning if any finalization-eligible tx waits longer than `STUCK_FINALIZATION_WINDOW_MULTIPLIER × VITE_FINALITY_WINDOW` (default 10×) with NULL `blocked_at`. Catches future starvation regressions before they go days unnoticed.

## Why these three together

The new gate (#1) is the actual fix for the starvation pattern. The recovery guard (#2) is critical because PR 1 makes finalization operations more frequent → more surface area for the latent recovery bug — left unfixed, a worker pod restart mid-finalization would silently corrupt the agreed state. The safety-net (#3) gives us early warning if scheduling regresses again.

## Why this isn't the full fix

The deeper issue is that `FinalizingState.handle` reads CURRENT contract `accepted` state instead of the tx's own stored `leader_receipt.contract_state`, and triggered-tx nonce assignment uses unlocked `COUNT(*)`. These bugs prevent us from simply allowing finalization and new consensus to run concurrently — they're why the per-contract lock exists. PR 2 will address those at the source so finalization can be truly independent.

## Test plan

- [x] New `tests/db-sqlalchemy/test_finalization_starvation.py` (6 tests): defer-on-eligible, proceed-when-no-eligible, proceed-during-window, recover-preserves-ACCEPTED-state, recover-still-resets-stuck-consensus, safety-net-warning-emission. All pass.
- [x] Full `tests/db-sqlalchemy/` suite: 127 passed, 1 xfailed (pre-existing).
- [x] Worker-related unit tests (`test_worker_leader_crash_retry.py`, `test_worker_health_degradation.py`, `test_contract_not_found_handling.py`): all 23 pass.
- [ ] Manual smoke after deploy to staging — observe at least one ACCEPTED→FINALIZED on a hot contract under continuous load.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved transaction claim deferral logic to prevent finalization starvation
  * Enhanced recovery system to release blocked transactions while preserving consensus data
  * Added early-warning detection for transactions experiencing prolonged finalization delays

* **Tests**
  * Added comprehensive regression test coverage for finalization starvation scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->