### PR TITLE
Security: Private Keys Can Be Logged

### DIFF
--- a/backend/protocol_rpc/message_handler/types.py
+++ b/backend/protocol_rpc/message_handler/types.py
@@ -19,14 +19,6 @@ class EventScope(Enum):
     TRANSACTION = "Transaction"
 
 
-def show_validator_private_keys_in_logs() -> bool:
-    return os.getenv("SHOW_VALIDATOR_PRIVATE_KEYS_IN_LOGS", "").lower() in {
-        "1",
-        "true",
-        "yes",
-    }
-
-
 def _is_private_key_field(key: Any) -> bool:
     if not isinstance(key, str):
         return False
@@ -37,9 +29,6 @@ def _is_private_key_field(key: Any) -> bool:
 
 def sanitize_log_data(value: Any) -> Any:
     """Return a copy of log data with private-key fields removed."""
-    if show_validator_private_keys_in_logs():
-        return value
-
     if isinstance(value, dict):
         return {
             key: sanitize_log_data(item)


### PR DESCRIPTION
## Summary

Security: Private Keys Can Be Logged

## Problem

**Severity**: `High` | **File**: `backend/protocol_rpc/message_handler/types.py:L16`

The function show_validator_private_keys_in_logs() in message_handler/types.py allows private keys to be logged via the SHOW_VALIDATOR_PRIVATE_KEYS_IN_LOGS environment variable. Even though there's sanitization, enabling this environment variable defeats the purpose of keeping keys secret.

## Solution

Remove the SHOW_VALIDATOR_PRIVATE_KEYS_IN_LOGS environment variable option entirely. Private keys should never be logged under any circumstances. The environment variable and related functions should be removed.

## Changes

- `backend/protocol_rpc/message_handler/types.py` (modified)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Removed the option to expose validator private keys in logs. All private key data is now consistently redacted from logs without exception, enhancing security.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->