### PR TITLE
fix(consensus): single-slot wall-clock budget + quorum-driven replacement

### DIFF
--- a/backend/consensus/base.py
+++ b/backend/consensus/base.py
@@ -3,7 +3,9 @@
 DEFAULT_VALIDATORS_COUNT = 5
 ACTIVATED_TRANSACTION_TIMEOUT = 900
 MAX_IDLE_REPLACEMENTS = 5
-DEFAULT_VALIDATOR_EXEC_TIMEOUT_SECONDS = ACTIVATED_TRANSACTION_TIMEOUT
+DEFAULT_EXEC_TIMEOUT_SECONDS = 600
+DEFAULT_LEADER_EXEC_TIMEOUT_SECONDS = DEFAULT_EXEC_TIMEOUT_SECONDS
+DEFAULT_VALIDATOR_EXEC_TIMEOUT_SECONDS = DEFAULT_EXEC_TIMEOUT_SECONDS
 
 import os
 import asyncio
@@ -54,7 +56,7 @@ from backend.rollup.consensus_service import ConsensusService
 
 import backend.validators as validators
 from backend.node.genvm.origin.public_abi import ResultCode
-from backend.consensus.types import ConsensusRound
+from backend.consensus.types import ConsensusResult, ConsensusRound
 from backend.consensus.utils import determine_consensus_from_votes
 from backend.consensus.decisions import (
     decide_undetermined,
@@ -219,16 +221,32 @@ def _redact_contract_for_log(contract_dict: dict) -> dict:
     return redacted
 
 
-def _validator_exec_timeout_seconds() -> float:
-    raw_timeout = os.getenv("CONSENSUS_VALIDATOR_EXEC_TIMEOUT_SECONDS")
+def _slot_budget_seconds(
+    transaction: Transaction,
+    role: Literal["leader", "validator"],
+) -> float:
+    """Per-tx slot budget.
+
+    Future: read from transaction.sim_config / gas mechanism. Today: env var
+    fallback.
+    """
+    _ = transaction
+    if role == "leader":
+        env_key = "CONSENSUS_LEADER_EXEC_TIMEOUT_SECONDS"
+        default = DEFAULT_LEADER_EXEC_TIMEOUT_SECONDS
+    else:
+        env_key = "CONSENSUS_VALIDATOR_EXEC_TIMEOUT_SECONDS"
+        default = DEFAULT_VALIDATOR_EXEC_TIMEOUT_SECONDS
+
+    raw_timeout = os.getenv(env_key)
     if raw_timeout is None:
-        return float(DEFAULT_VALIDATOR_EXEC_TIMEOUT_SECONDS)
+        return float(default)
     try:
         timeout = float(raw_timeout)
     except ValueError:
-        return float(DEFAULT_VALIDATOR_EXEC_TIMEOUT_SECONDS)
+        return float(default)
     if timeout <= 0:
-        return float(DEFAULT_VALIDATOR_EXEC_TIMEOUT_SECONDS)
+        return float(default)
     return timeout
 
 
@@ -1702,8 +1720,42 @@ class ProposingState(TransactionState):
                 context.transaction.hash, f"PROPOSING.LEADER.{step_name}"
             )
 
-        # Execute leader with replacement on fatal infrastructure failures
+        # Execute leader with one wall-clock slot budget. Fatal internal
+        # failures can still use replacements while budget remains.
+        leader_budget_seconds = _slot_budget_seconds(context.transaction, "leader")
+        leader_deadline = asyncio.get_running_loop().time() + leader_budget_seconds
+
+        def _build_leader_timeout_receipt(leader_dict: dict) -> Receipt:
+            timeout_ms = int(leader_budget_seconds * 1000)
+            return Receipt(
+                result=bytes([ResultCode.VM_ERROR]) + b"timeout",
+                calldata=b"",
+                gas_used=0,
+                mode=ExecutionMode.LEADER,
+                contract_state={},
+                node_config=leader_dict,
+                execution_result=ExecutionResultStatus.ERROR,
+                vote=None,
+                genvm_result={
+                    "stdout": "",
+                    "stderr": f"Leader execution exceeded {leader_budget_seconds:.3f}s",
+                    "error_code": "CONSENSUS_LEADER_EXEC_TIMEOUT",
+                    "raw_error": {
+                        "causes": ["LEADER_EXEC_TIMEOUT"],
+                        "fatal": False,
+                    },
+                },
+                processing_time=timeout_ms,
+            )
+
         for attempt in range(MAX_IDLE_REPLACEMENTS + 1):
+            remaining = leader_deadline - asyncio.get_running_loop().time()
+            if remaining <= 0:
+                context.consensus_data.leader_receipt = [
+                    _build_leader_timeout_receipt(context.leader)
+                ]
+                break
+
             leader_node = context.node_factory(
                 context.leader,
                 ExecutionMode.LEADER,
@@ -1722,10 +1774,27 @@ class ProposingState(TransactionState):
                 context.transaction.hash,
                 f"PROPOSING.LEADER_NODE_CREATED.attempt_{attempt}",
             )
+            exec_task = asyncio.create_task(
+                leader_node.exec_transaction(context.transaction)
+            )
             try:
-                context.consensus_data.leader_receipt = [
-                    await leader_node.exec_transaction(context.transaction)
-                ]
+                done, _ = await asyncio.wait(
+                    {exec_task},
+                    timeout=remaining,
+                    return_when=asyncio.FIRST_COMPLETED,
+                )
+                if exec_task not in done:
+                    exec_task.cancel()
+                    try:
+                        await asyncio.wait_for(exec_task, timeout=0.1)
+                    except (asyncio.CancelledError, asyncio.TimeoutError, Exception):
+                        pass
+                    context.consensus_data.leader_receipt = [
+                        _build_leader_timeout_receipt(context.leader)
+                    ]
+                    break
+
+                context.consensus_data.leader_receipt = [await exec_task]
                 break  # success
             except GenVMInternalError as e:
                 if not e.is_fatal:
@@ -1848,7 +1917,9 @@ class CommittingState(TransactionState):
                 context.shared_contract_snapshot_cache,
             )
 
-        validator_exec_timeout_seconds = _validator_exec_timeout_seconds()
+        validator_slot_budget_seconds = _slot_budget_seconds(
+            context.transaction, "validator"
+        )
 
         # Execute the transaction with a semaphore to limit the number of concurrent validators
         sem = asyncio.Semaphore(8)
@@ -1874,7 +1945,7 @@ class CommittingState(TransactionState):
             return isinstance(raw_error, dict) and raw_error.get("fatal") is True
 
         def _build_timeout_receipt(validator_dict: dict) -> Receipt:
