### PR TITLE
feat(rpc): per-contract / per-sender PENDING queue-depth admission control

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -97,6 +97,12 @@ RATE_LIMIT_ANON_PER_MINUTE='30'      # Anonymous (no API key) per-minute limit
 RATE_LIMIT_ANON_PER_HOUR='500'       # Anonymous per-hour limit
 RATE_LIMIT_ANON_PER_DAY='5000'       # Anonymous per-day limit
 
+# PENDING-tx queue depth caps for eth_sendRawTransaction (admission control).
+# Empty / unset = no cap (the default for self-hosted). Public shared
+# deployments should set both to prevent one user filling the queue.
+MAX_PENDING_PER_CONTRACT_DEFAULT=''  # Cap PENDING txs per contract (e.g. 50)
+MAX_PENDING_PER_SENDER_DEFAULT=''    # Cap PENDING txs per sender   (e.g. 20)
+
 ########################################
 # Usage Metrics Configuration (Optional)
 # Set these to enable sending transaction metrics to an external API

--- a/backend/protocol_rpc/endpoints.py
+++ b/backend/protocol_rpc/endpoints.py
@@ -6,8 +6,12 @@ import eth_utils
 import logging
 from functools import partial, wraps
 from typing import Any
-from backend.protocol_rpc.exceptions import JSONRPCError, NotFoundError
-from sqlalchemy import Table
+from backend.protocol_rpc.exceptions import (
+    JSONRPCError,
+    NotFoundError,
+    QueueDepthExceeded,
+)
+from sqlalchemy import Table, text
 from sqlalchemy.orm import Session
 import backend.validators as validators
 
@@ -98,6 +102,106 @@ def _check_rate_limit(address: str) -> None:
         )
     timestamps.append(now)
     _address_request_log[address] = timestamps
+
+
+# ---------------------------------------------------------------------------
+# Admission control on PENDING queue depth (eth_sendRawTransaction path).
+#
+# Studio Prod is a shared sandbox. Without this, a single user can submit
+# thousands of txs to one contract and starve everyone else's contracts
+# behind a 5-day backlog. We cap PENDING per (to_address) and per
+# (from_address) at submission time and return a structured error pointing
+# users at non-shared deployments for production-volume workloads.
+#
+# Both caps default to unset (unlimited) — meaningful only when explicitly
+# configured (the public studio deployment sets them; self-hosted does not).
+# ---------------------------------------------------------------------------
+def _parse_optional_positive_int(env_name: str) -> int | None:
+    raw = os.environ.get(env_name)
+    if raw is None or raw.strip() == "":
+        return None
+    try:
+        parsed = int(raw)
+    except (ValueError, TypeError):
+        return None
+    return parsed if parsed > 0 else None
+
+
+_MAX_PENDING_PER_CONTRACT = _parse_optional_positive_int(
+    "MAX_PENDING_PER_CONTRACT_DEFAULT"
+)
+_MAX_PENDING_PER_SENDER = _parse_optional_positive_int("MAX_PENDING_PER_SENDER_DEFAULT")
+
+# Generic guidance text in the error response — directs heavy users to
+# non-shared deployments rather than retrying against the same instance.
+_QUEUE_DEPTH_HELP = (
+    "The public Studio is a shared sandbox with per-contract and "
+    "per-sender PENDING transaction caps. For production-volume "
+    "workloads, run a self-hosted instance or use Rally."
+)
+
+
+def _enforce_pending_queue_caps(
+    transactions_processor,
+    to_address: str | None,
+    from_address: str | None,
+) -> None:
+    """Raise QueueDepthExceeded if the per-contract or per-sender cap is hit.
+
+    Both checks are best-effort and racy by design — two concurrent
+    submissions can both pass the COUNT(*) check before either commits,
+    so the actual depth can transiently exceed the cap by a few. That's
+    fine; the goal is to prevent unbounded growth, not to enforce an
+    exact bound.
+    """
+    if _MAX_PENDING_PER_CONTRACT is not None and to_address is not None:
+        contract_pending = transactions_processor.session.execute(
+            text(
+                "SELECT COUNT(*) FROM transactions "
+                "WHERE to_address = :addr AND status = 'PENDING'"
+            ),
+            {"addr": to_address},
+        ).scalar()
+        if (
+            contract_pending is not None
+            and contract_pending >= _MAX_PENDING_PER_CONTRACT
+        ):
+            raise QueueDepthExceeded(
+                message=(
+                    f"Contract {to_address} has {contract_pending} pending "
+                    f"transactions (limit: {_MAX_PENDING_PER_CONTRACT}). "
+                    f"{_QUEUE_DEPTH_HELP}"
+                ),
+                data={
+                    "scope": "contract",
+                    "address": to_address,
+                    "pending": contract_pending,
+                    "limit": _MAX_PENDING_PER_CONTRACT,
+                },
+            )
+
+    if _MAX_PENDING_PER_SENDER is not None and from_address is not None:
+        sender_pending = transactions_processor.session.execute(
+            text(
+                "SELECT COUNT(*) FROM transactions "
+                "WHERE from_address = :addr AND status = 'PENDING'"
+            ),
+            {"addr": from_address},
+        ).scalar()
+        if sender_pending is not None and sender_pending >= _MAX_PENDING_PER_SENDER:
+            raise QueueDepthExceeded(
+                message=(
+                    f"Sender {from_address} has {sender_pending} pending "
+                    f"transactions (limit: {_MAX_PENDING_PER_SENDER}). "
+                    f"{_QUEUE_DEPTH_HELP}"
+                ),
+                data={
+                    "scope": "sender",
+                    "address": from_address,
+                    "pending": sender_pending,
+                    "limit": _MAX_PENDING_PER_SENDER,
+                },
+            )
 
 
 ####### ADMIN ACCESS CONTROL #######
