### PR TITLE
fix: show deploy banner only on new contract deployment

### DIFF
--- a/frontend/src/stores/contracts.ts
+++ b/frontend/src/stores/contracts.ts
@@ -140,14 +140,13 @@ export const useContractsStore = defineStore('contractsStore', () => {
 
     if (index === -1) {
       allDeployedContracts.value.push(newItem);
+      notify({
+        title: 'Contract deployed',
+        type: 'success',
+      });
     } else {
       allDeployedContracts.value.splice(index, 1, newItem);
     }
-
-    notify({
-      title: 'Contract deployed',
-      type: 'success',
-    });
   }
 
   function removeDeployedContract(contractId: string): void {


### PR DESCRIPTION
Fixes #628

The deploy banner was showing up multiple times when deploying a contract.

The issue was in `addDeployedContract()` in `frontend/src/stores/contracts.ts` — 
`notify()` was being called unconditionally after the if/else block, so it fired 
whether the contract was new or just being redeployed.

Moved `notify()` inside the `if (index === -1)` branch so it only triggers 
on a fresh deployment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed duplicate "Contract deployed" notifications. The notification now displays only when a new contract is deployed, not when updating existing contract records.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/genlayerlabs/genlayer-studio/pull/1624)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->