### PR TITLE
fix(genvm): gate --debug-mode behind GENVM_DEBUG_MODE env var

### DIFF
--- a/backend/node/base.py
+++ b/backend/node/base.py
@@ -68,6 +68,24 @@ def _env_bool(name: str, default: bool = False) -> bool:
     return raw.strip().lower() in {"1", "true", "yes", "on"}
 
 
+def _genvm_extra_args() -> list[str]:
+    """Extra CLI args for the genvm executor.
+
+    `--debug-mode` enables the `:latest` and `:test` runner version
+    aliases (see genvm/executor/src/exe/run.rs:58-62). Convenient in
+    dev/stg where you want to iterate without pinning a specific runner
+    hash, but a footgun in prd: those aliases float, so two validators
+    on the same tx can resolve different runner binaries — breaks
+    determinism / consensus.
+
+    Gated on GENVM_DEBUG_MODE (default true to preserve dev/stg
+    convenience). Prd manifests should set GENVM_DEBUG_MODE=false so
+    contracts that try to use `py-genlayer:latest` or `py-genlayer:test`
+    fail fast at the executor.
+    """
+    return ["--debug-mode"] if _env_bool("GENVM_DEBUG_MODE", default=True) else []
+
+
 def _filter_genvm_log_by_level(genvm_log: list[dict]) -> list[dict]:
     """
     Filter genvm_log entries based on configured LOG_LEVEL.
@@ -905,7 +923,7 @@ class Node:
             ),
             message=message,
             permissions="rw",
-            extra_args=["--debug-mode"],
+            extra_args=_genvm_extra_args(),
             host_data='{"node_address":"0x", "tx_id":"0x"}',
             capture_output=True,
             is_sync=True,
@@ -1031,7 +1049,7 @@ class Node:
                 permissions=perms,
                 capture_output=True,
                 host_data=json.dumps(host_data),
-                extra_args=["--debug-mode"],
+                extra_args=_genvm_extra_args(),
                 is_sync=is_sync,
                 manager_uri=self.manager.url,
                 timeout=timeout,

--- a/frontend/src/views/Simulator/RunDebugView.vue
+++ b/frontend/src/views/Simulator/RunDebugView.vue
@@ -115,10 +115,21 @@ const consensusMaxRotations = computed(() => consensusStore.maxRotations);
         @openDeployment="isDeploymentOpen = true"
       />
 
+      <!--
+        Mirror the validator-required Alert in ContractInfo: while
+        validators are still loading we don't yet know whether to show
+        the "you need validators" warning or the deploy form, so render
+        the form rather than leave the user with just "Not deployed yet"
+        and no UI. After load:
+          - 1+ validators → form stays.
+          - 0 validators → Alert in ContractInfo takes over (gated on
+            `!isLoadingValidatorData`).
+      -->
       <template
         v-if="
           !isStudioNetwork ||
           nodeStore.hasAtLeastOneValidator ||
+          nodeStore.isLoadingValidatorData ||
           uiStore.showTutorial
         "
       >

--- a/tests/unit/test_genvm_debug_mode_gate.py
+++ b/tests/unit/test_genvm_debug_mode_gate.py
@@ -1,0 +1,49 @@
+"""Test the GENVM_DEBUG_MODE env-var gate around the executor's
+`--debug-mode` flag.
+
+`--debug-mode` enables `:latest` and `:test` runner version aliases in
+the genvm executor. Those aliases float across deploys and break
+determinism, so prd must have them disabled. The gate defaults to true
+(dev/stg keeps the convenience) but prd manifests should set
+GENVM_DEBUG_MODE=false.
+"""
+
+import importlib
+
+import pytest
+
+
+@pytest.fixture
+def base_module():
+    """Reload backend.node.base so each test sees fresh env-var
+    evaluation. `_genvm_extra_args` reads `os.getenv` at call time, so
+    reload isn't strictly required — but it guards against any future
+    module-level memoization regression."""
+    from backend.node import base
+
+    importlib.reload(base)
+    return base
+
+
+def test_debug_mode_enabled_by_default(monkeypatch, base_module):
+    """Unset env var → include --debug-mode (dev/stg convenience)."""
+    monkeypatch.delenv("GENVM_DEBUG_MODE", raising=False)
+    assert base_module._genvm_extra_args() == ["--debug-mode"]
+
+
+def test_debug_mode_enabled_when_true(monkeypatch, base_module):
+    for value in ("true", "TRUE", "1", "yes", "on"):
+        monkeypatch.setenv("GENVM_DEBUG_MODE", value)
+        assert base_module._genvm_extra_args() == [
+            "--debug-mode"
+        ], f"GENVM_DEBUG_MODE={value!r} should enable --debug-mode"
+
+
+def test_debug_mode_disabled_when_false(monkeypatch, base_module):
+    """Prd setting: GENVM_DEBUG_MODE=false strips --debug-mode so the
+    executor rejects `py-genlayer:latest` / `:test` runner aliases."""
+    for value in ("false", "FALSE", "0", "no", "off", "anything-else"):
+        monkeypatch.setenv("GENVM_DEBUG_MODE", value)
+        assert (
+            base_module._genvm_extra_args() == []
+        ), f"GENVM_DEBUG_MODE={value!r} should disable --debug-mode"


### PR DESCRIPTION
## Why

The genvm executor's \`--debug-mode\` flag enables \`:latest\` and \`:test\` runner version aliases (genvm/executor/src/exe/run.rs:58-62: _"whenever to allow \`:latest\` and \`:test\` as runners version, tracing, etc."_). Those aliases float across deploys: two validators on the same tx can resolve different runner binaries if the registry updates between their loads — breaks determinism, breaks consensus.

Studio Prod / Rally Prod were unconditionally passing \`--debug-mode\` from \`backend/node/base.py:908\` and \`:1034\`. Contracts with \`Depends: py-genlayer:latest\` or \`:test\` were allowed in prd with no warning. The right gate is at the genvm-invocation boundary, not a contract-linter rule.

## What

Replace the two hard-coded \`["--debug-mode"]\` literals with a single \`_genvm_extra_args()\` helper that reads \`GENVM_DEBUG_MODE\` (default \`true\` so dev/stg keep the iteration convenience). Prd manifests set \`false\`.

## Test

\`tests/unit/test_genvm_debug_mode_gate.py\`: pins the default-true behaviour and the truthy/falsy env-var parsing. **624 unit tests pass**.

## Companion PR

[devexp-apps-workload PR](https://github.com/genlayerlabs/devexp-apps-workload/pull/<TBD>) sets \`GENVM_DEBUG_MODE=false\` on both jsonrpc Rollout and consensus-worker Deployment in \`prd/studio\` and \`prd/rally-studio\` manifests.

## Test plan

- [ ] CI green
- [ ] After deploy + manifest merge: try deploying a contract with \`Depends: py-genlayer:latest\` on Studio Prod — expect the executor to reject it with a clear error.
- [ ] Verify dev/stg still accept the floating tags (default true preserved).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * GENVM debug mode is now configurable via environment variables; debug remains enabled by default.

* **Bug Fixes / Reliability**
  * Tightened LLM provider health checks to avoid counting contract-side crashes as provider failures.

* **Bug Fixes / UX**
  * Simulator deploy/tutorial view remains visible while validator data is loading, preventing premature hiding.

* **Tests**
  * Added unit tests for GENVM debug-mode gating and expanded health-check tests to cover structured vs. contract-side errors.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/genlayerlabs/genlayer-studio/pull/1631?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->