@@ -1529,6 +1633,23 @@ def send_raw_transaction(
 
         # Check for duplicate before debit+insert to avoid TOCTOU races
         is_duplicate = transactions_processor.get_transaction_by_hash(transaction_hash)
+
+        # Queue-depth admission control: refuse new submissions when a
+        # contract or a sender already has too many txs queued. Studio Prod
+        # is a shared sandbox; without this, one heavy user (e.g. an
+        # external oracle backend running batch verifications) can pile up
+        # thousands of PENDING txs on a single contract and starve the
+        # network for everyone else.
+        #
+        # Skip duplicates (resubmission of an already-known hash is benign)
+        # and SEND txs (faucet/transfer; not subject to per-contract pile-up
+        # because to_address is a user account, not a contract).
+        if is_duplicate is None and genlayer_transaction.type != TransactionType.SEND:
+            _enforce_pending_queue_caps(
+                transactions_processor=transactions_processor,
+                to_address=to_address,
+                from_address=from_address,
+            )
 
         # Debit sender BEFORE insert. Mint on demand if insufficient (Studio sandbox).
         # Skip for SEND (execute_transfer handles it) and duplicates.

--- a/backend/protocol_rpc/exceptions.py
+++ b/backend/protocol_rpc/exceptions.py
@@ -104,3 +104,19 @@ class RateLimitExceeded(JSONRPCError):
         self, message: str = "Rate limit exceeded", data: Optional[Any] = None
     ):
         super().__init__(code=-32029, message=message, data=data)
