### PR TITLE
fix(health): exclude contract-side crashes from llm_provider_failure detector

### DIFF
--- a/backend/protocol_rpc/health.py
+++ b/backend/protocol_rpc/health.py
@@ -812,7 +812,13 @@ async def _check_llm_provider_health() -> Dict[str, Any]:
                                     AS provider,
                                 v.receipt->'node_config'->'primary_model'->>'model'
                                     AS model,
-                                v.receipt->>'execution_result' AS execution_result
+                                v.receipt->>'execution_result' AS execution_result,
+                                v.receipt->'genvm_result'->>'error_code' AS error_code,
+                                -- Use ->> not -> so a JSONB null literal
+                                -- becomes SQL NULL (otherwise IS NOT NULL
+                                -- is true for `raw_error: null`).
+                                (v.receipt->'genvm_result'->>'raw_error') IS NOT NULL
+                                    AS has_raw_error
                             FROM transactions t,
                                  jsonb_array_elements(
                                      COALESCE(
@@ -838,8 +844,26 @@ async def _check_llm_provider_health() -> Dict[str, Any]:
                             provider,
                             model,
                             COUNT(*) AS samples,
-                            COUNT(*) FILTER (WHERE execution_result = 'ERROR')
-                                AS failures
+                            -- Only count errors that have a structured
+                            -- LLM/manager error_code OR raw_error block.
+                            -- Contract-side Python exceptions (e.g. a user
+                            -- contract using a non-existent SDK attribute)
+                            -- also surface as execution_result = 'ERROR',
+                            -- but have error_code = null AND raw_error =
+                            -- null because the failure happened inside the
+                            -- user code before any LLM call. Counting those
+                            -- here would let one broken contract make every
+                            -- validator (across all models) look like an
+                            -- LLM provider failure — exactly the false
+                            -- signal that fired Studio Prod's nonstop
+                            -- llm_provider_failure alert (May 2026).
+                            COUNT(*) FILTER (
+                                WHERE execution_result = 'ERROR'
+                                  AND (
+                                      error_code IS NOT NULL
+                                      OR has_raw_error
+                                  )
+                            ) AS failures
                         FROM receipts
                         GROUP BY provider, model
                         """
@@ -918,6 +942,15 @@ async def _check_llm_provider_health() -> Dict[str, Any]:
                                       'LEADER_TIMEOUT', 'VALIDATORS_TIMEOUT'
                                   )
                                   AND v.receipt->>'execution_result' = 'ERROR'
+                                  -- Match the aggregate filter: only sample
+                                  -- structured LLM/manager errors, skip
+                                  -- contract-side Python crashes.
+                                  AND (
+                                      v.receipt->'genvm_result'->>'error_code'
+                                          IS NOT NULL
+                                      OR (v.receipt->'genvm_result'->>'raw_error')
+                                          IS NOT NULL
+                                  )
                                   AND v.receipt->'node_config'->'primary_model'->>'provider'
                                           IS NOT NULL
                             )

--- a/tests/db-sqlalchemy/test_health_llm_provider_detection.py
+++ b/tests/db-sqlalchemy/test_health_llm_provider_detection.py
@@ -225,6 +225,7 @@ async def test_below_threshold_does_not_alert(engine: Engine):
                         provider="openrouter",
                         model="openai/gpt-5.4",
                         execution_result="SUCCESS" if ok else "ERROR",
+                        causes=None if ok else ["STATUS_NOT_OK"],
                     )
                 ],
                 created_at=now - timedelta(minutes=1 + i),
@@ -258,6 +259,7 @@ async def test_below_min_samples_does_not_alert(engine: Engine):
                         provider="openrouter",
                         model="z-ai/glm-5.1",
                         execution_result="ERROR",
+                        causes=["STATUS_NOT_OK"],
                     )
                 ],
                 created_at=now - timedelta(minutes=1 + i),
@@ -292,6 +294,7 @@ async def test_outside_window_excluded(engine: Engine):
                         provider="ionet",
                         model="failing-model",
                         execution_result="ERROR",
+                        causes=["STATUS_NOT_OK"],
                     )
                 ],
                 created_at=now - timedelta(hours=2),
@@ -363,6 +366,7 @@ async def test_only_terminal_status_txs_counted(engine: Engine):
                         provider="ionet",
                         model="in-flight-model",
                         execution_result="ERROR",
+                        causes=["STATUS_NOT_OK"],
                     )
                 ],
                 created_at=now - timedelta(minutes=1 + i),
@@ -413,6 +417,7 @@ async def test_multiple_providers_only_failing_one_in_alert(engine: Engine):
                         provider="ionet",
                         model="broken-model",
                         execution_result="ERROR",
+                        causes=["STATUS_NOT_OK"],
                     )
                 ],
                 created_at=now - timedelta(minutes=1 + i),
@@ -428,3 +433,119 @@ async def test_multiple_providers_only_failing_one_in_alert(engine: Engine):
     assert result["alert_providers"][0]["provider"] == "ionet"
     # total_samples spans both provider buckets.
     assert result["total_samples"] == 9
+
+
+@pytest.mark.asyncio
+async def test_contract_side_errors_do_not_count_as_llm_failures(engine: Engine):
+    """Contract-side Python exceptions (e.g. user code calling a non-
+    existent SDK attribute) surface as execution_result='ERROR' with
+    `error_code` AND `raw_error` both NULL — the genvm crashed in user
+    code before any LLM call.
+
+    Without filtering, one broken contract running on a hot path makes
+    every validator (across all models) look like an LLM provider
+    failure. This is exactly what fired Studio Prod's nonstop
+    llm_provider_failure alert in May 2026 (every openrouter model
+    reported 50-75% error rate; turned out to be one user contract
+    crashing with `AttributeError: module 'genlayer.gl' has no
+    attribute 'ContractState'`).
+
+    Pin: contract-side ERROR receipts (no error_code, no raw_error) MUST
+    NOT count as LLM failures.
+    """
+    Session_ = sessionmaker(bind=engine, expire_on_commit=False)
+    now = datetime.now(timezone.utc)
+
+    with Session_() as s:
+        # 30 receipts, all ERROR, all simulating a contract-side crash
+        # (no structured error fields). At 30 samples this is well above
+        # MIN_SAMPLES (25), so a naive counter would flip degraded.
+        for i in range(30):
+            _insert_tx_with_receipts(
+                s,
+                tx_hash=f"0x{(0x200 + i):064x}",
+                leader_receipt=None,
+                validators=[
+                    _make_validator(
+                        provider="openrouter",
+                        model="openai/gpt-5.4",
+                        execution_result="ERROR",
+                        # error_code=None, causes=None, http_status=None
+                        # → raw_error is None too. This is the contract-
+                        # crash shape (stderr contains the Python
+                        # traceback but we don't surface it).
+                    )
+                ],
+                created_at=now - timedelta(minutes=1),
+            )
+        s.commit()
+
+    from backend.protocol_rpc import health as health_module
+
+    result = await health_module._check_llm_provider_health()
+
+    # Sample count includes contract crashes (the receipt did happen),
+    # but failure count for the alert excludes them. So:
+    # - 30 samples total, 0 LLM failures → 0% failure rate → no alert.
+    assert result["status"] == "healthy", (
+        f"30 contract-crash ERROR receipts must NOT trigger an "
+        f"llm_provider_failure alert. Got: {result}"
+    )
+    assert result["alert_providers"] == []
+
+
+@pytest.mark.asyncio
+async def test_contract_crashes_mixed_with_real_llm_failures(engine: Engine):
+    """When the same (provider, model) sees both contract crashes and
+    real LLM errors, only the LLM errors count toward the failure rate.
+
+    Setup: 20 contract crashes + 10 real LLM errors → 30 samples, 10
+    failures = 33% → below the 50% threshold → no alert. Without the
+    filter this would be 30 samples, 30 failures = 100% → alert."""
+    Session_ = sessionmaker(bind=engine, expire_on_commit=False)
+    now = datetime.now(timezone.utc)
+
+    with Session_() as s:
+        # 20 contract crashes
+        for i in range(20):
+            _insert_tx_with_receipts(
+                s,
+                tx_hash=f"0x{(0x300 + i):064x}",
+                leader_receipt=None,
+                validators=[
+                    _make_validator(
+                        provider="openrouter",
+                        model="anthropic/claude-sonnet-4.6",
+                        execution_result="ERROR",
+                    )
+                ],
+                created_at=now - timedelta(minutes=2),
+            )
+        # 10 real LLM errors
+        for i in range(10):
+            _insert_tx_with_receipts(
+                s,
+                tx_hash=f"0x{(0x400 + i):064x}",
+                leader_receipt=None,
+                validators=[
+                    _make_validator(
+                        provider="openrouter",
+                        model="anthropic/claude-sonnet-4.6",
+                        execution_result="ERROR",
+                        causes=["STATUS_NOT_OK"],
+                        http_status="429",
+                    )
+                ],
+                created_at=now - timedelta(minutes=2),
+            )
+        s.commit()
+
+    from backend.protocol_rpc import health as health_module
+
+    result = await health_module._check_llm_provider_health()
+
+    # 30 samples, 10 LLM failures = 33% < 50% threshold → healthy
+    assert (
+        result["status"] == "healthy"
+    ), f"Mixed crashes + LLM errors: only LLM errors should count. Got: {result}"
+    assert result["alert_providers"] == []


### PR DESCRIPTION
## Why

**Studio Prod is firing nonstop \`llm_provider_failure\` alerts right now.** Looks like every openrouter model is degraded (41-75% error rate across 13 different models simultaneously). It's not.

Root cause investigated against live receipts: **one user contract** on a hot path is crashing with \`AttributeError: module 'genlayer.gl' has no attribute 'ContractState'\` (and a similar one against \`gl.eq_principle.get\` — both written against an SDK API that doesn't exist in the deployed runner). Every validator runs it, crashes the same way before any LLM call, returns \`execution_result: ERROR\`.

The detector counted ANY \`execution_result = 'ERROR'\` as an LLM failure, so one broken contract made every (provider, model) pair look like it was failing — masking real LLM outages and crying wolf.

Confirmed empirically: of 315 ERROR receipts on Studio Prod in the last hour, **all 315** have \`error_code: null\` AND \`raw_error: null\`. Real LLM/manager errors populate both. Contract-side Python exceptions populate neither (the crash is in user code, before any LLM call).

## What

\`backend/protocol_rpc/health.py\` — \`_check_llm_provider_health()\`:

- Add \`error_code\` and \`has_raw_error\` to the inner CTE.
- Filter the failure count to only include errors where one of those is set. Contract crashes still show in \`samples\` (the receipt did happen), but don't contribute to \`failures\`.
- Same filter on the sample-error pick query so we never select a contract crash as the "representative" error for an alert.

**JSONB gotcha** caught and fixed mid-implementation:
\`receipt->'genvm_result'->'raw_error' IS NOT NULL\` is TRUE even when \`raw_error\` is a JSON \`null\` literal (it's still a JSONB value, just one whose contents are null). Use \`->>\` instead — it serializes JSONB null to SQL NULL, which \`IS NOT NULL\` then distinguishes correctly. The test suite caught this on the first run.

## Test

- 5 existing tests updated: they simulated LLM failures with \`execution_result="ERROR"\` but no \`causes\` / \`http_status\` → under the new filter those would now match contract-crash shape. Added \`causes=["STATUS_NOT_OK"]\` so they represent real LLM errors (keeps test semantics).
- 2 new regression pins:
  - \`test_contract_side_errors_do_not_count_as_llm_failures\`: 30 contract-crash receipts on the same model MUST NOT flip degraded.
  - \`test_contract_crashes_mixed_with_real_llm_failures\`: 20 crashes + 10 real LLM errors = 33% real failure rate → no alert (would be 100% under old code).

Suite: **167 db-sqlalchemy pass** (was 165).

## Follow-up (not in this PR)

Contract crashes deserve their own health signal. Today they're silently absorbed; if many txs are crashing in user code, that's worth surfacing — just not as an *LLM* failure. Easy follow-up: a \`contract_crash_count\` field that counts execution_result=ERROR with both error_code and raw_error null.

## Test plan

- [ ] CI green
- [ ] After deploy: \`stuck_finalizations\` count unchanged; \`llm_providers.alert_providers\` no longer fires for the broken-contract pattern; if a real LLM provider has issues it still fires (one or both of error_code/raw_error are set)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refined LLM provider health detection to accurately distinguish between structured errors and system-level failures. Contract-side crashes are now correctly excluded from health calculations, reducing false provider failure alerts while maintaining detection of genuine LLM errors.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/genlayerlabs/genlayer-studio/pull/1632?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->