-            timeout_ms = int(validator_exec_timeout_seconds * 1000)
+            timeout_ms = int(validator_slot_budget_seconds * 1000)
             return Receipt(
                 result=bytes([ResultCode.VM_ERROR]) + b"timeout",
                 calldata=b"",
@@ -1883,21 +1954,44 @@ class CommittingState(TransactionState):
                 contract_state={},
                 node_config=validator_dict,
                 execution_result=ExecutionResultStatus.ERROR,
-                vote=None,
+                vote=Vote.TIMEOUT,
                 genvm_result={
                     "stdout": "",
                     "stderr": (
                         "Validator execution exceeded "
-                        f"{validator_exec_timeout_seconds:.3f}s"
+                        f"{validator_slot_budget_seconds:.3f}s"
                     ),
                     "error_code": "CONSENSUS_VALIDATOR_EXEC_TIMEOUT",
                     "raw_error": {
                         "causes": ["VALIDATOR_EXEC_TIMEOUT"],
-                        # Mark as fatal so replacement validators are attempted.
-                        "fatal": True,
+                        # Slot budget expiry is terminal for this attempt; timeout
+                        # replacement is driven after votes are collected.
+                        "fatal": False,
                     },
                 },
                 processing_time=timeout_ms,
+            )
+
+        def _build_synthetic_idle_receipt(validator_dict: dict) -> Receipt:
+            return Receipt(
+                result=bytes([ResultCode.VM_ERROR]) + b"idle",
+                calldata=b"",
+                gas_used=0,
+                mode=ExecutionMode.VALIDATOR,
+                contract_state={},
+                node_config=validator_dict,
+                execution_result=ExecutionResultStatus.ERROR,
+                vote=Vote.IDLE,
+                genvm_result={
+                    "stdout": "",
+                    "stderr": "Validator execution cancelled after quorum",
+                    "error_code": "CONSENSUS_VALIDATOR_QUORUM_REACHED",
+                    "raw_error": {
+                        "causes": ["VALIDATOR_QUORUM_REACHED"],
+                        "fatal": False,
+                    },
+                },
+                processing_time=0,
             )
 
         def _build_internal_error_receipt(
@@ -1928,7 +2022,15 @@ class CommittingState(TransactionState):
         async def run_single_validator(validator_dict: dict, index: int) -> Receipt:
             async with sem:
                 current = validator_dict
+                slot_deadline = (
+                    asyncio.get_running_loop().time() + validator_slot_budget_seconds
+                )
                 for attempt in range(MAX_IDLE_REPLACEMENTS + 1):
+                    remaining = slot_deadline - asyncio.get_running_loop().time()
+                    if remaining <= 0:
+                        result = _build_timeout_receipt(current)
+                        break
+
                     node = create_validator_node(context, current, index)
                     context.transactions_processor.add_state_timestamp(
                         context.transaction.hash,
@@ -1939,7 +2041,7 @@ class CommittingState(TransactionState):
                     )
                     done, _ = await asyncio.wait(
                         {exec_task},
-                        timeout=validator_exec_timeout_seconds,
+                        timeout=remaining,
                         return_when=asyncio.FIRST_COMPLETED,
                     )
                     if exec_task in done:
@@ -2006,11 +2108,114 @@ class CommittingState(TransactionState):
             context.transaction.hash, "COMMITTING.VALIDATORS_EXECUTION_START"
         )
 
-        validation_tasks = [
-            run_single_validator(validator_dict, index)
-            for index, validator_dict in enumerate(validators_to_run)
+        def _is_quorum_reached(votes_so_far: list[str], total_votes: int) -> bool:
+            pending = total_votes - len(votes_so_far)
+            if pending < 0:
+                return False
+            possible_pending_votes = (
+                Vote.AGREE.value,
+                Vote.DISAGREE.value,
+                Vote.TIMEOUT.value,
+                Vote.IDLE.value,
+            )
+            outcomes = {
+                determine_consensus_from_votes(votes_so_far + [pending_vote] * pending)
+                for pending_vote in possible_pending_votes
+            }
+            if len(outcomes) != 1:
+                return False
+            return next(iter(outcomes)) != ConsensusResult.NO_MAJORITY
+
+        async def _cancel_pending_validator_tasks(
+            pending: Iterable[asyncio.Task],
+        ) -> None:
+            for task in pending:
+                task.cancel()
+            for task in pending:
+                try:
+                    await task
+                except (asyncio.CancelledError, asyncio.TimeoutError, Exception):
+                    pass
+
+        async def _run_validator_wave(
+            results: list[Receipt | None],
+            slot_validators: list[dict],
+            indexes_to_run: list[int],
+        ) -> bool:
+            if not indexes_to_run:
+                return False
+
+            tasks_by_task = {
+                asyncio.create_task(
+                    run_single_validator(slot_validators[index], index)
+                ): index
+                for index in indexes_to_run
+            }
+            pending = set(tasks_by_task)
+            while pending:
+                done, pending = await asyncio.wait(
+                    pending, return_when=asyncio.FIRST_COMPLETED
+                )
+                for task in done:
+                    index = tasks_by_task[task]
+                    results[index] = task.result()
+
+                context.validation_results = list(results)
+                votes_so_far = [
+                    result.vote.value
+                    for result in results
+                    if result is not None and result.vote is not None
+                ]
+                if _is_quorum_reached(votes_so_far, len(slot_validators)):
+                    await _cancel_pending_validator_tasks(pending)
+                    for task in pending:
+                        index = tasks_by_task[task]
+                        results[index] = _build_synthetic_idle_receipt(
+                            slot_validators[index]
+                        )
+                    context.validation_results = list(results)
+                    return True
+
+            return False
+
+        slot_validators = list(validators_to_run)
+        results: list[Receipt | None] = [None] * len(slot_validators)
+        replacement_cycles = 0
+
+        while True:
+            indexes_to_run = [
+                index for index, result in enumerate(results) if result is None
+            ]
+            quorum_reached = await _run_validator_wave(
+                results, slot_validators, indexes_to_run
+            )
+            if quorum_reached:
+                break
+
+            timeout_indexes = [
+                index
+                for index, result in enumerate(results)
+                if result is not None and result.vote == Vote.TIMEOUT
+            ]
+            if not timeout_indexes or replacement_cycles >= MAX_IDLE_REPLACEMENTS:
+                break
+
+            replacement_indexes: list[int] = []
+            for index in timeout_indexes:
+                replacement = await pop_replacement()
+                if replacement is None:
+                    continue
+                slot_validators[index] = replacement
+                results[index] = None
+                replacement_indexes.append(index)
+
+            if not replacement_indexes:
+                break
+            replacement_cycles += 1
+
+        context.validation_results = [
+            result for result in results if result is not None
         ]
-        context.validation_results = await asyncio.gather(*validation_tasks)
 
         # If all validators voted IDLE, infrastructure is systemically broken
         if all(r.vote == Vote.IDLE for r in context.validation_results):
@@ -2030,10 +2235,7 @@ class CommittingState(TransactionState):
         )
 
         # Post-execution effects (vote committed events + timestamp)
