### PR TITLE
fix(consensus): per-contract finalization ordering + drain stranded NULL-timestamp rows

### DIFF
--- a/backend/consensus/worker.py
+++ b/backend/consensus/worker.py
@@ -193,6 +193,24 @@ class ConsensusWorker:
         Returns:
             Transaction data dict if claimed, None otherwise
         """
+        # Ordering invariant: a tx can only be claimed for finalization
+        # once every OLDER tx on the same contract has reached a terminal
+        # state ({FINALIZED, CANCELED}). Otherwise a younger tx could
+        # finalize before its predecessor — e.g. tx N+1 ACCEPTED finalizes
+        # while N is still stuck in COMMITTING, locking in state changes
+        # out of causal order. Made head-of-queue per contract; the
+        # cascade is automatic — when N finalizes, N+1 becomes eligible
+        # on the next claim cycle.
+        #
+        # Eligibility also accepts NULL timestamp_awaiting_finalization
+        # rows past STRANDED_TX_AFTER_SECONDS. Pre-fix code paths (e.g.
+        # the May 2026 insufficient-balance SEND short-circuit) could
+        # set a finalization-eligible status without stamping the
+        # timestamp, leaving the row invisible to this query forever.
+        # The defensive branch drains them naturally without backfill.
+        STRANDED_TX_AFTER_SECONDS = int(
+            os.environ.get("FINALIZATION_STRANDED_TX_AFTER_SECONDS", "600")
+        )
         # Query for transactions that are ready for finalization
         # They must be in ACCEPTED/UNDETERMINED/TIMEOUT states and appeal window must have passed
         start_time = time.perf_counter()
@@ -203,15 +221,30 @@ class ConsensusWorker:
                 FROM transactions t
                 WHERE t.status IN ('ACCEPTED', 'UNDETERMINED', 'LEADER_TIMEOUT', 'VALIDATORS_TIMEOUT')
                     AND t.appealed = false
-                    AND t.timestamp_awaiting_finalization IS NOT NULL
                     AND (
-                        t.execution_mode IN ('LEADER_ONLY', 'LEADER_SELF_VALIDATOR')
-                        OR (
-                            EXTRACT(EPOCH FROM NOW()) - t.timestamp_awaiting_finalization - COALESCE(t.appeal_processing_time, 0)
-                        ) > :finality_window_seconds * POWER(1 - :appeal_failed_reduction, COALESCE(t.appeal_failed, 0))
+                        -- Normal: timestamp set and finality window elapsed
+                        (t.timestamp_awaiting_finalization IS NOT NULL
+                         AND (
+                            t.execution_mode IN ('LEADER_ONLY', 'LEADER_SELF_VALIDATOR')
+                            OR (
+                                EXTRACT(EPOCH FROM NOW()) - t.timestamp_awaiting_finalization - COALESCE(t.appeal_processing_time, 0)
+                            ) > :finality_window_seconds * POWER(1 - :appeal_failed_reduction, COALESCE(t.appeal_failed, 0))
+                         ))
+                        OR
+                        -- Defensive: timestamp NULL + row past stranded threshold
+                        (t.timestamp_awaiting_finalization IS NULL
+                         AND t.created_at < NOW() - make_interval(secs => :stranded_threshold_seconds))
                     )
                     AND (t.blocked_at IS NULL
                          OR t.blocked_at < NOW() - CAST(:timeout AS INTERVAL))
+                    AND NOT EXISTS (
+                        -- Ordering invariant: no older non-terminal tx on the same contract
+                        SELECT 1 FROM transactions earlier
+                        WHERE earlier.to_address IS NOT DISTINCT FROM t.to_address
+                            AND earlier.created_at < t.created_at
+                            AND earlier.status NOT IN ('FINALIZED', 'CANCELED')
+                            AND earlier.hash != t.hash
+                    )
                     AND NOT EXISTS (
                         -- Ensure no other transaction for same contract is being processed
                         SELECT 1 FROM transactions t2
@@ -261,6 +294,7 @@ class ConsensusWorker:
                 "timeout": f"{self.transaction_timeout_minutes} minutes",
                 "finality_window_seconds": self.consensus_algorithm.finality_window_time,
                 "appeal_failed_reduction": self.consensus_algorithm.finality_window_appeal_failed_reduction,
+                "stranded_threshold_seconds": STRANDED_TX_AFTER_SECONDS,
             },
         ).first()
         duration = time.perf_counter() - start_time

--- a/tests/db-sqlalchemy/test_finalization_ordering.py
+++ b/tests/db-sqlalchemy/test_finalization_ordering.py
@@ -1,0 +1,344 @@
+"""
+Regression tests for the finalization ordering invariant in
+`ConsensusWorker.claim_next_finalization`.
+
+Two related invariants pinned here:
+
+1. **Ordering**: a tx can only be claimed for finalization once every
+   OLDER tx on the same contract has reached a terminal state
+   ({FINALIZED, CANCELED}). Without this, a younger tx N+1 ACCEPTED
+   could finalize while older N is still stuck in COMMITTING, locking
+   in state changes out of causal order.
+
+2. **NULL-timestamp tolerance**: rows with `timestamp_awaiting_finalization
+   IS NULL` past the stranded threshold are eligible. Pre-fix code paths
+   (e.g. the May 2026 insufficient-balance SEND short-circuit) reached
+   ACCEPTED-class statuses without stamping the timestamp; those rows
+   would otherwise sit invisible to the claim query forever.
+"""
+
+import os
+import time
+from contextlib import contextmanager
+from datetime import datetime, timedelta, timezone
+from typing import Iterable
+from unittest.mock import MagicMock
+
+import pytest
+from sqlalchemy import Engine, text
+from sqlalchemy.orm import Session, sessionmaker
+
+os.environ.setdefault("VITE_FINALITY_WINDOW", "30")
+os.environ.setdefault("VITE_FINALITY_WINDOW_APPEAL_FAILED_REDUCTION", "0.2")
+
+from backend.consensus.worker import ConsensusWorker
+
+
+CONTRACT = "0x" + "ff" * 20
+OTHER_CONTRACT = "0x" + "ee" * 20
+SENDER = "0x" + "ab" * 20
+
+
+def _insert_tx(
+    session: Session,
+    *,
+    tx_hash: str,
+    status: str,
+    nonce: int,
+    to_address: str = CONTRACT,
+    created_at: datetime | None = None,
+    timestamp_awaiting_finalization: int | None = None,
+    blocked_at: datetime | None = None,
+    worker_id: str | None = None,
+):
+    if created_at is None:
+        created_at = datetime.now(timezone.utc)
+    session.execute(
+        text(
+            """
+            INSERT INTO transactions (
+                hash, status, from_address, to_address,
+                data, value, type, nonce,
+                leader_only, execution_mode,
+                appealed, appeal_failed, appeal_undetermined,
+                appeal_leader_timeout, appeal_validators_timeout,
+                appeal_processing_time,
+                timestamp_awaiting_finalization, blocked_at, worker_id,
+                created_at, recovery_count, value_credited
+            ) VALUES (
+                :hash, CAST(:status AS transaction_status), :from_addr, :to_addr,
+                CAST('{}' AS jsonb), 0, 2, :nonce,
+                false, 'NORMAL',
+                false, 0, false,
+                false, false,
+                0,
+                :timestamp_awaiting_finalization, :blocked_at, :worker_id,
+                :created_at, 0, false
+            )
+            """
+        ),
+        {
+            "hash": tx_hash,
+            "status": status,
+            "from_addr": SENDER,
+            "to_addr": to_address,
+            "nonce": nonce,
+            "timestamp_awaiting_finalization": timestamp_awaiting_finalization,
+            "blocked_at": blocked_at,
+            "worker_id": worker_id,
+            "created_at": created_at,
+        },
+    )
+    session.commit()
+
+
+@pytest.fixture
+def worker(engine: Engine) -> Iterable[ConsensusWorker]:
+    Session_ = sessionmaker(bind=engine, expire_on_commit=False)
+
+    @contextmanager
+    def get_session():
+        s = Session_()
+        try:
+            yield s
+        finally:
+            s.close()
+
+    w = ConsensusWorker(
+        get_session=get_session,
+        msg_handler=MagicMock(),
+        consensus_service=MagicMock(),
+        validators_manager=MagicMock(),
+        genvm_manager=MagicMock(),
+        worker_id="test-worker",
+        transaction_timeout_minutes=20,
+    )
+    yield w
+
+
+@pytest.fixture
+def session(engine: Engine) -> Iterable[Session]:
+    Session_ = sessionmaker(bind=engine, expire_on_commit=False)
+    s = Session_()
+    yield s
+    s.rollback()
+    s.close()
+
+
+@pytest.mark.asyncio
+async def test_ordering_blocks_younger_when_older_still_in_consensus(
+    worker: ConsensusWorker, session: Session
+):
+    """Older tx still in COMMITTING ⇒ younger ACCEPTED with elapsed
+    finality window MUST NOT be claimed for finalization. This is the
+    causal-ordering invariant."""
+    now = datetime.now(timezone.utc)
+
+    _insert_tx(
+        session,
+        tx_hash="0x" + "10" * 32,
+        status="COMMITTING",
+        nonce=0,
+        created_at=now - timedelta(minutes=10),
+    )
+    _insert_tx(
+        session,
+        tx_hash="0x" + "11" * 32,
+        status="ACCEPTED",
+        nonce=1,
+        created_at=now - timedelta(minutes=5),
+        timestamp_awaiting_finalization=int(time.time()) - 600,  # window long elapsed
+    )
+
+    with worker.get_session() as s:
+        result = await worker.claim_next_finalization(s)
+
+    assert result is None, (
+        "Younger ACCEPTED tx must NOT be finalized while older tx is "
+        f"still in COMMITTING. Got: {result}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_ordering_allows_younger_after_older_finalized(
+    worker: ConsensusWorker, session: Session
+):
+    """Older tx FINALIZED ⇒ younger ACCEPTED becomes eligible. The
+    cascade behaviour: once the head is done, the next-oldest is up."""
+    now = datetime.now(timezone.utc)
+
+    _insert_tx(
+        session,
+        tx_hash="0x" + "20" * 32,
+        status="FINALIZED",
+        nonce=0,
+        created_at=now - timedelta(minutes=10),
+    )
+    _insert_tx(
+        session,
+        tx_hash="0x" + "21" * 32,
+        status="ACCEPTED",
+        nonce=1,
+        created_at=now - timedelta(minutes=5),
+        timestamp_awaiting_finalization=int(time.time()) - 600,
+    )
+
+    with worker.get_session() as s:
+        result = await worker.claim_next_finalization(s)
+
+    assert result is not None and result["hash"] == "0x" + "21" * 32, (
+        "Younger ACCEPTED tx must be eligible when the only older tx on "
+        f"the contract is FINALIZED. Got: {result}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_ordering_treats_canceled_as_terminal(
+    worker: ConsensusWorker, session: Session
+):
+    """CANCELED counts as terminal too — the queue should drain past it."""
+    now = datetime.now(timezone.utc)
+
+    _insert_tx(
+        session,
+        tx_hash="0x" + "30" * 32,
+        status="CANCELED",
+        nonce=0,
+        created_at=now - timedelta(minutes=10),
+    )
+    _insert_tx(
+        session,
+        tx_hash="0x" + "31" * 32,
+        status="ACCEPTED",
+        nonce=1,
+        created_at=now - timedelta(minutes=5),
+        timestamp_awaiting_finalization=int(time.time()) - 600,
+    )
+
+    with worker.get_session() as s:
+        result = await worker.claim_next_finalization(s)
+
+    assert result is not None and result["hash"] == "0x" + "31" * 32, (
+        "CANCELED counts as terminal; younger tx should be eligible. " f"Got: {result}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_null_timestamp_stranded_row_is_claimed_when_head(
+    worker: ConsensusWorker, session: Session
+):
+    """The defensive arm: a NULL-timestamp row past the stranded threshold
+    IS eligible when it's the head of its contract. Drains the May 2026
+    insufficient-balance SEND legacy rows without a backfill."""
+    now = datetime.now(timezone.utc)
+
+    _insert_tx(
+        session,
+        tx_hash="0x" + "40" * 32,
+        status="UNDETERMINED",
+        nonce=0,
+        created_at=now - timedelta(hours=2),
+        timestamp_awaiting_finalization=None,  # stranded
+    )
+
+    with worker.get_session() as s:
+        result = await worker.claim_next_finalization(s)
+
+    assert result is not None and result["hash"] == "0x" + "40" * 32, (
+        "Stranded NULL-timestamp head must drain via defensive eligibility. "
+        f"Got: {result}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_null_timestamp_stranded_row_blocked_by_older(
+    worker: ConsensusWorker, session: Session
+):
+    """Stranded row that ISN'T the head waits behind the older non-final
+    tx — same ordering invariant applies."""
+    now = datetime.now(timezone.utc)
+
+    _insert_tx(
+        session,
+        tx_hash="0x" + "50" * 32,
+        status="COMMITTING",
+        nonce=0,
+        created_at=now - timedelta(hours=3),  # older, still in consensus
+    )
+    _insert_tx(
+        session,
+        tx_hash="0x" + "51" * 32,
+        status="UNDETERMINED",
+        nonce=1,
+        created_at=now - timedelta(hours=2),
+        timestamp_awaiting_finalization=None,
+    )
+
+    with worker.get_session() as s:
+        result = await worker.claim_next_finalization(s)
+
+    assert result is None, (
+        "Stranded UNDETERMINED behind an older non-final tx must wait — "
+        f"ordering invariant applies even on the defensive eligibility branch. Got: {result}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_null_timestamp_recent_row_not_yet_eligible(
+    worker: ConsensusWorker, session: Session
+):
+    """NULL timestamp + row younger than threshold ⇒ NOT yet claimed.
+    Prevents premature finalization of rows still in the active path."""
+    now = datetime.now(timezone.utc)
+
+    _insert_tx(
+        session,
+        tx_hash="0x" + "60" * 32,
+        status="UNDETERMINED",
+        nonce=0,
+        created_at=now - timedelta(seconds=30),  # well under threshold
+        timestamp_awaiting_finalization=None,
+    )
+
+    with worker.get_session() as s:
+        result = await worker.claim_next_finalization(s)
+
+    assert result is None, (
+        "Recent NULL-timestamp row must not be claimed before the stranded "
+        f"threshold elapses. Got: {result}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_ordering_is_per_contract(worker: ConsensusWorker, session: Session):
+    """The ordering invariant is per-contract — a non-terminal tx on a
+    different contract does NOT block this one."""
+    now = datetime.now(timezone.utc)
+
+    # Older non-terminal tx on a DIFFERENT contract
+    _insert_tx(
+        session,
+        tx_hash="0x" + "70" * 32,
+        status="COMMITTING",
+        nonce=0,
+        to_address=OTHER_CONTRACT,
+        created_at=now - timedelta(minutes=10),
+    )
+    # Younger ACCEPTED on the target contract; no older tx on the same contract
+    _insert_tx(
+        session,
+        tx_hash="0x" + "71" * 32,
+        status="ACCEPTED",
+        nonce=0,
+        to_address=CONTRACT,
+        created_at=now - timedelta(minutes=5),
+        timestamp_awaiting_finalization=int(time.time()) - 600,
+    )
+
+    with worker.get_session() as s:
+        result = await worker.claim_next_finalization(s)
+
+    assert result is not None and result["hash"] == "0x" + "71" * 32, (
+        "Ordering must be per-contract; other contracts' state shouldn't matter. "
+        f"Got: {result}"
+    )

--- a/tests/integration/icontracts/conftest.py
+++ b/tests/integration/icontracts/conftest.py
@@ -49,6 +49,21 @@ def setup_validators():
     def _setup(mock_response: Any = None) -> None:
         nonlocal created_validator_addresses
         if mock_llms():
+            # Wipe ALL existing validators before seeding this test's mocks.
+            # Without this, a prior test's validator (which has different
+            # mock_response, possibly even none) can be picked into this
+            # test's consensus round via VRF, disagree with the leader's
+            # mocked output, and produce an UNDETERMINED result — the
+            # leader's receipt still says SUCCESS so tx_execution_succeeded
+            # passes, but contract state stays unchanged and the balance
+            # assertion fails. The xdist_group marker serializes these
+            # tests onto a single worker, so this wipe is safe for the
+            # parallel CI run.
+            delete_all = post_request_localhost(
+                payload("sim_deleteAllValidators")
+            ).json()
+            assert has_success_status(delete_all)
+
             mock_cfg = get_mock_provider_config()
             # Mock mode: create validators with specific mock_response for this test
             for _ in range(5):


### PR DESCRIPTION
## Why

Two issues with finalization, surfaced by today's incident response:

1. **No causal ordering enforcement.** `claim_next_finalization` could pick a younger ACCEPTED tx while older non-terminal tx on the same contract was still in COMMITTING. A finalized N+1 locks in state changes out of order with N — incorrect semantics.

2. **NULL `timestamp_awaiting_finalization` rows invisible.** 17 stranded UNDETERMINED rows currently sit on Studio Prod because pre-fix code (the May 2026 insufficient-balance SEND short-circuit, fixed in PR #1628) reached ACCEPTED-class statuses without stamping the timestamp. The existing query filtered on `timestamp_awaiting_finalization IS NOT NULL`; those rows never get picked up. Workaround was a one-time backfill SQL — replaced by this PR's defensive eligibility branch.

## What

`backend/consensus/worker.py::claim_next_finalization`:

1. **Ordering NOT EXISTS clause** — a tx is only eligible if no older tx on the same contract exists with status NOT IN ({FINALIZED, CANCELED}). Per-contract head-of-queue. Cascade is automatic: when the head finalizes, the next-oldest becomes eligible on the next claim cycle.

2. **Defensive eligibility branch** — accepts rows with `timestamp_awaiting_finalization IS NULL AND created_at < NOW() - FINALIZATION_STRANDED_TX_AFTER_SECONDS` (default 600s, env-overridable). Combined with the ordering invariant, those stranded rows can only finalize when they're the actual head of their contract's queue. The 17 stranded rows on Studio Prod will drain naturally after deploy — no backfill needed.

## Test

`tests/db-sqlalchemy/test_finalization_ordering.py`:
- Younger ACCEPTED blocked while older still in COMMITTING
- Younger ACCEPTED eligible after older reaches FINALIZED (cascade)
- CANCELED counts as terminal
- NULL-timestamp stranded head row IS claimed
- NULL-timestamp stranded row BLOCKED by older non-terminal sibling
- Recent NULL-timestamp row (under threshold) NOT claimed
- Ordering is per-contract (different contracts don't block)

Suite: **165 db-sqlalchemy pass** (incl. existing `test_finalization_starvation`), **621 unit pass**.

## Followup tracked separately

Gate `--debug-mode` flag passed to GenVM (currently unconditional in `backend/node/base.py:908,1034`) behind an env var so prd manifests can omit it. That disables `py-genlayer:latest` / `py-genlayer:test` runner tags in prd at the GenVM level — no contract-linter rule needed.

## Test plan

- [ ] CI green
- [ ] After deploy on Studio Prod: `stuck_finalization_count` drops from 17 to 0 (stranded rows drain via the defensive branch)
- [ ] No new stuck-finalization alerts (the ordering invariant prevents recurrence)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved transaction finalization recovery for transactions stuck without finalization tracking data, allowing them to be processed after a configurable timeout (default 10 minutes).

* **Tests**
  * Added comprehensive regression test suite validating transaction ordering logic and finalization eligibility scenarios.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/genlayerlabs/genlayer-studio/pull/1630)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->