+
+
+class QueueDepthExceeded(JSONRPCError):
+    """Per-contract or per-sender PENDING tx cap reached.
+
+    Distinct from RateLimitExceeded: that one caps RPC call frequency,
+    this one caps how many in-flight transactions a single contract or
+    sender can have queued for consensus. Studio Prod is a shared
+    sandbox — without this cap, one heavy user can fill the queue and
+    starve everyone else's contracts.
+    """
+
+    def __init__(
+        self, message: str = "Queue depth exceeded", data: Optional[Any] = None
+    ):
+        super().__init__(code=-32030, message=message, data=data)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -125,6 +125,11 @@ services:
       - RATE_LIMIT_ANON_PER_MINUTE=${RATE_LIMIT_ANON_PER_MINUTE:-30}
       - RATE_LIMIT_ANON_PER_HOUR=${RATE_LIMIT_ANON_PER_HOUR:-500}
       - RATE_LIMIT_ANON_PER_DAY=${RATE_LIMIT_ANON_PER_DAY:-5000}
+      # Per-contract / per-sender PENDING tx caps (admission control on
+      # eth_sendRawTransaction). Empty/unset = no cap. Set in shared
+      # deployments to keep one heavy user from filling the queue.
+      - MAX_PENDING_PER_CONTRACT_DEFAULT=${MAX_PENDING_PER_CONTRACT_DEFAULT:-}
+      - MAX_PENDING_PER_SENDER_DEFAULT=${MAX_PENDING_PER_SENDER_DEFAULT:-}
     ports:
       - "${RPCPORT}:${RPCPORT}"
     expose:

