### PR TITLE
feat(frontend): replace raw GenVM JSON errors with plain-English messages

### DIFF
--- a/frontend/src/components/Simulator/ConstructorParameters.vue
+++ b/frontend/src/components/Simulator/ConstructorParameters.vue
@@ -4,6 +4,7 @@ import { ref, computed } from 'vue';
 import PageSection from '@/components/Simulator/PageSection.vue';
 import { ArrowUpTrayIcon } from '@heroicons/vue/16/solid';
 import ContractParams from './ContractParams.vue';
+import FriendlyError from './FriendlyError.vue';
 import { type ArgData, unfoldArgsData } from './ContractParams';
 import type { ExecutionMode } from '@/types';
 
@@ -15,7 +16,7 @@ const props = defineProps<{
 const { contract, contractSchemaQuery, deployContract, isDeploying } =
   useContractQueries();
 
-const { data, isPending, isRefetching, isError } = contractSchemaQuery;
+const { data, isPending, isRefetching, isError, error } = contractSchemaQuery;
 
 const calldataArguments = ref<ArgData>({ args: [], kwargs: {} });
 
@@ -45,7 +46,7 @@ const handleDeployContract = async () => {
 
     <ContentLoader v-if="isPending" />
 
-    <Alert v-else-if="isError" error> Could not load contract schema. </Alert>
+    <FriendlyError v-else-if="isError" :error="error" />
 
     <template v-else-if="data">
       <ContractParams

--- a/frontend/src/components/Simulator/ContractReadMethods.vue
+++ b/frontend/src/components/Simulator/ContractReadMethods.vue
@@ -4,6 +4,7 @@ import { computed, ref } from 'vue';
 import PageSection from '@/components/Simulator/PageSection.vue';
 import ContractMethodItem from '@/components/Simulator/ContractMethodItem.vue';
 import EmptyListPlaceholder from '@/components/Simulator/EmptyListPlaceholder.vue';
+import FriendlyError from '@/components/Simulator/FriendlyError.vue';
 import type { ContractSchema } from 'genlayer-js/types';
 import type { ExecutionMode, ReadStateMode } from '@/types';
 
@@ -46,9 +47,7 @@ const readStateMode = ref<ReadStateMode>('ACCEPTED');
 
     <ContentLoader v-if="isPending" />
 
-    <Alert v-else-if="isError" error>
-      {{ error?.message }}
-    </Alert>
+    <FriendlyError v-else-if="isError" :error="error" />
 
     <template v-else-if="data">
       <ContractMethodItem

--- a/frontend/src/components/Simulator/ContractWriteMethods.vue
+++ b/frontend/src/components/Simulator/ContractWriteMethods.vue
@@ -4,6 +4,7 @@ import { computed, ref } from 'vue';
 import PageSection from '@/components/Simulator/PageSection.vue';
 import ContractMethodItem from '@/components/Simulator/ContractMethodItem.vue';
 import EmptyListPlaceholder from '@/components/Simulator/EmptyListPlaceholder.vue';
+import FriendlyError from '@/components/Simulator/FriendlyError.vue';
 import type { ContractSchema } from 'genlayer-js/types';
 import type { ExecutionMode } from '@/types';
 
@@ -43,9 +44,7 @@ const simulationMode = ref(false);
 
     <ContentLoader v-if="isPending" />
 
-    <Alert v-else-if="isError" error>
-      {{ error?.message }}
-    </Alert>
+    <FriendlyError v-else-if="isError" :error="error" />
 
     <template v-else-if="data">
       <ContractMethodItem

--- a/frontend/src/components/Simulator/FriendlyError.vue
+++ b/frontend/src/components/Simulator/FriendlyError.vue
@@ -1,0 +1,67 @@
+<script setup lang="ts">
+import { computed } from 'vue';
+import { XCircleIcon } from '@heroicons/vue/20/solid';
+import { ChevronRight } from 'lucide-vue-next';
+import CopyTextButton from '@/components/global/CopyTextButton.vue';
+import { parseGenVMError } from '@/utils/genvmErrors';
+
+const props = defineProps<{
+  /** Error from a `useQuery` / `try-catch` block. May be Error, string, or any payload. */
+  error: unknown;
+}>();
+
+const friendly = computed(() => parseGenVMError(props.error));
+</script>
+
+<template>
+  <div
+    class="rounded-md bg-red-500 bg-opacity-10 p-3 ring-1 ring-red-500/20"
+    data-testid="friendly-error"
+  >
+    <div class="flex gap-3">
+      <XCircleIcon
+        class="mt-0.5 h-5 w-5 flex-shrink-0 text-red-500"
+        aria-hidden="true"
+      />
+      <div class="min-w-0 flex-1">
+        <p class="text-sm font-semibold text-red-700 dark:text-red-300">
+          {{ friendly.title }}
+        </p>
+        <p
+          class="mt-1 text-sm text-red-700/90 dark:text-red-200/90"
+          data-testid="friendly-error-explanation"
+        >
+          {{ friendly.explanation }}
+        </p>
+
+        <pre
+          v-if="friendly.fix"
+          class="mt-3 overflow-x-auto whitespace-pre-wrap break-words rounded border border-red-500/20 bg-red-500/5 p-2 font-mono text-xs text-red-900 dark:text-red-100"
+          data-testid="friendly-error-fix"
+          >{{ friendly.fix }}</pre
+        >
+
+        <details class="group mt-3">
+          <summary
+            class="flex cursor-pointer select-none items-center gap-1 text-xs font-medium text-red-600/80 hover:text-red-700 dark:text-red-300/80 dark:hover:text-red-200"
+          >
+            <ChevronRight
+              class="h-3.5 w-3.5 transition-transform group-open:rotate-90"
+            />
+            Show technical details
+          </summary>
+          <div
+            class="mt-2 flex items-start gap-2 rounded border border-red-500/20 bg-black/30 p-2"
+          >
+            <pre
+              class="min-w-0 flex-1 overflow-x-auto whitespace-pre-wrap break-words font-mono text-[11px] leading-snug text-gray-200"
+              data-testid="friendly-error-raw"
+              >{{ friendly.raw }}</pre
+            >
+            <CopyTextButton :text="friendly.raw" />
+          </div>
+        </details>
+      </div>
+    </div>
+  </div>
+</template>

--- a/frontend/src/utils/genvmErrors.ts
+++ b/frontend/src/utils/genvmErrors.ts
@@ -1,0 +1,230 @@
+/**
+ * Translates raw GenVM / RPC errors into plain-English, actionable messages
+ * for the Studio UI.
+ *
+ * Closes #1609 — "[UX] Replace raw GenVM JSON errors in Studio with
+ * plain-English messages".
+ *
+ * The Studio's RPC layer surfaces errors as a single string that frequently
+ * embeds a JSON-encoded GenVM result, e.g.
+ *
+ *   ('execution failed', { 'genvm_log': [...],
+ *      'result': '{"kind": "VM_ERROR", "message": "invalid_contract absent_runner_comment"}' })
+ *
+ * The only signal a developer cares about is the `message` field. This module
+ * extracts it (best-effort, defensive) and maps known codes to a friendly
+ * `{ title, explanation, fix? }` triple. Unknown codes fall back to a generic
+ * friendly message; the original payload is always preserved on `raw` so the
+ * UI can offer a "Show technical details" toggle for bug reports.
+ */
+
+export interface FriendlyError {
+  /** Short, human-readable headline. */
+  title: string;
+  /** One-paragraph explanation of what went wrong. */
+  explanation: string;
+  /** Optional code snippet or instruction the developer should apply. */
+  fix?: string;
+  /** The original error payload, preserved for the technical-details panel. */
+  raw: string;
+  /** The extracted GenVM message ("invalid_contract absent_runner_comment", etc.) when found. */
+  code?: string;
+  /** True when we matched a known error code, false on the generic fallback. */
+  recognized: boolean;
+}
+
+const GENERIC_FALLBACK: Omit<FriendlyError, 'raw'> = {
+  title: 'Something went wrong',
+  explanation:
+    "We couldn't process this request. Expand Technical Details below to see the raw error and share it when reporting a bug.",
+  recognized: false,
+};
+
+/**
+ * Best-effort extraction of the inner GenVM `message` field from a raw error
+ * string. Tries, in order:
+ *   1. Direct JSON parse (when the whole error body is JSON).
+ *   2. Regex match on `"message": "<value>"` (single or double quotes,
+ *      handles the Python repr() form the backend currently emits).
+ *   3. Regex match on `'message': '<value>'`.
+ * Returns the extracted message, or `undefined` if nothing matched.
+ */
+export function extractGenVMMessage(raw: string): string | undefined {
+  if (!raw) return undefined;
+
+  // 1. Pure JSON
+  try {
+    const parsed = JSON.parse(raw);
+    const msg = findMessage(parsed);
+    if (msg) return msg;
+  } catch {
+    /* not JSON — fall through */
+  }
+
+  // 2. Embedded JSON inside Python repr — look for a 'result': '<json>' chunk
+  //    and try to parse it.
+  const resultMatch = raw.match(/['"]result['"]\s*:\s*['"]({[^}]+})['"]/);
+  if (resultMatch) {
+    try {
+      // Unescape doubled quotes that `repr()` produces.
+      const inner = resultMatch[1].replace(/\\"/g, '"').replace(/\\'/g, "'");
+      const parsed = JSON.parse(inner);
+      const msg = findMessage(parsed);
+      if (msg) return msg;
+    } catch {
+      /* fall through */
+    }
+  }
+
+  // 3. Bare regex on "message": "<value>" or 'message': '<value>'
+  const bareMatch =
+    raw.match(/["']message["']\s*:\s*["']([^"']+)["']/) ?? undefined;
+  if (bareMatch) return bareMatch[1];
+
+  return undefined;
+}
+
+function findMessage(obj: unknown): string | undefined {
+  if (!obj || typeof obj !== 'object') return undefined;
+  const o = obj as Record<string, unknown>;
+  if (typeof o.message === 'string') return o.message;
+  // Some payloads nest the result one level deeper.
+  if (o.result && typeof o.result === 'object') {
+    const inner = (o.result as Record<string, unknown>).message;
+    if (typeof inner === 'string') return inner;
+  }
+  return undefined;
+}
+
+interface Mapping {
+  /** Exact match or RegExp against the extracted GenVM message. */
+  match: string | RegExp;
+  build: (matched: string) => Omit<FriendlyError, 'raw' | 'recognized'>;
+}
+
+const RUNNER_COMMENT_FIX = '# { "Depends": "py-genlayer:test" }';
+
+/**
+ * Known GenVM error codes → friendly messages.
+ * Order matters: more specific patterns must come before generic ones
+ * (e.g. `invalid_contract absent_runner_comment` before bare `invalid_contract`).
+ */
+const MAPPINGS: Mapping[] = [
+  {
+    match: /^invalid_contract\s+absent_runner_comment$/,
+    build: (msg) => ({
+      title: 'Could not load contract',
+      explanation:
+        'Your contract is missing the runner comment on the very first line. The runner comment tells GenVM which Python runtime to load.',
+      fix: `Make sure the very first line of your contract is:\n\n${RUNNER_COMMENT_FIX}\n\nNo blank lines, no shebang, no other content above it.`,
+      code: msg,
+    }),
+  },
+  {
+    match: /^invalid_contract(?:\s+(.+))?$/,
+    build: (msg) => ({
+      title: 'Invalid contract',
+      explanation:
+        "The contract source could not be parsed by GenVM. This usually means the file's header (runner comment / version) is malformed or your code has a syntax error before any function is reachable.",
+      fix: `Check that the first line of your contract is a valid runner comment, e.g.:\n\n${RUNNER_COMMENT_FIX}`,
+      code: msg,
+    }),
+  },
+  {
+    match: 'timeout',
+    build: (msg) => ({
+      title: 'Execution timed out',
+      explanation:
+        'The contract took longer to execute than the configured limit. This is often caused by an unbounded loop or by an LLM call that never returns.',
+      fix: 'Review any `eq_principle` / LLM calls and add an explicit timeout, or reduce the workload of the entrypoint you ran.',
+      code: msg,
+    }),
+  },
+  {
+    match: 'OOM',
+    build: (msg) => ({
+      title: 'Out of memory',
+      explanation:
+        'The contract exceeded the GenVM memory limit during execution.',
+      fix: 'Avoid loading large blobs into memory at once — stream data, or split work across multiple transactions.',
+      code: msg,
+    }),
+  },
+  {
+    match: 'validator_disagrees',
+    build: (msg) => ({
+      title: 'Validator disagreement',
+      explanation:
+        'A validator produced a result that disagreed with the leader. This typically happens when contract logic depends on non-deterministic input that was not declared via an equivalence principle.',
+      fix: 'Wrap any non-deterministic operations (LLM calls, web requests, randomness) in `eq_principle.*` so validators can reach consensus.',
+      code: msg,
+    }),
+  },
+  {
+    match: 'version_too_big',
+    build: (msg) => ({
+      title: 'Unsupported contract version',
+      explanation:
+        'The version declared in your contract is newer than what this GenVM build supports.',
+      fix: 'Lower the version in the runner comment, or update the Studio image.',
+      code: msg,
+    }),
+  },
+  {
+    match: /^exit_code(?:\s+.+)?$/,
+    build: (msg) => ({
+      title: 'Contract exited with an error',
+      explanation:
+        'GenVM finished running but the contract returned a non-zero exit code. The most common cause is an unhandled Python exception in your contract.',
+      fix: 'Check the technical details below for stderr output, then add the missing import or fix the raised exception.',
+      code: msg,
+    }),
+  },
+];
+
+/**
+ * Convert any error-like value (string, Error, structured payload) into a
+ * `FriendlyError`. Always returns something renderable — never throws.
+ */
+export function parseGenVMError(input: unknown): FriendlyError {
+  const raw = stringifyError(input);
+  // Prefer an extracted GenVM message; fall back to the trimmed raw string
+  // so callers can pass already-bare codes like `"OOM"` directly.
+  const code = extractGenVMMessage(raw) ?? raw.trim();
+
+  if (code) {
+    for (const m of MAPPINGS) {
+      const matched =
+        typeof m.match === 'string' ? code === m.match : m.match.test(code);
+      if (matched) {
+        return {
+          ...m.build(code),
+          raw,
+          recognized: true,
+        };
+      }
+    }
+  }
+
+  return {
+    ...GENERIC_FALLBACK,
+    code: extractGenVMMessage(raw),
+    raw,
+  };
+}
+
+function stringifyError(input: unknown): string {
+  if (input == null) return '';
+  if (typeof input === 'string') return input;
+  if (input instanceof Error) return input.message || String(input);
+  if (typeof input === 'object') {
+    const o = input as Record<string, unknown>;
+    if (typeof o.message === 'string') return o.message;
+    try {
+      return JSON.stringify(input);
+    } catch {
+      return String(input);
+    }
+  }
+  return String(input);
+}

--- a/frontend/src/utils/genvmErrors.ts
+++ b/frontend/src/utils/genvmErrors.ts
@@ -189,8 +189,11 @@ const MAPPINGS: Mapping[] = [
 export function parseGenVMError(input: unknown): FriendlyError {
   const raw = stringifyError(input);
   // Prefer an extracted GenVM message; fall back to the trimmed raw string
-  // so callers can pass already-bare codes like `"OOM"` directly.
-  const code = extractGenVMMessage(raw) ?? raw.trim();
+  // so callers can pass already-bare codes like `"OOM"` directly. We compute
+  // the normalized code exactly once and reuse it in both the matched and
+  // fallback paths so the `code` field stays consistent for any input shape.
+  const trimmed = raw.trim();
+  const code = extractGenVMMessage(raw) ?? (trimmed.length > 0 ? trimmed : undefined);
 
   if (code) {
     for (const m of MAPPINGS) {
@@ -208,7 +211,7 @@ export function parseGenVMError(input: unknown): FriendlyError {
 
   return {
     ...GENERIC_FALLBACK,
-    code: extractGenVMMessage(raw),
+    code,
     raw,
   };
 }

--- a/frontend/test/unit/utils/genvmErrors.test.ts
+++ b/frontend/test/unit/utils/genvmErrors.test.ts
@@ -132,6 +132,22 @@ describe('parseGenVMError', () => {
       expect(result.recognized).toBe(false);
       expect(result.code).toBe('some_brand_new_error');
     });
+
+    it('exposes the normalized code consistently for bare-string fallbacks', () => {
+      // Regression: previously the fallback path re-ran extraction and dropped
+      // the bare-string code, so an unrecognized bare input came back with
+      // `code: undefined` while a *recognized* bare input came back with
+      // `code: "OOM"`. The field should now always reflect what we used for
+      // matching.
+      const result = parseGenVMError('not_a_known_code');
+      expect(result.recognized).toBe(false);
+      expect(result.code).toBe('not_a_known_code');
+    });
+
+    it('leaves code undefined when the input is empty / whitespace', () => {
+      expect(parseGenVMError('').code).toBeUndefined();
+      expect(parseGenVMError('   ').code).toBeUndefined();
+    });
   });
 
   describe('input normalization', () => {

--- a/frontend/test/unit/utils/genvmErrors.test.ts
+++ b/frontend/test/unit/utils/genvmErrors.test.ts
@@ -1,0 +1,159 @@
+import { describe, expect, it } from 'vitest';
+import {
+  parseGenVMError,
+  extractGenVMMessage,
+} from '@/utils/genvmErrors';
+
+describe('extractGenVMMessage', () => {
+  it('extracts message from a clean JSON payload', () => {
+    const raw = JSON.stringify({
+      kind: 'VM_ERROR',
+      message: 'invalid_contract absent_runner_comment',
+    });
+    expect(extractGenVMMessage(raw)).toBe(
+      'invalid_contract absent_runner_comment',
+    );
+  });
+
+  it('extracts message from a Python repr-style payload (the current backend format)', () => {
+    const raw =
+      "('execution failed', { 'stdout': '', 'stderr': '', " +
+      "'genvm_log': [{'ts': '1774564096787', 'target': 'genvm_common'}], " +
+      "'result': '{\"kind\": \"VM_ERROR\", \"message\": \"invalid_contract absent_runner_comment\"}' })";
+    expect(extractGenVMMessage(raw)).toBe(
+      'invalid_contract absent_runner_comment',
+    );
+  });
+
+  it('falls back to a bare regex match on quoted message field', () => {
+    const raw = 'execution failed: "message": "timeout" and other noise';
+    expect(extractGenVMMessage(raw)).toBe('timeout');
+  });
+
+  it('returns undefined when no message field is present', () => {
+    expect(extractGenVMMessage('totally unrelated error')).toBeUndefined();
+  });
+
+  it('handles empty input safely', () => {
+    expect(extractGenVMMessage('')).toBeUndefined();
+  });
+});
+
+describe('parseGenVMError', () => {
+  describe('absent_runner_comment (the main case from issue #1609)', () => {
+    const raw =
+      "('execution failed', { 'genvm_log': [...], " +
+      "'result': '{\"kind\": \"VM_ERROR\", \"message\": \"invalid_contract absent_runner_comment\"}' })";
+
+    it('produces a recognized friendly error', () => {
+      const result = parseGenVMError(raw);
+      expect(result.recognized).toBe(true);
+      expect(result.code).toBe('invalid_contract absent_runner_comment');
+      expect(result.title).toBe('Could not load contract');
+    });
+
+    it('explains the missing runner comment', () => {
+      const result = parseGenVMError(raw);
+      expect(result.explanation).toMatch(/runner comment/i);
+      expect(result.explanation).toMatch(/first line/i);
+    });
+
+    it('includes a fix snippet with the canonical runner comment', () => {
+      const result = parseGenVMError(raw);
+      expect(result.fix).toContain('# { "Depends": "py-genlayer:test" }');
+    });
+
+    it('preserves the raw payload for the technical-details panel', () => {
+      const result = parseGenVMError(raw);
+      expect(result.raw).toBe(raw);
+    });
+  });
+
+  describe('other known VmError codes', () => {
+    it.each<[string, RegExp]>([
+      ['timeout', /timed out/i],
+      ['OOM', /memory/i],
+      ['validator_disagrees', /validator/i],
+      ['version_too_big', /version/i],
+    ])('maps %s to a recognized friendly error', (code, pattern) => {
+      const raw = JSON.stringify({ kind: 'VM_ERROR', message: code });
+      const result = parseGenVMError(raw);
+      expect(result.recognized).toBe(true);
+      expect(result.code).toBe(code);
+      expect(result.title).toMatch(pattern);
+    });
+
+    it('matches generic invalid_contract <other>', () => {
+      const raw = JSON.stringify({
+        kind: 'VM_ERROR',
+        message: 'invalid_contract some_unknown_reason',
+      });
+      const result = parseGenVMError(raw);
+      expect(result.recognized).toBe(true);
+      expect(result.title).toBe('Invalid contract');
+    });
+
+    it('matches exit_code with optional detail', () => {
+      const raw = JSON.stringify({ kind: 'VM_ERROR', message: 'exit_code 1' });
+      const result = parseGenVMError(raw);
+      expect(result.recognized).toBe(true);
+      expect(result.title).toMatch(/exited/i);
+    });
+  });
+
+  describe('absent_runner_comment is matched before generic invalid_contract', () => {
+    it('does not fall through to the bare invalid_contract mapping', () => {
+      const raw = JSON.stringify({
+        kind: 'VM_ERROR',
+        message: 'invalid_contract absent_runner_comment',
+      });
+      const result = parseGenVMError(raw);
+      expect(result.title).toBe('Could not load contract');
+      // sanity: the generic mapping uses a different title
+      expect(result.title).not.toBe('Invalid contract');
+    });
+  });
+
+  describe('fallback for unknown errors', () => {
+    it('returns a generic message but still preserves the raw payload', () => {
+      const raw = 'something nobody has ever seen before';
+      const result = parseGenVMError(raw);
+      expect(result.recognized).toBe(false);
+      expect(result.title).toBe('Something went wrong');
+      expect(result.raw).toBe(raw);
+    });
+
+    it('still extracts and exposes the code when present, even if unrecognized', () => {
+      const raw = JSON.stringify({
+        kind: 'VM_ERROR',
+        message: 'some_brand_new_error',
+      });
+      const result = parseGenVMError(raw);
+      expect(result.recognized).toBe(false);
+      expect(result.code).toBe('some_brand_new_error');
+    });
+  });
+
+  describe('input normalization', () => {
+    it('accepts an Error instance', () => {
+      const err = new Error(
+        JSON.stringify({ kind: 'VM_ERROR', message: 'timeout' }),
+      );
+      const result = parseGenVMError(err);
+      expect(result.recognized).toBe(true);
+      expect(result.code).toBe('timeout');
+    });
+
+    it('accepts a structured object with a message field', () => {
+      const result = parseGenVMError({ message: 'OOM' });
+      expect(result.recognized).toBe(true);
+      expect(result.code).toBe('OOM');
+    });
+
+    it('handles null / undefined without throwing', () => {
+      expect(() => parseGenVMError(null)).not.toThrow();
+      expect(() => parseGenVMError(undefined)).not.toThrow();
+      expect(parseGenVMError(null).recognized).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
Closes #1609.

## Summary
When a contract failed to load or deploy in Studio, the user was shown the raw GenVM result wrapped in a Python `repr()` — a wall of `genvm_log` JSON with the only useful signal (`"message": "invalid_contract absent_runner_comment"`) buried inside. New developers had no path forward without asking on Discord.

This PR intercepts the error in the Studio frontend, maps known GenVM codes to plain-English `{ title, explanation, fix }` triples, and collapses the raw payload behind a "Show technical details" toggle with a copy-to-clipboard button for bug reports.

## What changed
- **[frontend/src/utils/genvmErrors.ts](cci:7://file:///c:/Users/isanoxel/CascadeProjects/open-design-page/genlayer-studio/frontend/src/utils/genvmErrors.ts:0:0-0:0)** — defensive parser. Extracts the inner GenVM `message` from JSON, Python `repr()` output, and bare strings. Maps every [VmError](cci:2://file:///c:/Users/isanoxel/CascadeProjects/open-design-page/genlayer-studio/backend/node/genvm/origin/public_abi.py:36:0-42:41) code from [backend/node/genvm/origin/public_abi.py](cci:7://file:///c:/Users/isanoxel/CascadeProjects/open-design-page/genlayer-studio/backend/node/genvm/origin/public_abi.py:0:0-0:0) plus the `invalid_contract absent_runner_comment` special case. Unknown codes fall back to a generic friendly message; `raw` is always preserved.
- **[frontend/src/components/Simulator/FriendlyError.vue](cci:7://file:///c:/Users/isanoxel/CascadeProjects/open-design-page/genlayer-studio/frontend/src/components/Simulator/FriendlyError.vue:0:0-0:0)** — red alert with title, explanation, optional fix code block, and a collapsed `<details>` "Show technical details" panel containing the raw payload + `CopyTextButton`.
- Wired [FriendlyError](cci:2://file:///c:/Users/isanoxel/CascadeProjects/open-design-page/genlayer-studio/frontend/src/utils/genvmErrors.ts:20:0-33:1) into the 3 call sites that previously surfaced raw errors:
  - [ConstructorParameters.vue](cci:7://file:///c:/Users/isanoxel/CascadeProjects/open-design-page/genlayer-studio/frontend/src/components/Simulator/ConstructorParameters.vue:0:0-0:0) (was a generic "Could not load contract schema." with no detail at all)
  - [ContractReadMethods.vue](cci:7://file:///c:/Users/isanoxel/CascadeProjects/open-design-page/genlayer-studio/frontend/src/components/Simulator/ContractReadMethods.vue:0:0-0:0) (rendered raw `error.message`)
  - [ContractWriteMethods.vue](cci:7://file:///c:/Users/isanoxel/CascadeProjects/open-design-page/genlayer-studio/frontend/src/components/Simulator/ContractWriteMethods.vue:0:0-0:0) (rendered raw `error.message`)
- 21 vitest unit tests covering extraction (clean JSON, Python repr, bare regex), every recognized code, mapping precedence (`absent_runner_comment` before generic `invalid_contract`), the unknown-code fallback, and input normalization (Error / object / string / null).

## Acceptance criteria (from #1609)
- [x] Studio intercepts schema/deploy errors before rendering
- [x] Known error codes render plain-English title + explanation + fix
- [x] Raw GenVM JSON is collapsed behind "Show technical details"
- [x] Unknown codes fall back to a generic friendly message
- [x] Copy-to-clipboard button on the raw error

## Verification
- `npx vitest run test/unit/utils/genvmErrors.test.ts` — 21/21 pass
- `npx vitest run` (full suite, after `node scripts/contract-examples.js`) — 31 files, 108/108 pass
- `npx vue-tsc --noEmit` — clean

## Notes for reviewers
The wording for `timeout` / `OOM` / `validator_disagrees` / `version_too_big` / `exit_code` is my best inference from the [VmError](cci:2://file:///c:/Users/isanoxel/CascadeProjects/open-design-page/genlayer-studio/backend/node/genvm/origin/public_abi.py:36:0-42:41) enum and is easy to tweak in review — happy to adjust to your preferred phrasing or to add more codes if I missed any.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Unified, user-friendly error UI across the contract simulator with clear titles, explanations, suggested fixes, and a collapsible technical-details view with copyable raw error text.
  * New error-parsing logic to translate raw runtime/RPC errors into readable messages for users.

* **Tests**
  * Added unit tests covering extraction and parsing of various runtime/RPC error formats and mappings.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/genlayerlabs/genlayer-studio/pull/1627)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->