### PR TITLE
fix(db): partial index for claim_next_finalization ordering NOT EXISTS

### DIFF
--- a/backend/database_handler/migration/versions/a7b8c9d0e1f2_add_finalization_ordering_index.py
+++ b/backend/database_handler/migration/versions/a7b8c9d0e1f2_add_finalization_ordering_index.py
@@ -1,0 +1,65 @@
+"""add partial index supporting claim_next_finalization's ordering NOT EXISTS
+
+Revision ID: a7b8c9d0e1f2
+Revises: f2c3d4e5a6b7
+Create Date: 2026-05-21 09:30:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision: str = "a7b8c9d0e1f2"
+down_revision: Union[str, None] = "f2c3d4e5a6b7"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # PR #1630 added a per-contract finalization ordering invariant to
+    # claim_next_finalization: a tx can only be claimed once every older
+    # tx on the same contract has reached a terminal state. The check
+    # is a NOT EXISTS:
+    #
+    #     SELECT 1 FROM transactions earlier
+    #     WHERE earlier.to_address IS NOT DISTINCT FROM t.to_address
+    #         AND earlier.created_at < t.created_at
+    #         AND earlier.status NOT IN ('FINALIZED', 'CANCELED')
+    #         AND earlier.hash != t.hash
+    #
+    # The negated `status NOT IN (...)` predicate cannot use the existing
+    # `idx_transactions_status` btree, so Postgres falls back to a parallel
+    # sequential scan of the full transactions table on every poll.
+    # Measured on Studio Prod (~80k rows): 110ms / 75,888 buffers per
+    # query, executed by every worker every 5s. That continuous scanning
+    # drove the consensus-worker CPU to 98%+ under modest load and
+    # tripped the stuck_finalizations alert via finalization head-of-
+    # line slowdown.
+    #
+    # Partial btree on (to_address, created_at) WHERE status NOT IN
+    # (...) is small (only non-terminal rows — typically <500 of the
+    # ~80k total) and exactly matches the access pattern. Same query
+    # dropped to 0.2ms / 28 buffers in EXPLAIN — ~570x improvement.
+    #
+    # CONCURRENTLY so the build doesn't lock writes on prod. Alembic's
+    # implicit transaction has to be committed first since CONCURRENTLY
+    # can't run inside a transaction block.
+    op.execute("COMMIT")
+    op.execute(
+        """
+        CREATE INDEX CONCURRENTLY IF NOT EXISTS
+            idx_transactions_nonterminal_by_contract
+        ON transactions (to_address, created_at)
+        WHERE status NOT IN ('FINALIZED', 'CANCELED')
+        """
+    )
+
+
+def downgrade() -> None:
+    op.execute("COMMIT")
+    op.execute(
+        "DROP INDEX CONCURRENTLY IF EXISTS idx_transactions_nonterminal_by_contract"
+    )


### PR DESCRIPTION
## Why

Today's \`stuck_finalizations\` alert (CPU 98.8%) traces to PR #1630's ordering NOT EXISTS:

\`\`\`sql
SELECT 1 FROM transactions earlier
WHERE earlier.to_address IS NOT DISTINCT FROM t.to_address
    AND earlier.created_at < t.created_at
    AND earlier.status NOT IN ('FINALIZED', 'CANCELED')
    AND earlier.hash != t.hash
\`\`\`

Negated \`status NOT IN (...)\` can't use the existing btree on \`status\`. EXPLAIN ANALYZE on Studio Prod:

> Parallel Seq Scan on transactions earlier
> Filter: (status <> ALL ('{FINALIZED,CANCELED}'))
> Rows Removed by Filter: 77882
> Execution Time: 110.146 ms / Buffers: shared hit=75888

Per claim, every worker, every 5s. That continuous full-table scanning is the CPU spike.

## What

Add partial btree:

\`\`\`sql
CREATE INDEX CONCURRENTLY idx_transactions_nonterminal_by_contract
    ON transactions (to_address, created_at)
    WHERE status NOT IN ('FINALIZED', 'CANCELED');
\`\`\`

Small (only hundreds of rows out of 80k+), exactly matches the access pattern.

Same query re-run with the index:

> Index Scan using idx_transactions_nonterminal_by_contract
> Execution Time: 0.194 ms / Buffers: shared hit=27 read=1

**570x speedup. 2,700x fewer buffer hits.**

## Test

Full db-sqlalchemy suite (167 + 1 xfailed) passes — migration applies cleanly from baseline and from current head \`f2c3d4e5a6b7\`. EXPLAIN data above is from a rolled-back transaction on the live Studio Prod DB.

## Test plan

- [ ] CI green
- [ ] After deploy: consensus-worker CPU drops back to baseline (was ~750m on the busy worker, expect <100m)
- [ ] \`stuck_finalizations\` alert stops recurring
- [ ] Schema migration completes via the normal release-lane pipeline (CONCURRENTLY → no table lock, safe under load)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Database schema updated with a new index to optimize transaction processing queries.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/genlayerlabs/genlayer-studio/pull/1633?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->