### PR TITLE
fix(consensus): stamp timestamp_awaiting_finalization on insufficient-balance SEND

### DIFF
--- a/backend/consensus/base.py
+++ b/backend/consensus/base.py
@@ -690,7 +690,13 @@ class ConsensusAlgorithm:
 
             # Check if the sender has enough balance
             if from_balance < transaction.value:
-                # Set the transaction status to UNDETERMINED if balance is insufficient
+                # UNDETERMINED is finalization-eligible: claim_next_finalization
+                # filters on timestamp_awaiting_finalization IS NOT NULL.
+                # Without this stamp the row strands forever (16 such rows
+                # accumulated on Studio Prod over 19 days before this fix).
+                transactions_processor.set_transaction_timestamp_awaiting_finalization(
+                    transaction.hash
+                )
                 await ConsensusAlgorithm.dispatch_transaction_status_update(
                     transactions_processor,
                     transaction.hash,

--- a/backend/protocol_rpc/health.py
+++ b/backend/protocol_rpc/health.py
@@ -256,6 +256,9 @@ async def _run_health_checks() -> None:
             "orphaned_transactions": consensus_health.get(
                 "total_orphaned_transactions", 0
             ),
+            "stuck_finalization_count": consensus_health.get(
+                "stuck_finalization_count", 0
+            ),
             "active_workers": consensus_health.get("active_workers", 0),
             "status": consensus_status,
         }
@@ -263,10 +266,15 @@ async def _run_health_checks() -> None:
             if overall_status == "healthy":
                 overall_status = "degraded"
             issues.append("consensus_issue")
-        elif consensus_health.get("total_orphaned_transactions", 0) >= 3:
-            if overall_status == "healthy":
-                overall_status = "degraded"
-            issues.append("orphaned_transactions")
+        else:
+            if consensus_health.get("total_orphaned_transactions", 0) >= 3:
+                if overall_status == "healthy":
+                    overall_status = "degraded"
+                issues.append("orphaned_transactions")
+            if consensus_health.get("stuck_finalization_count", 0) >= 3:
+                if overall_status == "healthy":
+                    overall_status = "degraded"
+                issues.append("stuck_finalizations")
 
         # 3. LLM provider health (per-provider failure-rate detection)
         # Catches cases like a provider returning HTTP 402 / "tier required"
@@ -548,13 +556,31 @@ async def _check_consensus_health() -> Dict[str, Any]:
     # Match the dashboard alert threshold so consensus.status and the
     # top-level "issues" tag agree on what counts as degraded.
     DEGRADED_AT_STUCK_HEADS = int(os.environ.get("HEALTH_DEGRADED_AT_STUCK_HEADS", "3"))
+    # Finalization-stall threshold: ACCEPTED/UNDETERMINED/*_TIMEOUT txs
+    # that haven't reached FINALIZED within this many seconds count as
+    # stuck. Default 600s (10 min) — finalization is supposed to be
+    # quick after the finality window opens.
+    STUCK_FINALIZATION_AFTER_SECONDS = int(
+        os.environ.get("HEALTH_STUCK_FINALIZATION_AFTER_SECONDS", "600")
+    )
+    DEGRADED_AT_STUCK_FINALIZATIONS = int(
+        os.environ.get("HEALTH_DEGRADED_AT_STUCK_FINALIZATIONS", "3")
+    )
 
-    # Statuses considered "in flight". Includes the *_TIMEOUT variants
-    # because finalization and appeal claim paths process them. Must
-    # match the head-CTE filter and the in-flight-count query for
-    # consistency.
-    IN_FLIGHT_STATUSES_SQL = (
+    # Statuses where the consensus state machine is actively working.
+    # The "head of queue stuck" check uses ONLY these: ACCEPTED-class
+    # statuses are post-consensus and live under the separate
+    # finalization-stall detector below.
+    CONSENSUS_ACTIVE_STATUSES_SQL = "'ACTIVATED','PROPOSING','COMMITTING','REVEALING'"
+    # Broader set including finalization-pending statuses. Used only
+    # in the "is any worker actively claiming on this contract" NOT
+    # EXISTS clause — a finalization worker counts as active work and
+    # should mask a stuck consensus head.
+    ANY_INFLIGHT_STATUSES_SQL = (
         "'ACTIVATED','PROPOSING','COMMITTING','REVEALING',"
+        "'ACCEPTED','UNDETERMINED','LEADER_TIMEOUT','VALIDATORS_TIMEOUT'"
+    )
+    FINALIZATION_ELIGIBLE_STATUSES_SQL = (
         "'ACCEPTED','UNDETERMINED','LEADER_TIMEOUT','VALIDATORS_TIMEOUT'"
     )
 
@@ -586,13 +612,18 @@ async def _check_consensus_health() -> Dict[str, Any]:
                 ).fetchone()
                 active_workers_count = active_workers_row.n if active_workers_row else 0
 