--- a/tests/db-sqlalchemy/test_queue_depth_admission.py
+++ b/tests/db-sqlalchemy/test_queue_depth_admission.py
@@ -1,0 +1,192 @@
+"""
+Regression tests for the PENDING queue-depth admission control on
+eth_sendRawTransaction.
+
+Without this cap, a single user can pile up thousands of PENDING txs on
+one contract (observed in Studio Prod: one oracle backend backlogged
+~2000 verifications on a single contract for 5 days, starving other
+contracts behind it). The cap rejects new submissions at admission time
+with a structured QueueDepthExceeded error, pointing heavy users toward
+non-shared deployments.
+
+These tests exercise `_enforce_pending_queue_caps` directly against a
+real Postgres session so the COUNT(*) query and the raise paths are
+both covered.
+"""
+
+import importlib
+import pytest
+from sqlalchemy import Engine, text
+from sqlalchemy.orm import sessionmaker
+
+from backend.database_handler.transactions_processor import TransactionsProcessor
+from backend.protocol_rpc.exceptions import QueueDepthExceeded
+
+
+CONTRACT = "0x" + "ab" * 20
+SENDER = "0x" + "cd" * 20
+
+
+def _seed_pending(session, n: int, *, to_address: str, from_address: str) -> None:
+    """Insert n PENDING txs; explicit unique hashes keep them distinct."""
+    for i in range(n):
+        tx_hash = f"0x{i:064x}"
+        session.execute(
+            text(
+                """
+                INSERT INTO transactions (
+                    hash, status, from_address, to_address, data, value, type,
+                    nonce, leader_only, execution_mode, appealed, appeal_failed,
+                    appeal_undetermined, appeal_leader_timeout,
+                    appeal_validators_timeout, appeal_processing_time,
+                    recovery_count, value_credited
+                ) VALUES (
+                    :hash, CAST('PENDING' AS transaction_status),
+                    :from_addr, :to_addr, CAST('{}' AS jsonb), 0, 2,
+                    :nonce, false, 'NORMAL', false, 0,
+                    false, false, false, 0, 0, false
+                )
+                """
+            ),
+            {
+                "hash": tx_hash,
+                "from_addr": from_address,
+                "to_addr": to_address,
+                "nonce": i,
+            },
+        )
+    session.commit()
+
+
+def _reload_endpoints_module(monkeypatch, **env_overrides):
+    """Re-import endpoints with patched env so module-level cap vars are
+    re-read. The caps are parsed at import time, so each test that wants
+    a different cap setting needs a fresh module load."""
+    for k, v in env_overrides.items():
+        if v is None:
+            monkeypatch.delenv(k, raising=False)
+        else:
+            monkeypatch.setenv(k, v)
+    import backend.protocol_rpc.endpoints as endpoints
+
+    return importlib.reload(endpoints)
+
+
+def test_no_caps_set_allows_unlimited(engine: Engine, monkeypatch):
+    """Self-hosted default: both caps unset → never raises."""
+    Session_ = sessionmaker(bind=engine, expire_on_commit=False)
+    with Session_() as session:
+        _seed_pending(session, 100, to_address=CONTRACT, from_address=SENDER)
+        endpoints = _reload_endpoints_module(
+            monkeypatch,
+            MAX_PENDING_PER_CONTRACT_DEFAULT=None,
+            MAX_PENDING_PER_SENDER_DEFAULT=None,
+        )
+        tp = TransactionsProcessor(session)
+        # Should not raise even with 100 PENDING already.
+        endpoints._enforce_pending_queue_caps(
+            transactions_processor=tp,
+            to_address=CONTRACT,
+            from_address=SENDER,
+        )
+
+
+def test_per_contract_cap_rejects_when_at_limit(engine: Engine, monkeypatch):
+    Session_ = sessionmaker(bind=engine, expire_on_commit=False)
+    with Session_() as session:
+        _seed_pending(session, 50, to_address=CONTRACT, from_address=SENDER)
+        endpoints = _reload_endpoints_module(
+            monkeypatch,
+            MAX_PENDING_PER_CONTRACT_DEFAULT="50",
+            MAX_PENDING_PER_SENDER_DEFAULT=None,
+        )
+        tp = TransactionsProcessor(session)
+        with pytest.raises(QueueDepthExceeded) as exc_info:
+            endpoints._enforce_pending_queue_caps(
+                transactions_processor=tp,
+                to_address=CONTRACT,
+                from_address="0x" + "ee" * 20,  # different sender, contract is full
+            )
+        assert exc_info.value.data["scope"] == "contract"
+        assert exc_info.value.data["limit"] == 50
+        assert exc_info.value.data["pending"] == 50
+        # Error message should point users at alternatives.
+        assert "self-hosted" in exc_info.value.message.lower()
+
+
+def test_per_contract_cap_allows_under_limit(engine: Engine, monkeypatch):
+    Session_ = sessionmaker(bind=engine, expire_on_commit=False)
+    with Session_() as session:
+        _seed_pending(session, 49, to_address=CONTRACT, from_address=SENDER)
+        endpoints = _reload_endpoints_module(
+            monkeypatch,
+            MAX_PENDING_PER_CONTRACT_DEFAULT="50",
+            MAX_PENDING_PER_SENDER_DEFAULT=None,
+        )
+        tp = TransactionsProcessor(session)
+        # 49 < 50, must not raise.
+        endpoints._enforce_pending_queue_caps(
+            transactions_processor=tp,
+            to_address=CONTRACT,
+            from_address="0x" + "ee" * 20,
+        )
+
+
+def test_per_sender_cap_rejects_when_at_limit(engine: Engine, monkeypatch):
+    Session_ = sessionmaker(bind=engine, expire_on_commit=False)
+    with Session_() as session:
+        _seed_pending(session, 20, to_address=CONTRACT, from_address=SENDER)
+        endpoints = _reload_endpoints_module(
+            monkeypatch,
+            MAX_PENDING_PER_CONTRACT_DEFAULT=None,
+            MAX_PENDING_PER_SENDER_DEFAULT="20",
+        )
+        tp = TransactionsProcessor(session)
+        with pytest.raises(QueueDepthExceeded) as exc_info:
+            # Submitting to a DIFFERENT contract — per-sender cap still trips.
+            endpoints._enforce_pending_queue_caps(
+                transactions_processor=tp,
+                to_address="0x" + "ff" * 20,
+                from_address=SENDER,
+            )
+        assert exc_info.value.data["scope"] == "sender"
+        assert exc_info.value.data["limit"] == 20
+        assert exc_info.value.data["pending"] == 20
+
+
+def test_invalid_cap_env_value_falls_back_to_unlimited(engine: Engine, monkeypatch):
+    """Garbage values in env shouldn't break submissions — fall back to no cap."""
+    Session_ = sessionmaker(bind=engine, expire_on_commit=False)
+    with Session_() as session:
+        _seed_pending(session, 100, to_address=CONTRACT, from_address=SENDER)
+        endpoints = _reload_endpoints_module(
+            monkeypatch,
+            MAX_PENDING_PER_CONTRACT_DEFAULT="not-a-number",
+            MAX_PENDING_PER_SENDER_DEFAULT="-5",  # negative → ignored
+        )
+        tp = TransactionsProcessor(session)
+        endpoints._enforce_pending_queue_caps(
+            transactions_processor=tp,
+            to_address=CONTRACT,
+            from_address=SENDER,
+        )
+
+
+def test_null_to_address_is_skipped(engine: Engine, monkeypatch):
+    """Some tx types (faucet, burn) have NULL to_address. The cap should
+    silently skip the contract check for them — there's no contract queue
+    to overflow."""
+    Session_ = sessionmaker(bind=engine, expire_on_commit=False)
+    with Session_() as session:
+        endpoints = _reload_endpoints_module(
+            monkeypatch,
+            MAX_PENDING_PER_CONTRACT_DEFAULT="1",
+            MAX_PENDING_PER_SENDER_DEFAULT=None,
+        )
+        tp = TransactionsProcessor(session)
+        # to_address=None → contract check is skipped.
+        endpoints._enforce_pending_queue_caps(
+            transactions_processor=tp,
+            to_address=None,
+            from_address=SENDER,
+        )


