### PR TITLE
Add "View on Explorer" button and contract address display after deployment (#1610)

### DIFF
--- a/frontend/src/components/Simulator/ContractItem.vue
+++ b/frontend/src/components/Simulator/ContractItem.vue
@@ -142,7 +142,14 @@ const handleDownloadFile = (e: Event) => {
         <div data-testid="contract-file" class="truncate font-semibold">
           {{ contract.name }}
         </div>
-
+<a 
+  v-if="contract?.address"
+  :href="'https://explorer.genlayer.com/address/' + contract.address" 
+  target="_blank"
+  class="ml-2 text-[10px] text-blue-500 hover:text-blue-700 underline flex items-center"
+>
+  View Explorer
+</a>
         <div class="hidden flex-row gap-1 group-hover:flex">
           <button @click.stop="handleEditFile" v-tooltip="'Edit Name'">
             <PencilSquareIcon

--- a/frontend/src/components/Simulator/ContractItem.vue
+++ b/frontend/src/components/Simulator/ContractItem.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { useNetworkStore } from '@/stores/network';
 import { useContractsStore } from '@/stores';
 import { type ContractFile } from '@/types';
 import {
@@ -8,7 +9,7 @@ import {
   TrashIcon,
   ArrowDownOnSquareIcon,
 } from '@heroicons/vue/16/solid';
-import { ref, onMounted, nextTick } from 'vue';
+import { ref, onMounted, nextTick, computed } from 'vue';
 import { notify } from '@kyvg/vue3-notification';
 
 const store = useContractsStore();
@@ -41,8 +42,19 @@ const handleEditFile = () => {
   nextTick(() => {
     editInput.value?.focus();
     editInput.value?.setSelectionRange(0, dotPosition);
-  });
+  }); 
 };
+const networkStore = useNetworkStore();
+
+const isLocalNetwork = computed(() => {
+  return networkStore.network?.id === 'studionet' || networkStore.network?.type === 'local';
+});
+
+const explorerUrl = computed(() => {
+  const address = props.contract?.address;
+  if (!address) return '';
+  return `https://explorer-asimov.genlayer.com/contract/${address}`;
+});
 
 onMounted(() => {
   if (props.isNewFile) {
@@ -142,10 +154,11 @@ const handleDownloadFile = (e: Event) => {
         <div data-testid="contract-file" class="truncate font-semibold">
           {{ contract.name }}
         </div>
-<a 
-  v-if="contract?.address"
-  :href="'https://explorer.genlayer.com/address/' + contract.address" 
+<a
+  v-if="props.contract?.address && !isLocalNetwork"
+  :href="explorerUrl"
   target="_blank"
+  rel="noopener noreferrer"
   class="ml-2 text-[10px] text-blue-500 hover:text-blue-700 underline flex items-center"
 >
   View Explorer


### PR DESCRIPTION
<!-- This is a TEMPLATE, modify it to fit your needs. -->

Fixes #1610
# What

<!-- Describe the changes you made. -->

- Added a "View on Explorer" link in the ContractItem.vue component.
- The link dynamically opens the GenLayer Explorer for deployed contracts.

# Why

<!-- Why are you making these changes? This should be related to the issue created, and the value we are adding with this PR -->

- to fix a bug
- To provide users with a quick way to verify their contract address and details on the explorer directly from the studio.

# Testing done

<!-- Describe the tests you ran to verify your changes. -->

- Verified that the link only appears when a contract has a valid address.
- Checked the link structure to ensure it correctly redirects to the GenLayer explorer.

# Decisions made

<!-- Describe any decisions made during the implementation of this PR. This should in general be in the code, but sometimes they are more related to the issue. For example: decisions on PR workflow -->

# Checks

- [x] I have tested this code
- [x] I have reviewed my own PR
- [x] I have created an issue for this PR
- [x] I have set a descriptive PR title compliant with [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)

# Reviewing tips

<!-- What can you tell the reviewer to make the review easier? -->

#Added a direct link to view deployed contracts on the GenLayer Explorer.

<!-- What should the user know about this change? Think of it going into public forums for end users to read -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "View Explorer" link beside contract names to open contract details on the blockchain explorer. The link appears only when a contract address is available and the app is connected to a non-local network, and it opens in a new tab for safe, convenient navigation.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/genlayerlabs/genlayer-studio/pull/1623)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->