-                # Stuck heads: per contract, the oldest in-flight tx
-                # whose contract has no unexpired worker claim AND head
-                # is old enough to expect progress. Returns the count
-                # of AFFECTED CONTRACTS, not the count of queued txs
-                # behind them — those are not the problem, the head is.
-                # Tie-break on hash so debug output (when we surface
-                # the heads) is deterministic.
+                # Stuck heads: per contract, the oldest consensus-active
+                # tx whose contract has no unexpired worker claim AND
+                # head is old enough to expect progress. Head CTE uses
+                # only the consensus-active set — ACCEPTED-class rows
+                # are post-consensus and would otherwise pollute the
+                # signal (one stranded UNDETERMINED on an unused
+                # contract is not a stuck head). The NOT EXISTS clause
+                # uses the broader set so a finalization worker
+                # currently processing on the same contract correctly
+                # masks the alarm.
+                # Returns the count of AFFECTED CONTRACTS, not the
+                # count of queued txs behind them.
                 stuck_row = conn.execute(
                     text(
                         f"""
@@ -603,7 +634,7 @@ async def _check_consensus_health() -> Dict[str, Any]:
                                 status,
                                 created_at
                             FROM transactions
-                            WHERE status IN ({IN_FLIGHT_STATUSES_SQL})
+                            WHERE status IN ({CONSENSUS_ACTIVE_STATUSES_SQL})
                               AND to_address IS NOT NULL
                             ORDER BY to_address, created_at ASC, hash ASC
                         )
@@ -614,7 +645,7 @@ async def _check_consensus_health() -> Dict[str, Any]:
                               SELECT 1
                               FROM transactions t2
                               WHERE t2.to_address = h.to_address
-                                AND t2.status IN ({IN_FLIGHT_STATUSES_SQL})
+                                AND t2.status IN ({ANY_INFLIGHT_STATUSES_SQL})
                                 AND t2.blocked_at IS NOT NULL
                                 AND t2.blocked_at > NOW() - make_interval(mins => :claim_window)
                           )
@@ -627,15 +658,47 @@ async def _check_consensus_health() -> Dict[str, Any]:
                 ).fetchone()
                 stuck_head_contracts = stuck_row.stuck_heads if stuck_row else 0
 
+                # Stuck finalizations: ACCEPTED-class txs waiting too
+                # long to reach FINALIZED. Two paths:
+                #   1. timestamp_awaiting_finalization set and stale
+                #      (normal "finalizer not running" case)
+                #   2. timestamp_awaiting_finalization NULL and the row
+                #      is old (catches future bugs like the May 2026
+                #      insufficient-balance SEND path, where a tx
+                #      reached UNDETERMINED without ever stamping the
+                #      timestamp — invisible to claim_next_finalization
+                #      forever)
+                stuck_fin_row = conn.execute(
+                    text(
+                        f"""
+                        SELECT COUNT(*) AS n
+                        FROM transactions
+                        WHERE status IN ({FINALIZATION_ELIGIBLE_STATUSES_SQL})
+                          AND (
+                              (timestamp_awaiting_finalization IS NOT NULL
+                               AND EXTRACT(EPOCH FROM NOW())::bigint
+                                   - timestamp_awaiting_finalization
+                                   > :stuck_seconds)
+                              OR
+                              (timestamp_awaiting_finalization IS NULL
+                               AND created_at
+                                   < NOW() - make_interval(secs => :stuck_seconds))
+                          )
+                        """
+                    ),
+                    {"stuck_seconds": STUCK_FINALIZATION_AFTER_SECONDS},
+                ).fetchone()
+                stuck_finalization_count = stuck_fin_row.n if stuck_fin_row else 0
+
                 # Total in-flight (non-final) tx count, for context.
-                # Same status set as the head CTE so the metrics are
-                # consistent.
+                # Consensus-active only — finalization-pending rows
+                # are tracked separately via stuck_finalization_count.
                 processing_row = conn.execute(
                     text(
                         f"""
                         SELECT COUNT(*) AS n
                         FROM transactions
-                        WHERE status IN ({IN_FLIGHT_STATUSES_SQL})
+                        WHERE status IN ({CONSENSUS_ACTIVE_STATUSES_SQL})
                           AND to_address IS NOT NULL
                         """
                     )
@@ -643,19 +706,22 @@ async def _check_consensus_health() -> Dict[str, Any]:
                 total_processing = processing_row.n if processing_row else 0
 
                 status = (
-                    "healthy"
-                    if stuck_head_contracts < DEGRADED_AT_STUCK_HEADS
-                    else "degraded"
+                    "degraded"
+                    if (
+                        stuck_head_contracts >= DEGRADED_AT_STUCK_HEADS
+                        or stuck_finalization_count >= DEGRADED_AT_STUCK_FINALIZATIONS
+                    )
+                    else "healthy"
                 )
 
                 return {
                     "status": status,
                     "total_processing_transactions": total_processing,
                     # Field name preserved for backwards-compat with the
-                    # external dashboard. Semantics changed: now counts
-                    # CONTRACTS whose head-of-queue is stuck, not raw
-                    # blocked txs. A long queue with a moving head reads 0.
+                    # external dashboard. Semantics: count of CONTRACTS
+                    # whose consensus head is stuck.
                     "total_orphaned_transactions": stuck_head_contracts,
+                    "stuck_finalization_count": stuck_finalization_count,
                     "active_workers": active_workers_count,
                 }
 

--- a/tests/db-sqlalchemy/test_execute_transfer_undetermined_finalization.py
+++ b/tests/db-sqlalchemy/test_execute_transfer_undetermined_finalization.py
@@ -1,0 +1,148 @@
+"""Regression test for `execute_transfer` insufficient-balance stranding.
+
+Bug history (May 2026): native SEND transactions with insufficient sender
+balance were dispatched to UNDETERMINED via `dispatch_transaction_status_update`
+without setting `timestamp_awaiting_finalization`. `claim_next_finalization`
+filters on that field being non-NULL, so the rows sat forever — 16 such rows
+accumulated on Studio Prod over 19 days. This test pins the fix in
+`backend/consensus/base.py::execute_transfer` so the timestamp is always set
+before the status flips.
+"""
+
+import pytest
+from sqlalchemy import text
+from sqlalchemy.orm import Session
+from unittest.mock import AsyncMock
+
+from backend.consensus.base import ConsensusAlgorithm
+from backend.database_handler.accounts_manager import AccountsManager
+from backend.database_handler.transactions_processor import (
+    TransactionsProcessor,
+    TransactionStatus,
+)
+from backend.domain.types import Transaction, TransactionType, TransactionExecutionMode
+
+
+SENDER = "0x" + "ab" * 20
+RECIPIENT = "0x" + "cd" * 20
+
+
+def _insert_send_tx(tp: TransactionsProcessor, *, value: int) -> str:
+    tx_hash = tp.insert_transaction(
+        from_address=SENDER,
+        to_address=RECIPIENT,
+        data={},
+        value=value,
+        type=TransactionType.SEND.value,
+        nonce=0,
+        leader_only=True,
+        config_rotation_rounds=0,
+        triggered_by_hash=None,
+        transaction_hash=("0x" + "ee" * 32),
+    )
+    tp.session.commit()
+    return tx_hash
+
+
+@pytest.mark.asyncio
+async def test_insufficient_balance_send_sets_timestamp_awaiting_finalization(
+    session: Session,
+):
+    """Insufficient-balance SEND must stamp timestamp_awaiting_finalization
+    so claim_next_finalization can pick the row up. Without the stamp the
+    row is invisible to the finalization claim query forever."""
+    tp = TransactionsProcessor(session)
+    am = AccountsManager(session)
+
+    # Sender balance = 0, tx asks for 1000 → triggers the insufficient-balance
+    # branch in execute_transfer.
+    am.update_account_balance(SENDER, 0)
+    session.commit()
+
+    tx_hash = _insert_send_tx(tp, value=1000)
+
+    tx = Transaction(
+        hash=tx_hash,
+        status=TransactionStatus.PENDING,
+        type=TransactionType.SEND,
+        from_address=SENDER,
+        to_address=RECIPIENT,
+        value=1000,
+        nonce=0,
+        leader_only=True,
+        execution_mode=TransactionExecutionMode.NORMAL,
+    )
+
+    msg_handler = AsyncMock()
+
+    await ConsensusAlgorithm.execute_transfer(
+        transaction=tx,
+        transactions_processor=tp,
+        accounts_manager=am,
+        msg_handler=msg_handler,
+    )
+    session.commit()
+
+    # Read the row directly to bypass any caching in TransactionsProcessor.
+    row = session.execute(
+        text(
+            "SELECT status, timestamp_awaiting_finalization FROM transactions WHERE hash = :h"
+        ),
+        {"h": tx_hash},
+    ).one()
+
+    assert row.status == "UNDETERMINED", (
+        f"expected UNDETERMINED, got {row.status} — insufficient-balance "
+        "SEND should short-circuit to UNDETERMINED"
+    )
+    assert row.timestamp_awaiting_finalization is not None, (
+        "timestamp_awaiting_finalization must be set on the insufficient-"
+        "balance UNDETERMINED path, otherwise claim_next_finalization (which "
+        "filters on this column being non-NULL) skips the row forever. "
+        "Regression: see Studio Prod stranded-UNDETERMINED rows, May 2026."
+    )
+    assert row.timestamp_awaiting_finalization > 0
+
+
+@pytest.mark.asyncio
+async def test_sufficient_balance_send_finalizes_without_undetermined(
+    session: Session,
+):
+    """Control: when the sender has enough balance, execute_transfer should
+    take the success path and dispatch FINALIZED, not UNDETERMINED. Guards
+    against accidental over-broadening of the insufficient-balance branch."""
+    tp = TransactionsProcessor(session)
+    am = AccountsManager(session)
+
+    am.update_account_balance(SENDER, 5000)
+    session.commit()
+
+    tx_hash = _insert_send_tx(tp, value=1000)
+
+    tx = Transaction(
+        hash=tx_hash,
+        status=TransactionStatus.PENDING,
+        type=TransactionType.SEND,
+        from_address=SENDER,
+        to_address=RECIPIENT,
+        value=1000,
+        nonce=0,
+        leader_only=True,
+        execution_mode=TransactionExecutionMode.NORMAL,
+    )
+
+    msg_handler = AsyncMock()
+
+    await ConsensusAlgorithm.execute_transfer(
+        transaction=tx,
+        transactions_processor=tp,
+        accounts_manager=am,
+        msg_handler=msg_handler,
+    )
+    session.commit()
+
+    row = session.execute(
+        text("SELECT status FROM transactions WHERE hash = :h"),
+        {"h": tx_hash},
+    ).one()
+    assert row.status == "FINALIZED"

--- a/tests/db-sqlalchemy/test_health_orphan_detection.py
+++ b/tests/db-sqlalchemy/test_health_orphan_detection.py
@@ -69,6 +69,7 @@ def _insert_tx(
     created_at: datetime,
     blocked_at: datetime | None = None,
     worker_id: str | None = None,
+    timestamp_awaiting_finalization: int | None = None,
 ):
     """Direct INSERT — bypass the processor so we can backdate created_at."""
     session.execute(
@@ -80,13 +81,15 @@ def _insert_tx(
                 appeal_undetermined, appeal_leader_timeout,
                 appeal_validators_timeout, appeal_processing_time,
                 recovery_count, value_credited,
-                created_at, blocked_at, worker_id
+                created_at, blocked_at, worker_id,
+                timestamp_awaiting_finalization
             ) VALUES (
                 :hash, CAST(:status AS transaction_status),
                 '0xfromaddress', :to_addr, CAST('{}' AS jsonb), 0, 2,
                 :nonce, false, 'NORMAL', false, 0,
                 false, false, false, 0, 0, false,
-                :created_at, :blocked_at, :worker_id
+                :created_at, :blocked_at, :worker_id,
+                :timestamp_awaiting_finalization
             )
             """
         ),
@@ -98,6 +101,7 @@ def _insert_tx(
             "created_at": created_at,
             "blocked_at": blocked_at,
             "worker_id": worker_id,
+            "timestamp_awaiting_finalization": timestamp_awaiting_finalization,
         },
     )
 
