### PR TITLE
fix(rpc): reject non-positive fund account amounts

### DIFF
--- a/backend/protocol_rpc/endpoints.py
+++ b/backend/protocol_rpc/endpoints.py
@@ -272,10 +272,18 @@ def fund_account(
 ) -> str:
     """Fund an account within a request-scoped database session."""
     accounts_manager = AccountsManager(session)
-    transactions_processor = TransactionsProcessor(session)
 
     if not accounts_manager.is_valid_address(account_address):
         raise InvalidAddressError(account_address)
+
+    if amount <= 0:
+        raise JSONRPCError(
+            code=-32602,
+            message="amount must be greater than 0",
+            data={},
+        )
+
+    transactions_processor = TransactionsProcessor(session)
 
     import secrets
 

--- a/tests/unit/test_simulator_sessions.py
+++ b/tests/unit/test_simulator_sessions.py
@@ -4,6 +4,7 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from backend.protocol_rpc import endpoints
+from backend.protocol_rpc.exceptions import JSONRPCError
 from backend.errors.errors import InvalidAddressError
 from backend.domain.types import LLMProvider, TransactionType
 from backend.database_handler.models import TransactionStatus
@@ -43,6 +44,9 @@ def test_fund_account_uses_request_scoped_session(monkeypatch):
     transactions_processor_instance.insert_transaction.assert_called_once_with(
         None, "0x" + "1" * 40, None, 25, 0, 12, False, 0, None, "0xabc"
     )
+    accounts_manager_instance.credit_tx_value_once.assert_called_once_with(
+        "0xabc", "0x" + "1" * 40, 25
+    )
 
 
 def test_fund_account_raises_for_invalid_address(monkeypatch):
@@ -59,6 +63,40 @@ def test_fund_account_raises_for_invalid_address(monkeypatch):
 
     with pytest.raises(InvalidAddressError):
         endpoints.fund_account(session, "0x" + "2" * 40, 10)
+
+
+@pytest.mark.parametrize("amount", [0, -1])
+def test_fund_account_rejects_non_positive_amount_without_side_effects(
+    monkeypatch, amount
+):
+    session = object()
+    account_address = "0x" + "5" * 40
+    accounts_manager_instance = MagicMock()
+    accounts_manager_instance.is_valid_address.return_value = True
+
+    transactions_processor_instance = MagicMock()
+    processor_sessions = []
+
+    def fake_transactions_processor(session):
+        processor_sessions.append(session)
+        return transactions_processor_instance
+
+    monkeypatch.setattr(
+        endpoints, "AccountsManager", lambda _session: accounts_manager_instance
+    )
+    monkeypatch.setattr(endpoints, "TransactionsProcessor", fake_transactions_processor)
+
+    with pytest.raises(JSONRPCError) as exc_info:
+        endpoints.fund_account(session, account_address, amount)
+
+    assert exc_info.value.code == -32602
+    assert exc_info.value.message == "amount must be greater than 0"
+    assert exc_info.value.data == {}
+    accounts_manager_instance.is_valid_address.assert_called_once_with(account_address)
+    assert processor_sessions == []
+    transactions_processor_instance.get_transaction_count.assert_not_called()
+    transactions_processor_instance.insert_transaction.assert_not_called()
+    accounts_manager_instance.credit_tx_value_once.assert_not_called()
 
 
 def test_fund_account_instantiates_managers_per_session(monkeypatch):


### PR DESCRIPTION
## Summary
Rejects non-positive `sim_fundAccount` amounts before creating or crediting a funding transaction.

## Why
`sim_fundAccount` is expected to create funding transactions only for positive values. Accepting `0` can create useless transactions, while negative values can lead to invalid transfer semantics later in the simulator flow.

## Changes
- Validate `amount > 0` in `fund_account`
- Return JSON-RPC invalid params for non-positive amounts
- Add focused tests for `0` and negative amounts
- Assert invalid inputs do not instantiate the transaction processor or create crediting side effects

## Test plan
- [x] `python3 -m py_compile backend/protocol_rpc/endpoints.py tests/unit/test_simulator_sessions.py`
- [x] `git diff --check -- backend/protocol_rpc/endpoints.py tests/unit/test_simulator_sessions.py`
- [x] `python3 -m pytest tests/unit/test_simulator_sessions.py -q`



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* The account funding endpoint now validates that the amount must be greater than 0, rejecting non-positive values with a clear error message (code -32602). Request validation checks now occur earlier in the process for improved efficiency.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/genlayerlabs/genlayer-studio/pull/1625)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->