### PR DESCRIPTION
## Summary

Adds two env-configurable caps that reject new \`eth_sendRawTransaction\` submissions at admission time when a contract or a sender already has too many txs queued. Companion change in \`devexp-apps-workload\` (separate PR) sets the prod values and turns on the existing API-level rate limiter.

## Motivation

Studio Prod has no admission control on PENDING queue depth. Today one heavy user can pile up thousands of PENDING txs on a single contract and starve everyone else behind the per-contract serialization gate (5+ day backlog observed). The deeper architectural fix is in flight (Phase 2: split per-contract lock); this PR is the immediate operational lever.

## What changed

- **\`MAX_PENDING_PER_CONTRACT_DEFAULT\`** — reject if \`to_address\` has ≥ N PENDING txs
- **\`MAX_PENDING_PER_SENDER_DEFAULT\`** — reject if \`from_address\` has ≥ N PENDING txs
- Both default to unset (unlimited) — meaningful only when explicitly configured
- New \`QueueDepthExceeded\` JSON-RPC error (code \`-32030\`) with structured \`data\` (scope/address/pending/limit) and a message that points heavy users at non-shared deployments (self-hosted / Rally)
- Check happens BEFORE sender-debit so failed admissions leave no half-applied state
- Skipped for duplicate submissions and SEND txs (faucet/transfer not subject to per-contract pile-up)

## Why no API-key bypass mechanism

Kept simple intentionally. The error message itself directs heavy users elsewhere; adding tier-based overrides can wait until we see who's actually hitting the cap and why. (Discussed in conversation; \`@edgars\` agreed to defer.)

## Test plan

- [x] New \`tests/db-sqlalchemy/test_queue_depth_admission.py\` — 6 tests:
  unlimited mode, per-contract reject, per-sender reject, under-limit allow,
  invalid env value → unlimited, NULL \`to_address\` → skip. **All pass.**
- [x] Full \`tests/db-sqlalchemy/\` suite: **134 passed, 1 xfailed (pre-existing)**
- [ ] Smoke after deploy to staging

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added queue depth admission control for pending transactions with configurable per-contract and per-sender caps to prevent queue flooding.
  * Pending transactions exceeding configured limits will be rejected with an error.
  * Caps can be left unset for unlimited transactions in shared deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->