@@ -163,7 +167,7 @@ async def test_stuck_head_no_active_work_is_orphaned(engine: Engine):
             s,
             tx_hash="0x" + "01" * 32,
             to_address=contract,
-            status="ACCEPTED",
+            status="COMMITTING",
             nonce=0,
             created_at=now - timedelta(minutes=30),
         )
@@ -279,7 +283,7 @@ async def test_multiple_contracts_only_stuck_heads_count(engine: Engine):
             s,
             tx_hash="0x" + "0b" * 32,
             to_address="0x" + "bb" * 20,
-            status="ACCEPTED",
+            status="COMMITTING",
             nonce=0,
             created_at=now - timedelta(minutes=30),
         )
@@ -375,15 +379,21 @@ async def test_expired_claim_counts_contract_as_stuck(engine: Engine):
 
 
 @pytest.mark.asyncio
-async def test_timeout_status_head_is_treated_as_in_flight(engine: Engine):
-    """LEADER_TIMEOUT and VALIDATORS_TIMEOUT are processed by the
-    finalization/appeal claim paths — they're in-flight statuses, so
-    a stale head in those states should still trigger detection."""
+async def test_post_consensus_statuses_excluded_from_stuck_head_count(engine: Engine):
+    """ACCEPTED / UNDETERMINED / *_TIMEOUT are post-consensus statuses,
+    awaiting finalization rather than blocked on consensus progress.
+    They MUST NOT count as stuck consensus heads — that's the false-
+    positive class that mis-fired the production alert in May 2026
+    (15 stranded UNDETERMINED rows on unused contracts looked like
+    stuck heads, but they had zero queue behind them). The dedicated
+    stuck-finalization detector covers these instead."""
     Session_ = sessionmaker(bind=engine, expire_on_commit=False)
     now = datetime.now(timezone.utc)
 
     with Session_() as s:
-        for i, st in enumerate(["LEADER_TIMEOUT", "VALIDATORS_TIMEOUT"]):
+        for i, st in enumerate(
+            ["ACCEPTED", "UNDETERMINED", "LEADER_TIMEOUT", "VALIDATORS_TIMEOUT"]
+        ):
             _insert_tx(
                 s,
                 tx_hash=f"0x{i:064x}",
@@ -398,9 +408,9 @@ async def test_timeout_status_head_is_treated_as_in_flight(engine: Engine):
 
     result = await health_module._check_consensus_health()
 
-    assert result["total_orphaned_transactions"] == 2, (
-        "*_TIMEOUT statuses must be in-flight per the head CTE so the "
-        "metric agrees with the worker claim paths that process them."
+    assert result["total_orphaned_transactions"] == 0, (
+        "Post-consensus statuses must not pollute the stuck-head signal. "
+        f"Got: {result}"
     )
 
 
@@ -419,7 +429,7 @@ async def test_status_threshold_matches_dashboard_alert_gate(engine: Engine):
                 s,
                 tx_hash=f"0x{i:064x}",
                 to_address=f"0x{(0x70 + i):02x}" + "00" * 19,
-                status="ACCEPTED",
+                status="COMMITTING",
                 nonce=0,
                 created_at=now - timedelta(minutes=30),
             )
@@ -433,3 +443,147 @@ async def test_status_threshold_matches_dashboard_alert_gate(engine: Engine):
     assert (
         result["status"] == "degraded"
     ), f"3 stuck contracts must flip status to degraded. Got: {result}"
+
+
+# ── Stuck-finalization detector ───────────────────────────────────
+#
+# Separate from the stuck-consensus-head detector. Post-consensus txs
+# (ACCEPTED / UNDETERMINED / *_TIMEOUT) carry agreed consensus_data and
+# only need finalization. They live under this metric. The detector
+# has two arms:
+#
+#   1. timestamp_awaiting_finalization set + stale → finalizer not
+#      making progress on these rows (e.g., finalization scheduler
+#      starvation, finalization claim path broken).
+#   2. timestamp_awaiting_finalization NULL + row is old → defensive:
+#      catches future bugs like the May 2026 insufficient-balance SEND
+#      path, which reached UNDETERMINED without ever stamping the
+#      timestamp and was invisible to claim_next_finalization forever.
+
+
+@pytest.mark.asyncio
+async def test_stuck_finalization_with_stale_timestamp_is_flagged(engine: Engine):
+    """timestamp_awaiting_finalization is set but older than the
+    threshold — classic "finalizer not running" case."""
+    import time
+
+    Session_ = sessionmaker(bind=engine, expire_on_commit=False)
+    now = datetime.now(timezone.utc)
+    stale_ts = int(time.time()) - 24 * 3600  # 1 day ago
+
+    with Session_() as s:
+        _insert_tx(
+            s,
+            tx_hash="0x" + "f1" * 32,
+            to_address="0x" + "f1" * 20,
+            status="ACCEPTED",
+            nonce=0,
+            created_at=now - timedelta(days=1),
+            timestamp_awaiting_finalization=stale_ts,
+        )
+        s.commit()
+
+    from backend.protocol_rpc import health as health_module
+
+    result = await health_module._check_consensus_health()
+
+    assert (
+        result["stuck_finalization_count"] == 1
+    ), f"Stale timestamp_awaiting_finalization must be flagged. Got: {result}"
+
+
+@pytest.mark.asyncio
+async def test_stuck_finalization_with_null_timestamp_is_flagged(engine: Engine):
+    """timestamp_awaiting_finalization is NULL but the row is old —
+    defensive coverage for the May 2026 insufficient-balance SEND bug
+    pattern (post-consensus row without an awaiting timestamp, invisible
+    to claim_next_finalization)."""
+    Session_ = sessionmaker(bind=engine, expire_on_commit=False)
+    now = datetime.now(timezone.utc)
+
+    with Session_() as s:
+        _insert_tx(
+            s,
+            tx_hash="0x" + "f2" * 32,
+            to_address="0x" + "f2" * 20,
+            status="UNDETERMINED",
+            nonce=0,
+            created_at=now - timedelta(hours=2),
+            timestamp_awaiting_finalization=None,
+        )
+        s.commit()
+
+    from backend.protocol_rpc import health as health_module
+
+    result = await health_module._check_consensus_health()
+
+    assert result["stuck_finalization_count"] == 1, (
+        "NULL timestamp + old row must be flagged so a regression of the "
+        f"insufficient-balance SEND bug is caught. Got: {result}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_recent_finalization_eligible_row_is_not_flagged(engine: Engine):
+    """Row younger than the stuck-finalization threshold must not be
+    flagged — the finalization window is still open."""
+    import time
+
+    Session_ = sessionmaker(bind=engine, expire_on_commit=False)
+    now = datetime.now(timezone.utc)
+
+    with Session_() as s:
+        _insert_tx(
+            s,
+            tx_hash="0x" + "f3" * 32,
+            to_address="0x" + "f3" * 20,
+            status="ACCEPTED",
+            nonce=0,
+            created_at=now - timedelta(seconds=30),
+            # set to "now" — finality window not exceeded yet
+            timestamp_awaiting_finalization=int(time.time()),
+        )
+        s.commit()
+
+    from backend.protocol_rpc import health as health_module
+
+    result = await health_module._check_consensus_health()
+
+    assert (
+        result["stuck_finalization_count"] == 0
+    ), f"Fresh finalization-eligible row must not be flagged. Got: {result}"
+
+
+@pytest.mark.asyncio
+async def test_stuck_finalization_flips_status_at_threshold(engine: Engine):
+    """consensus.status flips to degraded when stuck_finalization_count
+    reaches HEALTH_DEGRADED_AT_STUCK_FINALIZATIONS (default 3) —
+    independent of stuck-head count, so finalization stalls get their
+    own clear signal."""
+    import time
+
+    Session_ = sessionmaker(bind=engine, expire_on_commit=False)
+    now = datetime.now(timezone.utc)
+    stale_ts = int(time.time()) - 12 * 3600
+
+    with Session_() as s:
+        for i in range(3):
+            _insert_tx(
+                s,
+                tx_hash=f"0xf4{i:062x}",
+                to_address=f"0x{(0xF4 + i):02x}" + "00" * 19,
+                status="UNDETERMINED",
+                nonce=0,
+                created_at=now - timedelta(hours=12),
+                timestamp_awaiting_finalization=stale_ts,
+            )
+        s.commit()
+
+    from backend.protocol_rpc import health as health_module
+
+    result = await health_module._check_consensus_health()
+
+    assert result["stuck_finalization_count"] == 3
+    assert (
+        result["status"] == "degraded"
+    ), f"3 stuck finalizations must flip consensus.status. Got: {result}"


### PR DESCRIPTION
## Why

Two related issues, both surfaced by the May 2026 Studio Prod alert:

1. **Root bug**: native SEND with insufficient balance lands in UNDETERMINED via a short-circuit that bypasses the effects machinery — never stamps `timestamp_awaiting_finalization`, so `claim_next_finalization` (which filters on that column being non-NULL) never picks the row up. 16 such rows stranded on Studio Prod over 19 days.

2. **Alert hygiene**: the stuck-head detector's "in-flight" status set included ACCEPTED / UNDETERMINED / *_TIMEOUT. Those are post-consensus / awaiting finalization, not "head of queue not progressing". Stranded UNDETERMINED rows from (1) tripped the alert on contracts that were otherwise healthy.

Root-caused jointly with Codex.

## Fix

**Commit 1 — `execute_transfer` stamps the timestamp before status flip.** The newer consensus paths (`decide_undetermined`, `decide_validators_timeout`, appeal-success branches) emit `SetTimestampAwaitingFinalizationEffect` correctly; only this short-circuit was missing it.

**Commit 2 — split the health detector into two clear signals:**
- **Stuck consensus head**: counts contracts whose oldest `ACTIVATED/PROPOSING/COMMITTING/REVEALING` head has no fresh worker claim. Field unchanged for dashboard backwards-compat: `total_orphaned_transactions`.
- **Stuck finalization**: counts `ACCEPTED/UNDETERMINED/*_TIMEOUT` rows past `HEALTH_STUCK_FINALIZATION_AFTER_SECONDS` (default 600s). Two arms — stale `timestamp_awaiting_finalization`, AND defensive: NULL timestamp + old `created_at` so the next bug-of-this-shape can't hide. New field: `stuck_finalization_count`. New issues tag: `"stuck_finalizations"`. Threshold env: `HEALTH_DEGRADED_AT_STUCK_FINALIZATIONS` (default 3).
- The `NOT EXISTS` clause keeps the broader set so an active finalization worker on the same contract still masks a stuck-head alarm.

## Test

`tests/db-sqlalchemy/test_execute_transfer_undetermined_finalization.py`:
- insufficient-balance SEND must produce UNDETERMINED with non-NULL `timestamp_awaiting_finalization`. Verified failing on pre-fix code.
- sufficient-balance control finalizes.

`tests/db-sqlalchemy/test_health_orphan_detection.py`:
- post-consensus statuses MUST NOT count as stuck heads (pins the false-positive).
- stuck-finalization detector: stale timestamp, NULL + old, fresh-row negative, threshold flips status.
- 2 existing tests retargeted from ACCEPTED → COMMITTING (ACCEPTED no longer in head set).

Full db-sqlalchemy suite: **157 passed, 1 xfailed**.

## Prod backfill (one-off, run after deploy)

```sql
UPDATE transactions
SET timestamp_awaiting_finalization = EXTRACT(EPOCH FROM created_at)::bigint
WHERE status IN ('ACCEPTED','UNDETERMINED','LEADER_TIMEOUT','VALIDATORS_TIMEOUT')
  AND appealed = false
  AND timestamp_awaiting_finalization IS NULL;
```

Run on Studio Prod (16 known rows) and Rally Prod (defensive). After this, `claim_next_finalization` picks them up and they reach FINALIZED.

## Test plan

- [ ] CI: db-sqlalchemy passes
- [ ] After deploy: run the backfill SQL above
- [ ] Confirm Studio Prod `orphaned_transactions` health alert clears
- [ ] Verify the new `stuck_finalization_count` field shows 0 once the backfill drains