### PR TITLE
fix(rpc): quiet sim_getConsensusContract log spam for missing deployments

### DIFF
--- a/backend/rollup/consensus_service.py
+++ b/backend/rollup/consensus_service.py
@@ -24,10 +24,18 @@ class ConsensusService:
         Get a contract instance
 
         Returns:
-            Contract: The contract instance
+            Contract: The contract instance.
+            None: If deployment data is unavailable for this contract on this
+                instance — the caller should treat this as a soft "not found"
+                rather than a system error. Hosted Studio does not ship the
+                hardhat deployment artifacts for the rollup-side consensus
+                contracts (Queues / RevealingPhase / IdlenessPhase / etc.)
+                because newer genlayer-js clients carry that info in their
+                chain config; older clients still fall through to this RPC.
 
         Raises:
-            Exception: If the contract deployment data cannot be loaded or the contract does not exist
+            Exception: If the contract should exist but the on-chain code is
+                missing, or for any other unexpected error.
         """
         # Load deployment data
         deployment_data = self._load_deployment_data(contract_name)
@@ -43,7 +51,11 @@ class ConsensusService:
                     return self.web3.eth.contract(
                         address=default_contract["address"], abi=default_contract["abi"]
                     )
-            raise Exception(f"Failed to load {contract_name} deployment data")
+            # Soft "not found" — caller (endpoints.get_contract) will turn
+            # this into a NotFoundError, which the RPC framework logs at the
+            # JSONRPCError soft-error path instead of the noisy
+            # "Unexpected error in sim_getConsensusContract" stderr print.
+            return None
 
         # Verify contract exists on chain
         code = self.web3.eth.get_code(deployment_data["address"])
@@ -76,6 +88,12 @@ class ConsensusService:
         """
         try:
             contract = self._get_contract(contract_name)
+            if contract is None:
+                # _get_contract returns None for the soft "deployment data
+                # missing" case — propagate that up so endpoints.get_contract
+                # raises NotFoundError instead of the caller seeing a bare
+                # exception.
+                return None
             deployment_data = self._load_deployment_data(contract_name)
 
             return {

--- a/tests/unit/test_consensus_contract_soft_not_found.py
+++ b/tests/unit/test_consensus_contract_soft_not_found.py
@@ -1,0 +1,62 @@
+"""
+Regression test: sim_getConsensusContract should produce a soft NotFoundError
+(structured JSON-RPC error) when the requested consensus contract has no
+deployment data on this instance — not a bare Exception.
+
+Hosted Studio doesn't ship the hardhat deployment artifacts for the
+rollup-side consensus contracts (Queues / RevealingPhase / IdlenessPhase).
+Newer genlayer-js carries that info in chain config and never calls this
+RPC. Older clients still fall through to it. Pre-fix, every fallback call
+spammed the jsonrpc log with:
+
+    Unexpected error in sim_getConsensusContract:
+    Failed to load Queues deployment data
+
+…via the bare-Exception print() in rpc_endpoint_manager. Post-fix,
+consensus_service.load_contract returns None, endpoints.get_contract
+raises NotFoundError, and the RPC framework routes it through the quiet
+soft-error path.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from backend.protocol_rpc import endpoints
+from backend.protocol_rpc.exceptions import NotFoundError
+
+
+def test_get_contract_raises_NotFoundError_when_load_contract_returns_None():
+    consensus_service = MagicMock()
+    consensus_service.load_contract.return_value = None
+
+    with pytest.raises(NotFoundError) as exc_info:
+        endpoints.get_contract(consensus_service, "Queues")
+
+    assert "Queues" in exc_info.value.message
+    # NotFoundError code is the standard "soft not found" code.
+    assert exc_info.value.code == -32001
+    consensus_service.load_contract.assert_called_once_with("Queues")
+
+
+def test_consensus_service_load_contract_returns_None_when_deployment_missing(
+    monkeypatch,
+):
+    """consensus_service.load_contract must return None — not raise — for
+    non-ConsensusMain contracts whose deployment file isn't on disk. This is
+    what bypasses the noisy bare-Exception path in rpc_endpoint_manager."""
+    from backend.rollup.consensus_service import ConsensusService
+
+    # Avoid the singleton Web3 connection pool grabbing a real chain.
+    monkeypatch.setattr(
+        "backend.rollup.web3_pool.Web3ConnectionPool.get",
+        lambda: MagicMock(),
+    )
+    svc = ConsensusService()
+
+    # _load_deployment_data returns None when the file is missing — simulate.
+    monkeypatch.setattr(svc, "_load_deployment_data", lambda name: None)
+
+    assert svc.load_contract("Queues") is None
+    assert svc.load_contract("RevealingPhase") is None
+    assert svc.load_contract("IdlenessPhase") is None


### PR DESCRIPTION
## Summary

Hosted Studio's jsonrpc pod was emitting pages of stderr noise per minute:

```
Unexpected error in sim_getConsensusContract:
Failed to load Queues deployment data
Unexpected error in sim_getConsensusContract:
Failed to load RevealingPhase deployment data
Unexpected error in sim_getConsensusContract:
Failed to load IdlenessPhase deployment data
…
```

Functionality was unaffected — clients gracefully handle the failure — but the log volume obscures real errors and was reported by a builder on Discord who thought Studio was down.

## Root cause

Hosted Studio doesn't ship the hardhat deployment artifacts (`/app/hardhat/deployments/genlayer_network/{Queues,RevealingPhase,IdlenessPhase}.json`) for the rollup-side consensus contracts. Newer `genlayer-js` carries that info in its bundled chain config and doesn't hit this RPC at all — but older clients fall through to it. Each call raised a bare `Exception` in `consensus_service._get_contract`, which the RPC framework treats as an unexpected internal error and dumps to stderr via `print()` (`rpc_endpoint_manager.py:253`).

## Fix

`consensus_service._get_contract` now returns `None` instead of raising when deployment data is missing for a non-ConsensusMain contract. `load_contract` propagates `None` up. `endpoints.get_contract` already raises `NotFoundError` when the contract is `None`. `NotFoundError` is a structured `JSONRPCError` that the RPC framework routes through the soft-error path — no stderr print, just structured session_logger.

Real errors (web3/network failures, on-chain code missing for an existing deployment) still propagate as before.

## Test plan

- [x] New `tests/unit/test_consensus_contract_soft_not_found.py` covers both:
  - `consensus_service.load_contract` returns `None` (not raise) for missing deployment files
  - `endpoints.get_contract` raises `NotFoundError` when load_contract returns `None`
- [x] Both tests pass locally

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for missing consensus contract deployment data with graceful "not found" responses instead of raising exceptions.

* **Tests**
  * Added regression tests verifying consensus contract "soft not found" behavior and error propagation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->