-        if validation_by_leader:
-            validators_to_emit = [context.leader] + context.remaining_validators
-        else:
-            validators_to_emit = list(context.remaining_validators)
+        validators_to_emit = slot_validators
 
         post_effects = decide_post_committing(
             tx_hash=context.transaction.hash,

--- a/backend/consensus/base.py
+++ b/backend/consensus/base.py
@@ -690,7 +690,13 @@ class ConsensusAlgorithm:
 
             # Check if the sender has enough balance
             if from_balance < transaction.value:
-                # Set the transaction status to UNDETERMINED if balance is insufficient
+                # UNDETERMINED is finalization-eligible: claim_next_finalization
+                # filters on timestamp_awaiting_finalization IS NOT NULL.
+                # Without this stamp the row strands forever (16 such rows
+                # accumulated on Studio Prod over 19 days before this fix).
+                transactions_processor.set_transaction_timestamp_awaiting_finalization(
+                    transaction.hash
+                )
                 await ConsensusAlgorithm.dispatch_transaction_status_update(
                     transactions_processor,
                     transaction.hash,

--- a/backend/node/genvm/base.py
+++ b/backend/node/genvm/base.py
@@ -421,7 +421,9 @@ class Host(genvmhost.IHost):
         self, type: StorageType, account: bytes, slot: bytes, index: int, le: int, /
     ) -> bytes:
         assert type != StorageType.LATEST_FINAL
-        return self._state_proxy.storage_read(Address(account), slot, index, le)
+        return await asyncio.to_thread(
+            self._state_proxy.storage_read, Address(account), slot, index, le
+        )
 
     async def consume_gas(self, gas: int, /) -> None:
         pass
@@ -431,7 +433,7 @@ class Host(genvmhost.IHost):
         assert False
 
     async def get_balance(self, account: bytes, /) -> int:
-        return self._state_proxy.get_balance(Address(account))
+        return await asyncio.to_thread(self._state_proxy.get_balance, Address(account))
 
     async def notify_nondet_disagreement(self, call_no: int, /) -> None:
         self._nondet_disagreement = call_no

--- a/backend/node/genvm/origin/base_host.py
+++ b/backend/node/genvm/origin/base_host.py
@@ -640,9 +640,34 @@ async def run_genvm(
 
     # IMPORTANT: if proc setup fails (e.g., manager accepts TCP but never replies),
     # don't wait forever on host_loop.
-    done, pending = await asyncio.wait(
-        [fut_host, fut_proc, fut_prob], return_when=asyncio.FIRST_EXCEPTION
-    )
+    try:
+        done, pending = await asyncio.wait(
+            [fut_host, fut_proc, fut_prob], return_when=asyncio.FIRST_EXCEPTION
+        )
+    except BaseException:
+        cancellation_event.set()
+        tasks = [fut_host, fut_proc, fut_prob]
+        for task in tasks:
+            if not task.done():
+                task.cancel()
+        for task in tasks:
+            try:
+                await task
+            except BaseException:
+                pass
+
+        timeout_task = timeout_task_cell[0]
+        if timeout_task is not None and not timeout_task.done():
+            timeout_task.cancel()
+            try:
+                await timeout_task
+            except BaseException:
+                pass
+
+        genvm_id = genvm_id_cell[0]
+        if genvm_id is not None:
+            await _send_timeout(manager_uri, genvm_id, ctx=ctx)
+        raise
 
     # Log which tasks completed/failed for debugging
     done_names = [task_names.get(id(t), "unknown") for t in done]

--- a/backend/protocol_rpc/health.py
+++ b/backend/protocol_rpc/health.py
@@ -256,6 +256,9 @@ async def _run_health_checks() -> None:
             "orphaned_transactions": consensus_health.get(
                 "total_orphaned_transactions", 0
             ),
+            "stuck_finalization_count": consensus_health.get(
+                "stuck_finalization_count", 0
+            ),
             "active_workers": consensus_health.get("active_workers", 0),
             "status": consensus_status,
         }
@@ -263,10 +266,15 @@ async def _run_health_checks() -> None:
             if overall_status == "healthy":
                 overall_status = "degraded"
             issues.append("consensus_issue")
-        elif consensus_health.get("total_orphaned_transactions", 0) >= 3:
-            if overall_status == "healthy":
-                overall_status = "degraded"
-            issues.append("orphaned_transactions")
+        else:
+            if consensus_health.get("total_orphaned_transactions", 0) >= 3:
+                if overall_status == "healthy":
+                    overall_status = "degraded"
+                issues.append("orphaned_transactions")
+            if consensus_health.get("stuck_finalization_count", 0) >= 3:
+                if overall_status == "healthy":
+                    overall_status = "degraded"
+                issues.append("stuck_finalizations")
 
         # 3. LLM provider health (per-provider failure-rate detection)
         # Catches cases like a provider returning HTTP 402 / "tier required"
@@ -548,13 +556,31 @@ async def _check_consensus_health() -> Dict[str, Any]:
     # Match the dashboard alert threshold so consensus.status and the
     # top-level "issues" tag agree on what counts as degraded.
     DEGRADED_AT_STUCK_HEADS = int(os.environ.get("HEALTH_DEGRADED_AT_STUCK_HEADS", "3"))
+    # Finalization-stall threshold: ACCEPTED/UNDETERMINED/*_TIMEOUT txs
+    # that haven't reached FINALIZED within this many seconds count as
+    # stuck. Default 600s (10 min) — finalization is supposed to be
+    # quick after the finality window opens.
+    STUCK_FINALIZATION_AFTER_SECONDS = int(
+        os.environ.get("HEALTH_STUCK_FINALIZATION_AFTER_SECONDS", "600")
+    )
+    DEGRADED_AT_STUCK_FINALIZATIONS = int(
+        os.environ.get("HEALTH_DEGRADED_AT_STUCK_FINALIZATIONS", "3")
+    )
 
-    # Statuses considered "in flight". Includes the *_TIMEOUT variants
-    # because finalization and appeal claim paths process them. Must
-    # match the head-CTE filter and the in-flight-count query for
-    # consistency.
-    IN_FLIGHT_STATUSES_SQL = (
+    # Statuses where the consensus state machine is actively working.
+    # The "head of queue stuck" check uses ONLY these: ACCEPTED-class
+    # statuses are post-consensus and live under the separate
+    # finalization-stall detector below.
+    CONSENSUS_ACTIVE_STATUSES_SQL = "'ACTIVATED','PROPOSING','COMMITTING','REVEALING'"
+    # Broader set including finalization-pending statuses. Used only
+    # in the "is any worker actively claiming on this contract" NOT
+    # EXISTS clause — a finalization worker counts as active work and
+    # should mask a stuck consensus head.
+    ANY_INFLIGHT_STATUSES_SQL = (
         "'ACTIVATED','PROPOSING','COMMITTING','REVEALING',"
+        "'ACCEPTED','UNDETERMINED','LEADER_TIMEOUT','VALIDATORS_TIMEOUT'"
+    )
+    FINALIZATION_ELIGIBLE_STATUSES_SQL = (
         "'ACCEPTED','UNDETERMINED','LEADER_TIMEOUT','VALIDATORS_TIMEOUT'"
     )
 
@@ -586,13 +612,18 @@ async def _check_consensus_health() -> Dict[str, Any]:
                 ).fetchone()
                 active_workers_count = active_workers_row.n if active_workers_row else 0
 
-                # Stuck heads: per contract, the oldest in-flight tx
-                # whose contract has no unexpired worker claim AND head
-                # is old enough to expect progress. Returns the count
-                # of AFFECTED CONTRACTS, not the count of queued txs
-                # behind them — those are not the problem, the head is.
-                # Tie-break on hash so debug output (when we surface
-                # the heads) is deterministic.
+                # Stuck heads: per contract, the oldest consensus-active
+                # tx whose contract has no unexpired worker claim AND
+                # head is old enough to expect progress. Head CTE uses
+                # only the consensus-active set — ACCEPTED-class rows
+                # are post-consensus and would otherwise pollute the
+                # signal (one stranded UNDETERMINED on an unused
+                # contract is not a stuck head). The NOT EXISTS clause
+                # uses the broader set so a finalization worker
+                # currently processing on the same contract correctly
+                # masks the alarm.
+                # Returns the count of AFFECTED CONTRACTS, not the
+                # count of queued txs behind them.
                 stuck_row = conn.execute(
                     text(
                         f"""
@@ -603,7 +634,7 @@ async def _check_consensus_health() -> Dict[str, Any]:
                                 status,
                                 created_at
                             FROM transactions
-                            WHERE status IN ({IN_FLIGHT_STATUSES_SQL})
+                            WHERE status IN ({CONSENSUS_ACTIVE_STATUSES_SQL})
                               AND to_address IS NOT NULL
                             ORDER BY to_address, created_at ASC, hash ASC
                         )
@@ -614,7 +645,7 @@ async def _check_consensus_health() -> Dict[str, Any]:
                               SELECT 1
                               FROM transactions t2
                               WHERE t2.to_address = h.to_address
-                                AND t2.status IN ({IN_FLIGHT_STATUSES_SQL})
+                                AND t2.status IN ({ANY_INFLIGHT_STATUSES_SQL})
                                 AND t2.blocked_at IS NOT NULL
                                 AND t2.blocked_at > NOW() - make_interval(mins => :claim_window)
                           )
@@ -627,15 +658,47 @@ async def _check_consensus_health() -> Dict[str, Any]:
                 ).fetchone()
                 stuck_head_contracts = stuck_row.stuck_heads if stuck_row else 0
 
+                # Stuck finalizations: ACCEPTED-class txs waiting too
+                # long to reach FINALIZED. Two paths:
+                #   1. timestamp_awaiting_finalization set and stale
+                #      (normal "finalizer not running" case)
+                #   2. timestamp_awaiting_finalization NULL and the row
+                #      is old (catches future bugs like the May 2026
+                #      insufficient-balance SEND path, where a tx
+                #      reached UNDETERMINED without ever stamping the
+                #      timestamp — invisible to claim_next_finalization
+                #      forever)
+                stuck_fin_row = conn.execute(
+                    text(
+                        f"""
+                        SELECT COUNT(*) AS n
+                        FROM transactions
+                        WHERE status IN ({FINALIZATION_ELIGIBLE_STATUSES_SQL})
+                          AND (
+                              (timestamp_awaiting_finalization IS NOT NULL
+                               AND EXTRACT(EPOCH FROM NOW())::bigint
+                                   - timestamp_awaiting_finalization
+                                   > :stuck_seconds)
+                              OR
+                              (timestamp_awaiting_finalization IS NULL
+                               AND created_at
+                                   < NOW() - make_interval(secs => :stuck_seconds))
+                          )
+                        """
+                    ),
+                    {"stuck_seconds": STUCK_FINALIZATION_AFTER_SECONDS},
+                ).fetchone()
+                stuck_finalization_count = stuck_fin_row.n if stuck_fin_row else 0
+
                 # Total in-flight (non-final) tx count, for context.
-                # Same status set as the head CTE so the metrics are
-                # consistent.
+                # Consensus-active only — finalization-pending rows
+                # are tracked separately via stuck_finalization_count.
                 processing_row = conn.execute(
                     text(
                         f"""
                         SELECT COUNT(*) AS n
                         FROM transactions
-                        WHERE status IN ({IN_FLIGHT_STATUSES_SQL})
+                        WHERE status IN ({CONSENSUS_ACTIVE_STATUSES_SQL})
                           AND to_address IS NOT NULL
                         """
                     )
@@ -643,19 +706,22 @@ async def _check_consensus_health() -> Dict[str, Any]:
                 total_processing = processing_row.n if processing_row else 0
 
                 status = (
-                    "healthy"
-                    if stuck_head_contracts < DEGRADED_AT_STUCK_HEADS
-                    else "degraded"
+                    "degraded"
+                    if (
+                        stuck_head_contracts >= DEGRADED_AT_STUCK_HEADS
+                        or stuck_finalization_count >= DEGRADED_AT_STUCK_FINALIZATIONS
+                    )
+                    else "healthy"
                 )
 
                 return {
                     "status": status,
                     "total_processing_transactions": total_processing,
                     # Field name preserved for backwards-compat with the
-                    # external dashboard. Semantics changed: now counts
-                    # CONTRACTS whose head-of-queue is stuck, not raw
-                    # blocked txs. A long queue with a moving head reads 0.
+                    # external dashboard. Semantics: count of CONTRACTS
+                    # whose consensus head is stuck.
                     "total_orphaned_transactions": stuck_head_contracts,
+                    "stuck_finalization_count": stuck_finalization_count,
                     "active_workers": active_workers_count,
                 }
 

--- a/tests/db-sqlalchemy/test_execute_transfer_undetermined_finalization.py
+++ b/tests/db-sqlalchemy/test_execute_transfer_undetermined_finalization.py
@@ -1,0 +1,148 @@
+"""Regression test for `execute_transfer` insufficient-balance stranding.
+
+Bug history (May 2026): native SEND transactions with insufficient sender
+balance were dispatched to UNDETERMINED via `dispatch_transaction_status_update`
+without setting `timestamp_awaiting_finalization`. `claim_next_finalization`
+filters on that field being non-NULL, so the rows sat forever — 16 such rows
+accumulated on Studio Prod over 19 days. This test pins the fix in
+`backend/consensus/base.py::execute_transfer` so the timestamp is always set
+before the status flips.
+"""
+
+import pytest
+from sqlalchemy import text
+from sqlalchemy.orm import Session
+from unittest.mock import AsyncMock
+
+from backend.consensus.base import ConsensusAlgorithm
+from backend.database_handler.accounts_manager import AccountsManager
+from backend.database_handler.transactions_processor import (
+    TransactionsProcessor,
+    TransactionStatus,
+)
+from backend.domain.types import Transaction, TransactionType, TransactionExecutionMode
+
+
+SENDER = "0x" + "ab" * 20
+RECIPIENT = "0x" + "cd" * 20
+
+
+def _insert_send_tx(tp: TransactionsProcessor, *, value: int) -> str:
+    tx_hash = tp.insert_transaction(
+        from_address=SENDER,
+        to_address=RECIPIENT,
+        data={},
+        value=value,
+        type=TransactionType.SEND.value,
+        nonce=0,
+        leader_only=True,
+        config_rotation_rounds=0,
+        triggered_by_hash=None,
+        transaction_hash=("0x" + "ee" * 32),
+    )
+    tp.session.commit()
+    return tx_hash
+
+
+@pytest.mark.asyncio
+async def test_insufficient_balance_send_sets_timestamp_awaiting_finalization(
+    session: Session,
+):
+    """Insufficient-balance SEND must stamp timestamp_awaiting_finalization
+    so claim_next_finalization can pick the row up. Without the stamp the
+    row is invisible to the finalization claim query forever."""
+    tp = TransactionsProcessor(session)
+    am = AccountsManager(session)
+
+    # Sender balance = 0, tx asks for 1000 → triggers the insufficient-balance
+    # branch in execute_transfer.
+    am.update_account_balance(SENDER, 0)
+    session.commit()
+
+    tx_hash = _insert_send_tx(tp, value=1000)
+
+    tx = Transaction(
+        hash=tx_hash,
+        status=TransactionStatus.PENDING,
+        type=TransactionType.SEND,
+        from_address=SENDER,
+        to_address=RECIPIENT,
+        value=1000,
+        nonce=0,
+        leader_only=True,
+        execution_mode=TransactionExecutionMode.NORMAL,
+    )
+
+    msg_handler = AsyncMock()
+
+    await ConsensusAlgorithm.execute_transfer(
+        transaction=tx,
+        transactions_processor=tp,
+        accounts_manager=am,
+        msg_handler=msg_handler,
+    )
+    session.commit()
+
+    # Read the row directly to bypass any caching in TransactionsProcessor.
+    row = session.execute(
+        text(
+            "SELECT status, timestamp_awaiting_finalization FROM transactions WHERE hash = :h"
+        ),
+        {"h": tx_hash},
+    ).one()
+
+    assert row.status == "UNDETERMINED", (
+        f"expected UNDETERMINED, got {row.status} — insufficient-balance "
+        "SEND should short-circuit to UNDETERMINED"
+    )
+    assert row.timestamp_awaiting_finalization is not None, (
+        "timestamp_awaiting_finalization must be set on the insufficient-"
+        "balance UNDETERMINED path, otherwise claim_next_finalization (which "
+        "filters on this column being non-NULL) skips the row forever. "
+        "Regression: see Studio Prod stranded-UNDETERMINED rows, May 2026."
+    )
+    assert row.timestamp_awaiting_finalization > 0
+
+
+@pytest.mark.asyncio
+async def test_sufficient_balance_send_finalizes_without_undetermined(
+    session: Session,
+):
+    """Control: when the sender has enough balance, execute_transfer should
+    take the success path and dispatch FINALIZED, not UNDETERMINED. Guards
+    against accidental over-broadening of the insufficient-balance branch."""
+    tp = TransactionsProcessor(session)
+    am = AccountsManager(session)
+
+    am.update_account_balance(SENDER, 5000)
+    session.commit()
+
+    tx_hash = _insert_send_tx(tp, value=1000)
+
+    tx = Transaction(
+        hash=tx_hash,
+        status=TransactionStatus.PENDING,
+        type=TransactionType.SEND,
+        from_address=SENDER,
+        to_address=RECIPIENT,
+        value=1000,
+        nonce=0,
+        leader_only=True,
+        execution_mode=TransactionExecutionMode.NORMAL,
+    )
+
+    msg_handler = AsyncMock()
+
+    await ConsensusAlgorithm.execute_transfer(
+        transaction=tx,
+        transactions_processor=tp,
+        accounts_manager=am,
+        msg_handler=msg_handler,
+    )
+    session.commit()
+
+    row = session.execute(
+        text("SELECT status FROM transactions WHERE hash = :h"),
+        {"h": tx_hash},
+    ).one()
+    assert row.status == "FINALIZED"

--- a/tests/db-sqlalchemy/test_genvm_host_async_callbacks.py
+++ b/tests/db-sqlalchemy/test_genvm_host_async_callbacks.py
@@ -1,0 +1,44 @@
+import asyncio
+import time
+
+import pytest
+
+from backend.node.genvm.base import Host
+from backend.node.genvm.origin.public_abi import StorageType
+
+
+class _SlowStateProxy:
+    def storage_read(self, *_args):
+        time.sleep(0.1)
+        return b"x"
+
+    def get_balance(self, *_args):
+        time.sleep(0.1)
+        return 0
+
+
+@pytest.mark.asyncio
+async def test_storage_read_runs_off_event_loop():
+    host = Host(
+        None,
+        calldata_bytes=b"",
+        state_proxy=_SlowStateProxy(),
+        leader_results=None,
+    )
+
+    storage_task = asyncio.create_task(
+        host.storage_read(
+            StorageType.DEFAULT,
+            b"\x01" * 20,
+            b"\x02" * 32,
+            0,
+            1,
+        )
+    )
+
+    start = asyncio.get_running_loop().time()
+    await asyncio.sleep(0.01)
+    elapsed = asyncio.get_running_loop().time() - start
+
+    assert elapsed < 0.05
+    assert await storage_task == b"x"

--- a/tests/db-sqlalchemy/test_health_orphan_detection.py
+++ b/tests/db-sqlalchemy/test_health_orphan_detection.py
@@ -69,6 +69,7 @@ def _insert_tx(
     created_at: datetime,
     blocked_at: datetime | None = None,
     worker_id: str | None = None,
+    timestamp_awaiting_finalization: int | None = None,
 ):
     """Direct INSERT — bypass the processor so we can backdate created_at."""
     session.execute(
@@ -80,13 +81,15 @@ def _insert_tx(
                 appeal_undetermined, appeal_leader_timeout,
                 appeal_validators_timeout, appeal_processing_time,
                 recovery_count, value_credited,
-                created_at, blocked_at, worker_id
+                created_at, blocked_at, worker_id,
+                timestamp_awaiting_finalization
             ) VALUES (
                 :hash, CAST(:status AS transaction_status),
                 '0xfromaddress', :to_addr, CAST('{}' AS jsonb), 0, 2,
                 :nonce, false, 'NORMAL', false, 0,
                 false, false, false, 0, 0, false,
-                :created_at, :blocked_at, :worker_id
+                :created_at, :blocked_at, :worker_id,
+                :timestamp_awaiting_finalization
             )
             """
         ),
@@ -98,6 +101,7 @@ def _insert_tx(
             "created_at": created_at,
             "blocked_at": blocked_at,
             "worker_id": worker_id,
+            "timestamp_awaiting_finalization": timestamp_awaiting_finalization,
         },
     )
 
@@ -163,7 +167,7 @@ async def test_stuck_head_no_active_work_is_orphaned(engine: Engine):
             s,
             tx_hash="0x" + "01" * 32,
             to_address=contract,
-            status="ACCEPTED",
+            status="COMMITTING",
             nonce=0,
             created_at=now - timedelta(minutes=30),
         )
