### PR TITLE
feat(health): per-provider LLM failure-rate detection

### DIFF
--- a/backend/protocol_rpc/health.py
+++ b/backend/protocol_rpc/health.py
@@ -268,7 +268,27 @@ async def _run_health_checks() -> None:
                 overall_status = "degraded"
             issues.append("orphaned_transactions")
 
-        # 3. Memory health
+        # 3. LLM provider health (per-provider failure-rate detection)
+        # Catches cases like a provider returning HTTP 402 / "tier required"
+        # for every call from a specific (provider, model) entry — the
+        # actual cause behind a recent stuck-shard incident that the
+        # generic "orphaned_transactions" tag couldn't articulate.
+        llm_health = await _check_llm_provider_health()
+        llm_status = llm_health.get("status", "unknown")
+        services["llm_providers"] = {
+            "status": llm_status,
+            "alert_providers": llm_health.get("alert_providers", []),
+            "window_minutes": llm_health.get("window_minutes"),
+            "total_samples": llm_health.get("total_samples"),
+        }
+        if llm_status == "error":
+            issues.append("llm_provider_check_error")
+        elif llm_status == "degraded" and llm_health.get("alert_providers"):
+            if overall_status == "healthy":
+                overall_status = "degraded"
+            issues.append("llm_provider_failure")
+
+        # 4. Memory health
         memory_health = await _check_memory_health()
         memory_status = memory_health.get("status", "unknown")
         services["memory"] = {
@@ -282,7 +302,7 @@ async def _run_health_checks() -> None:
                 overall_status = "degraded"
             issues.append("memory_issue")
 
-        # 4. Redis health
+        # 5. Redis health
         redis_status = await _check_redis_health()
         services["redis"] = redis_status
         if redis_status == "unhealthy":
@@ -290,7 +310,7 @@ async def _run_health_checks() -> None:
                 overall_status = "degraded"
             issues.append("redis_unreachable")
 
-        # 5. GenVM manager health (+ capacity details when available)
+        # 6. GenVM manager health (+ capacity details when available)
         genvm_ok, genvm_error, genvm_status = await _check_genvm_health()
         services["genvm"] = {"status": "healthy" if genvm_ok else "unhealthy"}
         _health_cache.genvm_healthy = genvm_ok
@@ -330,14 +350,14 @@ async def _run_health_checks() -> None:
             _health_cache.genvm_available_permits = None
             _health_cache.genvm_active_executions = None
 
-        # 6. Aggregate counts for metrics
+        # 7. Aggregate counts for metrics
         decisions_count, users_count, pending_count = await _get_aggregate_counts()
         _health_cache.total_decisions = decisions_count
         _health_cache.total_users = users_count
         _health_cache.pending_transactions = pending_count
         _health_cache.uptime_percent = 100.0  # 100% while running
 
-        # 7. Get pending contracts breakdown for dashboard
+        # 8. Get pending contracts breakdown for dashboard
         _health_cache.pending_contracts = await _get_pending_contracts()
 
         # Update cache
@@ -643,6 +663,250 @@ async def _check_consensus_health() -> Dict[str, Any]:
 
     except Exception as e:
         logger.exception("Consensus health check failed")
+        return {"status": "error", "error": str(e)}
+
+
+async def _check_llm_provider_health() -> Dict[str, Any]:
+    """Per-(provider, model) failure-rate detection from recent receipts.
+
+    Mines `consensus_data->'leader_receipt'` and
+    `consensus_data->'validators'` on txs created in the last
+    `LLM_PROVIDER_WINDOW_MINUTES` minutes. For each (provider, model)
+    pair, counts validator runs whose `execution_result == 'ERROR'` and
+    reports those whose failure rate is above
+    `LLM_PROVIDER_FAILURE_THRESHOLD` AND have at least
+    `LLM_PROVIDER_MIN_SAMPLES` runs in the window.
+
+    Output schema (always shaped, never partial):
+
+        {
+          "status": "healthy" | "degraded" | "no_data" | "error",
+          "alert_providers": [
+              {
+                "provider": "...", "model": "...",
+                "samples": int, "failures": int, "failure_rate": float,
+                "sample_error": {error_code, causes, http_status, brief}
+              }, ...
+          ],
+          "window_minutes": int,
+          "total_samples": int,
+        }
+
+    Limitations (acknowledged):
+      - Window is on `tx.created_at`, not "consensus ran in the last N
+        min" — the schema has no `status_changed_at`. For very slow
+        contracts a tx that finished consensus 6h after submission falls
+        outside the window. Acceptable trade-off for a 15-minute alert.
+      - Cannot detect "primary failed but fallback rescued it":
+        backend/node/llm.lua's try_provider returns SUCCESS as soon as
+        any provider succeeds, with no persisted record of the primary
+        attempt. This metric catches all-providers-down (the primary
+        failure mode that took an instance into DEGRADED yesterday) but
+        not stealth fallback-masked outages. A future improvement would
+        persist `llm_attempts[]` from Lua at call time.
+
+    Privacy: never expose raw stderr (contains LLM prompts), node_config
+    (contains validator private keys), or raw_error.ctx.host_data
+    (contains payloads). Only emits structured signals: error_code,
+    causes (joined string), HTTP status, and a 200-char cap of
+    error_description.
+    """
+    import os
+
+    from backend.database_handler.session_factory import get_database_manager
+
+    WINDOW_MINUTES = int(os.environ.get("LLM_PROVIDER_WINDOW_MINUTES", "15"))
+    MIN_SAMPLES = int(os.environ.get("LLM_PROVIDER_MIN_SAMPLES", "25"))
+    FAILURE_THRESHOLD = float(os.environ.get("LLM_PROVIDER_FAILURE_THRESHOLD", "0.5"))
+
+    try:
+        if not _rpc_router_ref:
+            return {
+                "status": "not_initialized",
+                "error": "RPC router not available",
+            }
+
+        db_manager = get_database_manager()
+
+        def _query_llm_health():
+            from sqlalchemy import text
+
+            with db_manager.engine.connect() as conn:
+                # One row per (provider, model) over the window.
+                # Concatenates leader_receipt[] and validators[] arrays so
+                # leader-only txs (where validators is empty) still count.
+                # Status filter excludes in-flight rows where
+                # consensus_data could still mutate.
+                agg_rows = conn.execute(
+                    text(
+                        """
+                        WITH receipts AS (
+                            SELECT
+                                v.receipt->'node_config'->'primary_model'->>'provider'
+                                    AS provider,
+                                v.receipt->'node_config'->'primary_model'->>'model'
+                                    AS model,
+                                v.receipt->>'execution_result' AS execution_result
+                            FROM transactions t,
+                                 jsonb_array_elements(
+                                     COALESCE(
+                                         t.consensus_data->'leader_receipt',
+                                         '[]'::jsonb
+                                     )
+                                     || COALESCE(
+                                         t.consensus_data->'validators',
+                                         '[]'::jsonb
+                                     )
+                                 ) AS v(receipt)
+                            WHERE t.consensus_data IS NOT NULL
+                              AND t.created_at > NOW()
+                                  - make_interval(mins => :window_minutes)
+                              AND t.status IN (
+                                  'FINALIZED', 'ACCEPTED', 'UNDETERMINED',
+                                  'LEADER_TIMEOUT', 'VALIDATORS_TIMEOUT'
+                              )
+                              AND v.receipt->'node_config'->'primary_model'->>'provider'
+                                      IS NOT NULL
+                        )
+                        SELECT
+                            provider,
+                            model,
+                            COUNT(*) AS samples,
+                            COUNT(*) FILTER (WHERE execution_result = 'ERROR')
+                                AS failures
+                        FROM receipts
+                        GROUP BY provider, model
+                        """
+                    ),
+                    {"window_minutes": WINDOW_MINUTES},
+                ).fetchall()
+
+                if not agg_rows:
+                    return {
+                        "status": "no_data",
+                        "alert_providers": [],
+                        "window_minutes": WINDOW_MINUTES,
+                        "total_samples": 0,
+                    }
+
+                total_samples = sum(r.samples for r in agg_rows)
+
+                # Pick which (provider, model) pairs are alert-worthy
+                # before doing the (more expensive) sample-error query.
+                alert_keys = []
+                for r in agg_rows:
+                    if (
+                        r.samples >= MIN_SAMPLES
+                        and r.failures / r.samples >= FAILURE_THRESHOLD
+                    ):
+                        alert_keys.append((r.provider, r.model, r))
+
+                # Sample errors: one most-recent ERROR per alert (provider,
+                # model). Done as a separate query to keep the aggregate
+                # cheap when there are no alerts. Allowlists structured
+                # fields only — no raw stderr, no node_config.
+                sample_errors_by_key: dict[tuple, dict] = {}
+                if alert_keys:
+                    err_rows = conn.execute(
+                        text(
+                            """
+                            WITH error_rows AS (
+                                SELECT
+                                    v.receipt->'node_config'->'primary_model'->>'provider'
+                                        AS provider,
+                                    v.receipt->'node_config'->'primary_model'->>'model'
+                                        AS model,
+                                    v.receipt->'genvm_result'->>'error_code'
+                                        AS error_code,
+                                    v.receipt->'genvm_result'->'raw_error'->'causes'
+                                        AS causes,
+                                    v.receipt->'genvm_result'->'raw_error'->'ctx'->>'status'
+                                        AS http_status,
+                                    SUBSTRING(
+                                        v.receipt->'genvm_result'->>'error_description'
+                                        FROM 1 FOR 200
+                                    ) AS description_brief,
+                                    t.created_at AS tx_created_at,
+                                    ROW_NUMBER() OVER (
+                                        PARTITION BY
+                                            v.receipt->'node_config'->'primary_model'->>'provider',
+                                            v.receipt->'node_config'->'primary_model'->>'model'
+                                        ORDER BY t.created_at DESC
+                                    ) AS rn
+                                FROM transactions t,
+                                     jsonb_array_elements(
+                                         COALESCE(
+                                             t.consensus_data->'leader_receipt',
+                                             '[]'::jsonb
+                                         )
+                                         || COALESCE(
+                                             t.consensus_data->'validators',
+                                             '[]'::jsonb
+                                         )
+                                     ) AS v(receipt)
+                                WHERE t.consensus_data IS NOT NULL
+                                  AND t.created_at > NOW()
+                                      - make_interval(mins => :window_minutes)
+                                  AND t.status IN (
+                                      'FINALIZED', 'ACCEPTED', 'UNDETERMINED',
+                                      'LEADER_TIMEOUT', 'VALIDATORS_TIMEOUT'
+                                  )
+                                  AND v.receipt->>'execution_result' = 'ERROR'
+                                  AND v.receipt->'node_config'->'primary_model'->>'provider'
+                                          IS NOT NULL
+                            )
+                            SELECT provider, model, error_code, causes,
+                                   http_status, description_brief
+                            FROM error_rows
+                            WHERE rn = 1
+                            """
+                        ),
+                        {"window_minutes": WINDOW_MINUTES},
+                    ).fetchall()
+                    for er in err_rows:
+                        causes_summary = None
+                        if er.causes:
+                            try:
+                                causes_summary = ", ".join(str(c) for c in er.causes)[
+                                    :200
+                                ]
+                            except (TypeError, ValueError):
+                                causes_summary = str(er.causes)[:200]
+                        sample_errors_by_key[(er.provider, er.model)] = {
+                            "error_code": er.error_code,
+                            "causes": causes_summary,
+                            "http_status": er.http_status,
+                            "description_brief": er.description_brief,
+                        }
+
+                alert_providers = []
+                for provider, model, r in alert_keys:
+                    alert_providers.append(
+                        {
+                            "provider": provider,
+                            "model": model,
+                            "samples": int(r.samples),
+                            "failures": int(r.failures),
+                            "failure_rate": round(r.failures / r.samples, 3),
+                            "sample_error": sample_errors_by_key.get((provider, model)),
+                        }
+                    )
+                # Sort: highest failure rate first, then highest sample
+                # count, for stable & operator-friendly output.
+                alert_providers.sort(key=lambda a: (-a["failure_rate"], -a["samples"]))
+
+                status = "degraded" if alert_providers else "healthy"
+                return {
+                    "status": status,
+                    "alert_providers": alert_providers,
+                    "window_minutes": WINDOW_MINUTES,
+                    "total_samples": total_samples,
+                }
+
+        return await asyncio.to_thread(_query_llm_health)
+
+    except Exception as e:
+        logger.exception("LLM provider health check failed")
         return {"status": "error", "error": str(e)}
 
 

--- a/tests/db-sqlalchemy/test_health_llm_provider_detection.py
+++ b/tests/db-sqlalchemy/test_health_llm_provider_detection.py
@@ -1,0 +1,430 @@
+"""
+Tests for /health's per-(provider, model) LLM failure-rate detection.
+
+Background: a recent incident on Rally Prod was caused by IO Intelligence
+returning HTTP 402 ("requires a higher IO Intelligence tier") for every
+call from a specific validator entry. The dashboard alert read "There
+are 58 pending transactions" — useless for diagnosis. The actual cause
+was buried in worker stderr.
+
+This test suite verifies the new `_check_llm_provider_health()` correctly
+mines `transactions.consensus_data` (leader_receipt + validators) and
+exposes:
+  - `degraded` only when a (provider, model) crosses both the
+    failure-rate AND sample-size thresholds
+  - `no_data` when the window has zero receipts
+  - `healthy` when failures are scattered or below thresholds
+  - sanitized sample-error fields (no raw stderr / node_config)
+
+Limitations the implementation acknowledges and we don't test for:
+  - Fallback-rescued primary failures (Lua's try_provider returns
+    SUCCESS as soon as any provider works, with no persisted record of
+    the primary failed attempt). This metric only catches
+    all-providers-down on a given (provider, model).
+  - Window is on `created_at`, not "consensus ran in last N min" — the
+    schema has no `status_changed_at`.
+"""
+
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from sqlalchemy import Engine, text
+from sqlalchemy.orm import sessionmaker
+
+
+@dataclass
+class _StubManager:
+    engine: Engine
+
+
+@pytest.fixture(autouse=True)
+def _wire_health_module_to_test_engine(engine: Engine, monkeypatch):
+    """Point session_factory at the test engine; tighten thresholds so
+    each test can drive the alert with a small handful of receipts."""
+    from backend.database_handler import session_factory
+    from backend.protocol_rpc import health as health_module
+
+    prev_mgr = session_factory._db_manager
+    prev_router = health_module._rpc_router_ref
+
+    session_factory._db_manager = _StubManager(engine=engine)
+    health_module._rpc_router_ref = object()
+
+    # Lower MIN_SAMPLES so each test only needs a handful of rows.
+    monkeypatch.setenv("LLM_PROVIDER_MIN_SAMPLES", "3")
+    monkeypatch.setenv("LLM_PROVIDER_FAILURE_THRESHOLD", "0.5")
+    monkeypatch.setenv("LLM_PROVIDER_WINDOW_MINUTES", "15")
+
+    yield
+
+    session_factory._db_manager = prev_mgr
+    health_module._rpc_router_ref = prev_router
+
+
+def _make_validator(
+    *,
+    provider: str,
+    model: str,
+    execution_result: str,
+    error_code: str | None = None,
+    causes: list | None = None,
+    http_status: str | None = None,
+    description: str | None = None,
+) -> dict:
+    return {
+        "execution_result": execution_result,
+        "node_config": {
+            "address": "0xvalidator",
+            # private_key intentionally present in real receipts; tests
+            # confirm we don't surface it.
+            "private_key": "0xdeadbeef" * 8,
+            "stake": 100,
+            "primary_model": {"provider": provider, "model": model},
+            "secondary_model": None,
+        },
+        "genvm_result": {
+            "stdout": "",
+            "stderr": "MUST NEVER BE EXPOSED — contains LLM prompts and ctx",
+            "error_code": error_code,
+            "raw_error": (
+                {
+                    "causes": causes,
+                    "ctx": {"status": http_status} if http_status else {},
+                }
+                if (causes or http_status)
+                else None
+            ),
+            "error_description": description,
+        },
+    }
+
+
+def _insert_tx_with_receipts(
+    session,
+    *,
+    tx_hash: str,
+    leader_receipt: list | None,
+    validators: list,
+    created_at: datetime,
+    status: str = "FINALIZED",
+):
+    consensus_data = {}
+    if leader_receipt is not None:
+        consensus_data["leader_receipt"] = leader_receipt
+    consensus_data["validators"] = validators
+    session.execute(
+        text(
+            """
+            INSERT INTO transactions (
+                hash, status, from_address, to_address, data, value, type,
+                nonce, leader_only, execution_mode, appealed, appeal_failed,
+                appeal_undetermined, appeal_leader_timeout,
+                appeal_validators_timeout, appeal_processing_time,
+                recovery_count, value_credited,
+                created_at, consensus_data
+            ) VALUES (
+                :hash, CAST(:status AS transaction_status),
+                '0xfromaddr', '0xtoaddr', CAST('{}' AS jsonb), 0, 2,
+                :nonce, false, 'NORMAL', false, 0,
+                false, false, false, 0, 0, false,
+                :created_at, CAST(:consensus_data AS jsonb)
+            )
+            """
+        ),
+        {
+            "hash": tx_hash,
+            "status": status,
+            "nonce": int(tx_hash[2:18], 16) % 100000,
+            "created_at": created_at,
+            "consensus_data": __import__("json").dumps(consensus_data),
+        },
+    )
+
+
+@pytest.mark.asyncio
+async def test_no_data_when_no_recent_receipts(engine: Engine):
+    """An empty window must report no_data, not degraded."""
+    from backend.protocol_rpc import health as health_module
+
+    result = await health_module._check_llm_provider_health()
+
+    assert result["status"] == "no_data"
+    assert result["alert_providers"] == []
+    assert result["total_samples"] == 0
+
+
+@pytest.mark.asyncio
+async def test_one_provider_failing_at_100pct_alerts(engine: Engine):
+    """The yesterday case: every call from one (provider, model) fails
+    in the window. Must surface as a single alert_provider with the
+    sample error fields."""
+    Session_ = sessionmaker(bind=engine, expire_on_commit=False)
+    now = datetime.now(timezone.utc)
+
+    with Session_() as s:
+        for i in range(5):
+            _insert_tx_with_receipts(
+                s,
+                tx_hash=f"0x{i:064x}",
+                leader_receipt=[
+                    _make_validator(
+                        provider="ionet",
+                        model="Qwen/Qwen3-Next-80B-A3B-Instruct",
+                        execution_result="ERROR",
+                        causes=["STATUS_NOT_OK"],
+                        http_status="402",
+                        description=(
+                            "Model 'Qwen/Qwen3-Next-80B-A3B-Instruct' "
+                            "requires a higher IO Intelligence tier"
+                        ),
+                    )
+                ],
+                validators=[],
+                created_at=now - timedelta(minutes=2 + i),
+            )
+        s.commit()
+
+    from backend.protocol_rpc import health as health_module
+
+    result = await health_module._check_llm_provider_health()
+
+    assert result["status"] == "degraded"
+    assert len(result["alert_providers"]) == 1
+    a = result["alert_providers"][0]
+    assert a["provider"] == "ionet"
+    assert a["model"] == "Qwen/Qwen3-Next-80B-A3B-Instruct"
+    assert a["samples"] == 5
+    assert a["failures"] == 5
+    assert a["failure_rate"] == 1.0
+    # Sanitized sample error: structured fields only.
+    err = a["sample_error"]
+    assert err["http_status"] == "402"
+    assert "tier" in err["description_brief"].lower()
+    # Privacy: nothing leaks raw stderr or node_config.
+    assert "stderr" not in err
+    assert "private_key" not in str(result)
+
+
+@pytest.mark.asyncio
+async def test_below_threshold_does_not_alert(engine: Engine):
+    """A provider failing at 30% should not cross the 0.5 alert threshold."""
+    Session_ = sessionmaker(bind=engine, expire_on_commit=False)
+    now = datetime.now(timezone.utc)
+
+    with Session_() as s:
+        # 10 receipts for openrouter/gpt-5.4: 3 failures, 7 successes (30%).
+        for i in range(10):
+            ok = i >= 3
+            _insert_tx_with_receipts(
+                s,
+                tx_hash=f"0x{(0xa0 + i):064x}",
+                leader_receipt=None,
+                validators=[
+                    _make_validator(
+                        provider="openrouter",
+                        model="openai/gpt-5.4",
+                        execution_result="SUCCESS" if ok else "ERROR",
+                    )
+                ],
+                created_at=now - timedelta(minutes=1 + i),
+            )
+        s.commit()
+
+    from backend.protocol_rpc import health as health_module
+
+    result = await health_module._check_llm_provider_health()
+
+    assert result["status"] == "healthy"
+    assert result["alert_providers"] == []
+    assert result["total_samples"] == 10
+
+
+@pytest.mark.asyncio
+async def test_below_min_samples_does_not_alert(engine: Engine):
+    """Two failures out of two samples is 100% failure but below the
+    min-samples floor — must not alert (could just be a flake)."""
+    Session_ = sessionmaker(bind=engine, expire_on_commit=False)
+    now = datetime.now(timezone.utc)
+
+    with Session_() as s:
+        for i in range(2):
+            _insert_tx_with_receipts(
+                s,
+                tx_hash=f"0x{(0xb0 + i):064x}",
+                leader_receipt=None,
+                validators=[
+                    _make_validator(
+                        provider="openrouter",
+                        model="z-ai/glm-5.1",
+                        execution_result="ERROR",
+                    )
+                ],
+                created_at=now - timedelta(minutes=1 + i),
+            )
+        s.commit()
+
+    from backend.protocol_rpc import health as health_module
+
+    result = await health_module._check_llm_provider_health()
+
+    assert result["status"] == "healthy"
+    assert result["alert_providers"] == []
+
+
+@pytest.mark.asyncio
+async def test_outside_window_excluded(engine: Engine):
+    """Receipts older than the window must not contribute. Tests that
+    the time filter works."""
+    Session_ = sessionmaker(bind=engine, expire_on_commit=False)
+    now = datetime.now(timezone.utc)
+
+    with Session_() as s:
+        # 5 ERROR receipts, but all created 2h ago — outside the
+        # 15-minute window.
+        for i in range(5):
+            _insert_tx_with_receipts(
+                s,
+                tx_hash=f"0x{(0xc0 + i):064x}",
+                leader_receipt=None,
+                validators=[
+                    _make_validator(
+                        provider="ionet",
+                        model="failing-model",
+                        execution_result="ERROR",
+                    )
+                ],
+                created_at=now - timedelta(hours=2),
+            )
+        s.commit()
+
+    from backend.protocol_rpc import health as health_module
+
+    result = await health_module._check_llm_provider_health()
+
+    # No receipts in window → no_data.
+    assert result["status"] == "no_data"
+    assert result["total_samples"] == 0
+
+
+@pytest.mark.asyncio
+async def test_aggregates_across_leader_and_validators(engine: Engine):
+    """The query unions both leader_receipt and validators arrays. A
+    failing provider that only appears as a leader (not in validators)
+    must still be detected."""
+    Session_ = sessionmaker(bind=engine, expire_on_commit=False)
+    now = datetime.now(timezone.utc)
+
+    with Session_() as s:
+        for i in range(4):
+            _insert_tx_with_receipts(
+                s,
+                tx_hash=f"0x{(0xd0 + i):064x}",
+                leader_receipt=[
+                    _make_validator(
+                        provider="ionet",
+                        model="leader-only",
+                        execution_result="ERROR",
+                        causes=["STATUS_NOT_OK"],
+                    )
+                ],
+                validators=[],
+                created_at=now - timedelta(minutes=1 + i),
+            )
+        s.commit()
+
+    from backend.protocol_rpc import health as health_module
+
+    result = await health_module._check_llm_provider_health()
+
+    assert result["status"] == "degraded"
+    assert len(result["alert_providers"]) == 1
+    assert result["alert_providers"][0]["provider"] == "ionet"
+    assert result["alert_providers"][0]["model"] == "leader-only"
+
+
+@pytest.mark.asyncio
+async def test_only_terminal_status_txs_counted(engine: Engine):
+    """In-flight rows (PROPOSING/COMMITTING/REVEALING) have mutable
+    consensus_data and must be excluded — otherwise we double-count
+    interim receipts that may flip back to non-error on the next round."""
+    Session_ = sessionmaker(bind=engine, expire_on_commit=False)
+    now = datetime.now(timezone.utc)
+
+    with Session_() as s:
+        # 5 ERROR receipts but on a tx still in PROPOSING.
+        for i in range(5):
+            _insert_tx_with_receipts(
+                s,
+                tx_hash=f"0x{(0xe0 + i):064x}",
+                leader_receipt=None,
+                validators=[
+                    _make_validator(
+                        provider="ionet",
+                        model="in-flight-model",
+                        execution_result="ERROR",
+                    )
+                ],
+                created_at=now - timedelta(minutes=1 + i),
+                status="PROPOSING",
+            )
+        s.commit()
+
+    from backend.protocol_rpc import health as health_module
+
+    result = await health_module._check_llm_provider_health()
+
+    # All rows are PROPOSING → excluded from the window.
+    assert result["status"] == "no_data"
+    assert result["total_samples"] == 0
+
+
+@pytest.mark.asyncio
+async def test_multiple_providers_only_failing_one_in_alert(engine: Engine):
+    """One healthy provider, one failing — only the failing one shows
+    in alert_providers."""
+    Session_ = sessionmaker(bind=engine, expire_on_commit=False)
+    now = datetime.now(timezone.utc)
+
+    with Session_() as s:
+        # openrouter/healthy: 5 SUCCESS
+        for i in range(5):
+            _insert_tx_with_receipts(
+                s,
+                tx_hash=f"0x{(0xf0 + i):064x}",
+                leader_receipt=None,
+                validators=[
+                    _make_validator(
+                        provider="openrouter",
+                        model="healthy-model",
+                        execution_result="SUCCESS",
+                    )
+                ],
+                created_at=now - timedelta(minutes=1 + i),
+            )
+        # ionet/broken: 4 ERROR
+        for i in range(4):
+            _insert_tx_with_receipts(
+                s,
+                tx_hash=f"0x{(0x100 + i):064x}",
+                leader_receipt=None,
+                validators=[
+                    _make_validator(
+                        provider="ionet",
+                        model="broken-model",
+                        execution_result="ERROR",
+                    )
+                ],
+                created_at=now - timedelta(minutes=1 + i),
+            )
+        s.commit()
+
+    from backend.protocol_rpc import health as health_module
+
+    result = await health_module._check_llm_provider_health()
+
+    assert result["status"] == "degraded"
+    assert len(result["alert_providers"]) == 1
+    assert result["alert_providers"][0]["provider"] == "ionet"
+    # total_samples spans both provider buckets.
+    assert result["total_samples"] == 9


### PR DESCRIPTION
## Summary

Adds a new \`services.llm_providers\` block to \`/health\` that surfaces specific (provider, model) combinations crossing a failure-rate threshold, with a sanitized sample error. Replaces "DEGRADED — There are 58 pending transactions" with "DEGRADED — Provider 'ionet' / model 'Qwen/...': 47/47 fail, '402 tier required'".

## Why

Yesterday's Rally Prod stuck-shard incident was caused by IO Intelligence returning HTTP 402 for every Qwen call. The dashboard alert read "58 pending transactions" — useless for diagnosis. The actual cause was buried in worker stderr; an operator had to kubectl in and grep for STATUS_NOT_OK.

The data was already in \`transactions.consensus_data\` — we just had no metric or alert reading it.

## What it catches

A specific (provider, model) failing at high rate (e.g. tier required, API down). Default trigger: \`failure_rate >= 0.5\` over \`>= 25 samples\` in the last 15 minutes. All thresholds env-configurable.

## Acknowledged limitation

**Cannot detect "primary failed but fallback rescued it."** \`backend/node/llm.lua\`'s \`try_provider\` returns SUCCESS as soon as any provider works, with no persisted record of the primary attempt. This metric only catches **all-providers-down** on a given (provider, model). 

A future improvement would persist \`llm_attempts[]\` from Lua at call time. Filed as a follow-up; not blocking this PR — yesterday's case (where IO Intelligence was failing as both primary AND fallback) WOULD have been caught.

## Codex review

This proposal went through \`/codex\` review which surfaced four issues fixed before this PR:
- Window must be on \`created_at\` (no \`status_changed_at\` column exists) — acknowledged in code/tests
- Must aggregate from BOTH \`leader_receipt[]\` AND \`validators[]\`, not just validators
- Status filter excludes in-flight rows where \`consensus_data\` is still mutable
- Strict privacy allowlist: never expose stderr (LLM prompts), node_config (private keys), or \`raw_error.ctx.host_data\` (payloads). Only structured fields: error_code, causes (joined), HTTP status, capped description.

## Output schema

\`\`\`json
"llm_providers": {
  "status": "healthy" | "degraded" | "no_data" | "error",
  "alert_providers": [
    {
      "provider": "ionet",
      "model": "Qwen/Qwen3-Next-80B-A3B-Instruct",
      "samples": 47,
      "failures": 47,
      "failure_rate": 1.0,
      "sample_error": {
        "error_code": null,
        "causes": "STATUS_NOT_OK",
        "http_status": "402",
        "description_brief": "Model 'Qwen/...' requires a higher IO Intelligence tier"
      }
    }
  ],
  "window_minutes": 15,
  "total_samples": 240
}
\`\`\`

When \`alert_providers\` is non-empty, the top-level health response gets \`status=degraded\` and \`issues: ["llm_provider_failure"]\`. The dashboard can now compose specific alert text from the structured data.

## Test plan

- [x] 8 new tests in \`test_health_llm_provider_detection.py\`: no_data on empty window, 100% failure alerts with correct sanitized fields, below-threshold doesn't alert, below-min-samples doesn't alert, window filter excludes old receipts, \`leader_receipt\` is aggregated alongside \`validators[]\`, in-flight statuses excluded, mixed-provider scenarios
- [x] Full \`tests/db-sqlalchemy/\` suite: **151 passed, 1 xfailed (pre-existing)**

## Follow-ups (not blocking)

- Persist \`llm_attempts[]\` from Lua to detect fallback-masked primary failures
- Dashboard side: format the alert message from \`alert_providers[]\` instead of "N pending transactions"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features

* Enhanced health-check monitoring with LLM provider health assessment, tracking per-provider and per-model failure rates over a configurable time window and alerting when failures exceed configured thresholds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->