@@ -279,7 +283,7 @@ async def test_multiple_contracts_only_stuck_heads_count(engine: Engine):
             s,
             tx_hash="0x" + "0b" * 32,
             to_address="0x" + "bb" * 20,
-            status="ACCEPTED",
+            status="COMMITTING",
             nonce=0,
             created_at=now - timedelta(minutes=30),
         )
@@ -375,15 +379,21 @@ async def test_expired_claim_counts_contract_as_stuck(engine: Engine):
 
 
 @pytest.mark.asyncio
-async def test_timeout_status_head_is_treated_as_in_flight(engine: Engine):
-    """LEADER_TIMEOUT and VALIDATORS_TIMEOUT are processed by the
-    finalization/appeal claim paths — they're in-flight statuses, so
-    a stale head in those states should still trigger detection."""
+async def test_post_consensus_statuses_excluded_from_stuck_head_count(engine: Engine):
+    """ACCEPTED / UNDETERMINED / *_TIMEOUT are post-consensus statuses,
+    awaiting finalization rather than blocked on consensus progress.
+    They MUST NOT count as stuck consensus heads — that's the false-
+    positive class that mis-fired the production alert in May 2026
+    (15 stranded UNDETERMINED rows on unused contracts looked like
+    stuck heads, but they had zero queue behind them). The dedicated
+    stuck-finalization detector covers these instead."""
     Session_ = sessionmaker(bind=engine, expire_on_commit=False)
     now = datetime.now(timezone.utc)
 
     with Session_() as s:
-        for i, st in enumerate(["LEADER_TIMEOUT", "VALIDATORS_TIMEOUT"]):
+        for i, st in enumerate(
+            ["ACCEPTED", "UNDETERMINED", "LEADER_TIMEOUT", "VALIDATORS_TIMEOUT"]
+        ):
             _insert_tx(
                 s,
                 tx_hash=f"0x{i:064x}",
@@ -398,9 +408,9 @@ async def test_timeout_status_head_is_treated_as_in_flight(engine: Engine):
 
     result = await health_module._check_consensus_health()
 
-    assert result["total_orphaned_transactions"] == 2, (
-        "*_TIMEOUT statuses must be in-flight per the head CTE so the "
-        "metric agrees with the worker claim paths that process them."
+    assert result["total_orphaned_transactions"] == 0, (
+        "Post-consensus statuses must not pollute the stuck-head signal. "
+        f"Got: {result}"
     )
 
 
@@ -419,7 +429,7 @@ async def test_status_threshold_matches_dashboard_alert_gate(engine: Engine):
                 s,
                 tx_hash=f"0x{i:064x}",
                 to_address=f"0x{(0x70 + i):02x}" + "00" * 19,
-                status="ACCEPTED",
+                status="COMMITTING",
                 nonce=0,
                 created_at=now - timedelta(minutes=30),
             )
@@ -433,3 +443,147 @@ async def test_status_threshold_matches_dashboard_alert_gate(engine: Engine):
     assert (
         result["status"] == "degraded"
     ), f"3 stuck contracts must flip status to degraded. Got: {result}"
+
+
+# ── Stuck-finalization detector ───────────────────────────────────
+#
+# Separate from the stuck-consensus-head detector. Post-consensus txs
+# (ACCEPTED / UNDETERMINED / *_TIMEOUT) carry agreed consensus_data and
+# only need finalization. They live under this metric. The detector
+# has two arms:
+#
+#   1. timestamp_awaiting_finalization set + stale → finalizer not
+#      making progress on these rows (e.g., finalization scheduler
+#      starvation, finalization claim path broken).
+#   2. timestamp_awaiting_finalization NULL + row is old → defensive:
+#      catches future bugs like the May 2026 insufficient-balance SEND
+#      path, which reached UNDETERMINED without ever stamping the
+#      timestamp and was invisible to claim_next_finalization forever.
+
+
+@pytest.mark.asyncio
+async def test_stuck_finalization_with_stale_timestamp_is_flagged(engine: Engine):
+    """timestamp_awaiting_finalization is set but older than the
+    threshold — classic "finalizer not running" case."""
+    import time
+
+    Session_ = sessionmaker(bind=engine, expire_on_commit=False)
+    now = datetime.now(timezone.utc)
+    stale_ts = int(time.time()) - 24 * 3600  # 1 day ago
+
+    with Session_() as s:
+        _insert_tx(
+            s,
+            tx_hash="0x" + "f1" * 32,
+            to_address="0x" + "f1" * 20,
+            status="ACCEPTED",
+            nonce=0,
+            created_at=now - timedelta(days=1),
+            timestamp_awaiting_finalization=stale_ts,
+        )
+        s.commit()
+
+    from backend.protocol_rpc import health as health_module
+
+    result = await health_module._check_consensus_health()
+
+    assert (
+        result["stuck_finalization_count"] == 1
+    ), f"Stale timestamp_awaiting_finalization must be flagged. Got: {result}"
+
+
+@pytest.mark.asyncio
+async def test_stuck_finalization_with_null_timestamp_is_flagged(engine: Engine):
+    """timestamp_awaiting_finalization is NULL but the row is old —
+    defensive coverage for the May 2026 insufficient-balance SEND bug
+    pattern (post-consensus row without an awaiting timestamp, invisible
+    to claim_next_finalization)."""
+    Session_ = sessionmaker(bind=engine, expire_on_commit=False)
+    now = datetime.now(timezone.utc)
+
+    with Session_() as s:
+        _insert_tx(
+            s,
+            tx_hash="0x" + "f2" * 32,
+            to_address="0x" + "f2" * 20,
+            status="UNDETERMINED",
+            nonce=0,
+            created_at=now - timedelta(hours=2),
+            timestamp_awaiting_finalization=None,
+        )
+        s.commit()
+
+    from backend.protocol_rpc import health as health_module
+
+    result = await health_module._check_consensus_health()
+
+    assert result["stuck_finalization_count"] == 1, (
+        "NULL timestamp + old row must be flagged so a regression of the "
+        f"insufficient-balance SEND bug is caught. Got: {result}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_recent_finalization_eligible_row_is_not_flagged(engine: Engine):
+    """Row younger than the stuck-finalization threshold must not be
+    flagged — the finalization window is still open."""
+    import time
+
+    Session_ = sessionmaker(bind=engine, expire_on_commit=False)
+    now = datetime.now(timezone.utc)
+
+    with Session_() as s:
+        _insert_tx(
+            s,
+            tx_hash="0x" + "f3" * 32,
+            to_address="0x" + "f3" * 20,
+            status="ACCEPTED",
+            nonce=0,
+            created_at=now - timedelta(seconds=30),
+            # set to "now" — finality window not exceeded yet
+            timestamp_awaiting_finalization=int(time.time()),
+        )
+        s.commit()
+
+    from backend.protocol_rpc import health as health_module
+
+    result = await health_module._check_consensus_health()
+
+    assert (
+        result["stuck_finalization_count"] == 0
+    ), f"Fresh finalization-eligible row must not be flagged. Got: {result}"
+
+
+@pytest.mark.asyncio
+async def test_stuck_finalization_flips_status_at_threshold(engine: Engine):
+    """consensus.status flips to degraded when stuck_finalization_count
+    reaches HEALTH_DEGRADED_AT_STUCK_FINALIZATIONS (default 3) —
+    independent of stuck-head count, so finalization stalls get their
+    own clear signal."""
+    import time
+
+    Session_ = sessionmaker(bind=engine, expire_on_commit=False)
+    now = datetime.now(timezone.utc)
+    stale_ts = int(time.time()) - 12 * 3600
+
+    with Session_() as s:
+        for i in range(3):
+            _insert_tx(
+                s,
+                tx_hash=f"0xf4{i:062x}",
+                to_address=f"0x{(0xF4 + i):02x}" + "00" * 19,
+                status="UNDETERMINED",
+                nonce=0,
+                created_at=now - timedelta(hours=12),
+                timestamp_awaiting_finalization=stale_ts,
+            )
+        s.commit()
+
+    from backend.protocol_rpc import health as health_module
+
+    result = await health_module._check_consensus_health()
+
+    assert result["stuck_finalization_count"] == 3
+    assert (
+        result["status"] == "degraded"
+    ), f"3 stuck finalizations must flip consensus.status. Got: {result}"

--- a/tests/unit/consensus/test_validator_exec_timeout.py
+++ b/tests/unit/consensus/test_validator_exec_timeout.py
@@ -6,6 +6,7 @@ import pytest
 
 from backend.consensus.base import CommittingState
 from backend.database_handler.types import ConsensusData
+from backend.node.genvm.error_codes import GenVMInternalError, GenVMErrorCode
 from backend.node.genvm.origin.public_abi import ResultCode
 from backend.node.types import ExecutionMode, ExecutionResultStatus, Receipt, Vote
 
@@ -37,7 +38,8 @@ def _snapshot_node(address: str) -> SimpleNamespace:
 
 @pytest.mark.asyncio
 async def test_committing_times_out_hung_validator_without_blocking(monkeypatch):
-    monkeypatch.setenv("CONSENSUS_VALIDATOR_EXEC_TIMEOUT_SECONDS", "0.01")
+    """Outer slot timeout now produces a terminal TIMEOUT vote, not fatal IDLE."""
+    monkeypatch.setenv("CONSENSUS_VALIDATOR_EXEC_TIMEOUT_SECONDS", "0.05")
 
     transaction = SimpleNamespace(hash="tx-hash")
 
@@ -105,13 +107,15 @@ async def test_committing_times_out_hung_validator_without_blocking(monkeypatch)
     elapsed = asyncio.get_running_loop().time() - start
 
     assert next_state.__class__.__name__ == "RevealingState"
-    assert elapsed < 0.15
+    assert elapsed <= 0.7
 
     votes = [r.vote for r in context.validation_results]
-    assert votes.count(Vote.IDLE) == 1
+    assert votes.count(Vote.TIMEOUT) == 1
     assert votes.count(Vote.AGREE) == 1
 
-    timeout_receipt = next(r for r in context.validation_results if r.vote == Vote.IDLE)
+    timeout_receipt = next(
+        r for r in context.validation_results if r.vote == Vote.TIMEOUT
+    )
     assert timeout_receipt.genvm_result is not None
     assert (
         timeout_receipt.genvm_result["error_code"] == "CONSENSUS_VALIDATOR_EXEC_TIMEOUT"
@@ -119,6 +123,7 @@ async def test_committing_times_out_hung_validator_without_blocking(monkeypatch)
     assert timeout_receipt.genvm_result["raw_error"]["causes"] == [
         "VALIDATOR_EXEC_TIMEOUT"
     ]
+    assert timeout_receipt.genvm_result["raw_error"]["fatal"] is False
 
     timeout_timestamps = [
         call.args[1]
@@ -126,3 +131,209 @@ async def test_committing_times_out_hung_validator_without_blocking(monkeypatch)
         if "_TIMEOUT" in call.args[1]
     ]
     assert timeout_timestamps
+
+
+def _make_context(
+    *,
+    validators: list[str],
+    node_factory,
+    snapshot_addresses: list[str] | None = None,
+) -> SimpleNamespace:
+    tx_processor = MagicMock()
+    tx_processor.add_state_timestamp = MagicMock()
+    tx_processor.update_transaction_status = MagicMock()
+    tx_processor.set_transaction_timestamp_last_vote = MagicMock()
+
+    return SimpleNamespace(
+        transaction=SimpleNamespace(hash="tx-hash"),
+        transactions_processor=tx_processor,
+        msg_handler=_MessageHandler(),
+        consensus_service=MagicMock(),
+        contract_processor=MagicMock(),
+        node_factory=node_factory,
+        contract_snapshot=MagicMock(),
+        contract_snapshot_factory=MagicMock(),
+        validators_snapshot=SimpleNamespace(
+            nodes=[
+                _snapshot_node(address)
+                for address in (snapshot_addresses or ["leader", *validators])
+            ]
+        ),
+        genvm_manager=MagicMock(),
+        shared_decoded_value_cache={},
+        shared_contract_snapshot_cache={},
+        leader={"address": "leader"},
+        remaining_validators=[{"address": address} for address in validators],
+        consensus_data=ConsensusData(votes={}, leader_receipt=None, validators=[]),
+        validation_results=[],
+    )
+
+
+@pytest.mark.asyncio
+async def test_outer_timeout_does_not_trigger_replacement(monkeypatch):
+    """Replacement is no longer driven by the outer timeout receipt's fatal flag."""
+    monkeypatch.setenv("CONSENSUS_VALIDATOR_EXEC_TIMEOUT_SECONDS", "0.02")
+    calls: list[str] = []
+
+    async def exec_hung(_transaction):
+        await asyncio.sleep(0.2)
+        return _make_receipt("validator-1", Vote.AGREE)
+
+    async def exec_replacement(_transaction):
+        return _make_receipt("replacement", Vote.AGREE)
+
+    def node_factory(validator, *_args):
+        calls.append(validator["address"])
+        if validator["address"] == "validator-1":
+            return SimpleNamespace(exec_transaction=exec_hung)
+        return SimpleNamespace(exec_transaction=exec_replacement)
+
+    context = _make_context(
+        validators=["validator-1"],
+        snapshot_addresses=["leader", "validator-1", "replacement"],
+        node_factory=node_factory,
+    )
+
+    await CommittingState().handle(context)
+
+    assert "replacement" not in calls
+    timeout_receipt = next(
+        r
+        for r in context.validation_results
+        if r.node_config["address"] == "validator-1"
+    )
+    assert timeout_receipt.vote == Vote.TIMEOUT
+    assert timeout_receipt.genvm_result["raw_error"]["fatal"] is False
+
+
+@pytest.mark.asyncio
+async def test_fatal_internal_error_still_replaces_within_slot(monkeypatch):
+    """Fatal GenVM internal errors still use replacement validators within budget."""
+    monkeypatch.setenv("CONSENSUS_VALIDATOR_EXEC_TIMEOUT_SECONDS", "1")
+    calls: list[str] = []
+
+    async def exec_validator(_transaction):
+        raise GenVMInternalError(
+            message="fatal",
+            error_code=GenVMErrorCode.LLM_NO_PROVIDER,
+            causes=["NO_PROVIDER_FOR_PROMPT"],
+            is_fatal=True,
+        )
+
+    async def exec_replacement(_transaction):
+        return _make_receipt("replacement", Vote.AGREE)
+
+    def node_factory(validator, *_args):
+        calls.append(validator["address"])
+        if validator["address"] == "validator-1":
+            return SimpleNamespace(exec_transaction=exec_validator)
+        return SimpleNamespace(exec_transaction=exec_replacement)
+
+    context = _make_context(
+        validators=["validator-1"],
+        snapshot_addresses=["leader", "validator-1", "replacement"],
+        node_factory=node_factory,
+    )
+
+    await CommittingState().handle(context)
+
+    assert calls == ["validator-1", "replacement"]
+    assert context.validation_results[0].node_config["address"] == "replacement"
+    assert context.validation_results[0].vote == Vote.AGREE
+
+
+@pytest.mark.asyncio
+async def test_quorum_short_circuits_pending_validators(monkeypatch):
+    monkeypatch.setenv("CONSENSUS_VALIDATOR_EXEC_TIMEOUT_SECONDS", "1")
+
+    async def exec_fast(_transaction, address: str):
+        return _make_receipt(address, Vote.AGREE)
+
+    async def exec_slow(_transaction):
+        await asyncio.sleep(1)
+        return _make_receipt("slow", Vote.DISAGREE)
+
+    def node_factory(validator, *_args):
+        if validator["address"] in {"validator-4", "validator-5"}:
+            return SimpleNamespace(exec_transaction=exec_slow)
+        return SimpleNamespace(
+            exec_transaction=lambda transaction, address=validator[
+                "address"
+            ]: exec_fast(transaction, address)
+        )
+
+    context = _make_context(
+        validators=[
+            "validator-1",
+            "validator-2",
+            "validator-3",
+            "validator-4",
+            "validator-5",
+        ],
+        node_factory=node_factory,
+    )
+
+    start = asyncio.get_running_loop().time()
+    await CommittingState().handle(context)
+    elapsed = asyncio.get_running_loop().time() - start
+
+    assert elapsed < 0.2
+    assert len(context.validation_results) == 5
+    votes = [result.vote for result in context.validation_results]
+    assert votes.count(Vote.AGREE) == 3
+    assert votes.count(Vote.IDLE) == 2
+
+
+@pytest.mark.asyncio
+async def test_no_quorum_replaces_timeout_slots_only(monkeypatch):
+    monkeypatch.setenv("CONSENSUS_VALIDATOR_EXEC_TIMEOUT_SECONDS", "0.02")
+    calls: list[str] = []
+
+    async def exec_hung(_transaction):
+        await asyncio.sleep(0.2)
+        return _make_receipt("validator-1", Vote.AGREE)
+
+    async def exec_vote(address: str, vote: Vote):
+        return _make_receipt(address, vote)
+
+    async def exec_replacement(_transaction):
+        return _make_receipt("replacement", Vote.AGREE)
+
+    def node_factory(validator, *_args):
+        calls.append(validator["address"])
+        if validator["address"] == "validator-1":
+            return SimpleNamespace(exec_transaction=exec_hung)
+        if validator["address"] == "replacement":
+            return SimpleNamespace(exec_transaction=exec_replacement)
+        vote = Vote.AGREE if validator["address"] == "validator-4" else Vote.DISAGREE
+        return SimpleNamespace(
+            exec_transaction=lambda _transaction, address=validator["address"]: (
+                exec_vote(address, vote)
+            )
+        )
+
+    context = _make_context(
+        validators=["validator-1", "validator-2", "validator-3", "validator-4"],
+        snapshot_addresses=[
+            "leader",
+            "validator-1",
+            "validator-2",
+            "validator-3",
+            "validator-4",
+            "replacement",
+        ],
+        node_factory=node_factory,
+    )
+
+    await CommittingState().handle(context)
+
+    assert calls.count("validator-2") == 1
+    assert calls.count("validator-3") == 1
+    assert calls.count("validator-4") == 1
+    assert "replacement" in calls
+    assert [result.node_config["address"] for result in context.validation_results] == [
+        "replacement",
+        "validator-2",
+        "validator-3",
+        "validator-4",
+    ]


### PR DESCRIPTION
## Why

Two recent production incidents — a Studio Prod tx stuck in COMMITTING for 8 days and a Rally Prod tx for ~90 min — root-caused jointly with Codex. Three intertwined defects in the validator/leader execution path:

1. **Nested per-attempt timeouts.** `asyncio.wait(timeout=900s)` wrapped each retry inside `run_single_validator`. On timeout it produced a TIMEOUT receipt marked `fatal: true`, which triggered the idleness-replacement loop with a *fresh* 900s budget. `MAX_IDLE_REPLACEMENTS=5` → up to 6 attempts × 15 min = **90 min per slot worst case**.

2. **`asyncio.gather(*validation_tasks)` waited for ALL validators.** A single hung slot stalled the whole round even when the other four had already agreed. No early-completion on quorum.

3. **Synchronous Host callbacks blocked the event loop.** `Host.storage_read` and `Host.get_balance` are `async def` with zero awaits — they ran SQLAlchemy queries and base64-decoding on the event loop. While the loop is blocked, neither `wrap_timeout`'s `asyncio.sleep` nor the outer `asyncio.wait` timer can fire. This is the proximate cause of the 8-day Studio Prod stuck tx — timers paused, and recovery sweep was defeated by worker re-claim refreshing `blocked_at`.

(Separately, the upstream `reqwest::Client` in `genvm-modules` has no timeout configured for LLM HTTP calls — a hung provider can keep a connection silent-but-alive indefinitely. Feature request filed in `genvm`; orthogonal to this PR.)

## What

**A. Async Host callbacks.** `Host.storage_read` and `Host.get_balance` now run their synchronous SQLAlchemy/decode work via `asyncio.to_thread`, keeping the event loop responsive so the timeouts below can actually fire.

**B. Non-fatal outer-timeout receipts.** Slot budget expiry produces a `vote=TIMEOUT` receipt marked `fatal: false`. Internal GenVM crashes (`GenVMInternalError(is_fatal=True)`) keep their existing replacement behaviour. Outer expiry no longer triggers an implicit retry loop.

**C. Single wall-clock budget per slot.** `run_single_validator` now computes `slot_deadline` once and the inner loop uses `remaining = slot_deadline - loop.time()` on every attempt. Internal-error replacement still happens inside the slot, but each retry only gets the time remaining — no fresh 900s budgets. Defaults aligned at 600s (well above Rally Prod p99 of 6.5 min).

**D. Symmetric leader budget.** `ProposingState` now wraps leader execution in the same wall-clock pattern. On budget expiry, synthesizes a VM-error timeout receipt with `leader_receipt_timed_out=true` so the existing `decide_post_proposal` path correctly transitions to `LeaderTimeoutState` (rather than raising `GenVMInternalError`, which would trigger worker-level recovery — wrong semantics).

**E. Per-tx budget plumbing.** New `_slot_budget_seconds(transaction, role)` helper. Env-var fallback today (`CONSENSUS_LEADER_EXEC_TIMEOUT_SECONDS`, `CONSENSUS_VALIDATOR_EXEC_TIMEOUT_SECONDS`); the upcoming gas mechanism will plug per-tx `leader_seconds` / `validator_seconds` from `transaction.sim_config` without further refactor.

**F. Post-vote, quorum-driven replacement.** `asyncio.gather` replaced with a collector: tasks complete one at a time, after each completion we evaluate quorum using `determine_consensus_from_votes` against all worst-case-for-pending vote permutations. On quorum, pending tasks are cancelled and their slots filled with synthetic IDLE receipts (preserves `context.validation_results` length = N for appeal-correctness invariants in `merge_appeal_validators` and extra-appeal sizing). On no-quorum-with-timeouts, idleness-replacement runs *only* for the TIMEOUT slots — not all slots. Capped at `MAX_IDLE_REPLACEMENTS` replacement cycles.

**G. Cleanup on outer cancellation.** `base_host.run_genvm`'s main `asyncio.wait` now has a `try/except BaseException` that cancels host_loop/proc/prob tasks, cancels `wrap_timeout`, and sends a best-effort DELETE on outer cancellation. Previously, when the outer validator's `task.cancel()` propagated here, the cleanup block was skipped (no `try/finally`).

## Test

- `tests/unit/consensus/test_validator_exec_timeout.py`: existing test updated for nonfatal TIMEOUT semantics; four new tests:
  - `test_outer_timeout_does_not_trigger_replacement`
  - `test_fatal_internal_error_still_replaces_within_slot`
  - `test_quorum_short_circuits_pending_validators`
  - `test_no_quorum_replaces_timeout_slots_only`
- `tests/db-sqlalchemy/test_genvm_host_async_callbacks.py` (new): regression asserting `Host.storage_read` runs off the event loop — a concurrent `asyncio.sleep(0.01)` must fire within 50ms even while a `time.sleep(0.1)` storage_read is in flight. Would fail today; passes under the new code.

Locally:
- Unit suite (excluding the documented rpc_endpoint_manager skip): **621 passed**.
- db-sqlalchemy suite (dockerized): **158 passed, 1 xfailed** (pre-existing).
- Integration `test_llm_erc20` (the flaky one): **passed 4/4 successive runs**, with mock LLMs and the new code.

## Not in this PR

- The upstream genvm-modules `reqwest::Client` timeout fix. Feature request filed.
- Cap-on-re-claim for stuck COMMITTING txs (separate concern).

## Test plan

- [ ] CI: unit + db-sqlalchemy + integration suites green
- [ ] After deploy to stg: monitor for any consensus regressions for a few hours before promoting to prd

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added stuck-finalization detection to health monitoring.
  * Introduced slot-budget-based execution timeout configuration for improved timeout management.

* **Improvements**
  * Optimized validator voting with wave-based scheduling for faster quorum detection.
  * Fixed event-loop blocking in storage operations.
  * Enhanced error handling and cleanup during initialization failures.
  * Refined transaction finalization tracking for pending transfers.

* **Tests**
  * Added regression tests for finalization tracking and health monitoring.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/genlayerlabs/genlayer-studio/pull/1629)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->