### PR TITLE
fix: prevent GenVM finalization poison loops

### DIFF
--- a/backend/consensus/worker.py
+++ b/backend/consensus/worker.py
@@ -637,30 +637,62 @@ class ConsensusWorker:
         """
         update_query = text(
             """
+            WITH target AS (
+                SELECT hash, recovery_count
+                FROM transactions
+                WHERE hash = :hash
+                  AND worker_id = :worker_id
+                FOR UPDATE
+            )
             UPDATE transactions
             SET blocked_at = NULL,
                 worker_id = NULL,
-                consensus_data = NULL,
                 consensus_history = NULL,
-                status = 'PENDING'
-            WHERE hash = :hash
-              AND worker_id = :worker_id
-            RETURNING hash, status, blocked_at, worker_id
+                recovery_count = target.recovery_count + 1,
+                status = CASE
+                    WHEN target.recovery_count + 1 >= :max_recovery_cycles
+                    THEN 'CANCELED'::transaction_status
+                    ELSE 'PENDING'::transaction_status
+                END,
+                consensus_data = CASE
+                    WHEN target.recovery_count + 1 >= :max_recovery_cycles
+                    THEN jsonb_build_object(
+                        'error', 'max_recovery_cycles_exceeded',
+                        'recovery_count', target.recovery_count + 1
+                    )
+                    ELSE NULL
+                END
+            FROM target
+            WHERE transactions.hash = target.hash
+            RETURNING transactions.hash, transactions.status, transactions.blocked_at,
+                      transactions.worker_id, transactions.recovery_count
         """
         )
 
         try:
             result = session.execute(
                 update_query,
-                {"hash": transaction_hash, "worker_id": self.worker_id},
+                {
+                    "hash": transaction_hash,
+                    "worker_id": self.worker_id,
+                    "max_recovery_cycles": self._max_recovery_cycles,
+                },
             )
             row = result.first()
             session.commit()
 
             if row:
-                logger.info(
-                    f"[Worker {self.worker_id}] Reset transaction {transaction_hash} to PENDING after GenVM internal error"
-                )
+                if row.status == TransactionStatus.CANCELED.value:
+                    logger.error(
+                        f"[Worker {self.worker_id}] Canceled transaction {transaction_hash} "
+                        f"after {row.recovery_count} GenVM reset cycles"
+                    )
+                else:
+                    logger.info(
+                        f"[Worker {self.worker_id}] Reset transaction {transaction_hash} "
+                        f"to PENDING after GenVM internal error "
+                        f"(cycle {row.recovery_count}/{self._max_recovery_cycles})"
+                    )
             else:
                 logger.warning(
                     f"[Worker {self.worker_id}] Transaction {transaction_hash} not found or owned by another worker when resetting"

--- a/backend/node/genvm/error_codes.py
+++ b/backend/node/genvm/error_codes.py
@@ -74,6 +74,7 @@ class GenVMErrorCode(StrEnum):
     LLM_NO_PROVIDER = "LLM_NO_PROVIDER"
     LLM_PROVIDER_ERROR = "LLM_PROVIDER_ERROR"
     LLM_INVALID_API_KEY = "LLM_INVALID_API_KEY"
+    LLM_INVALID_PROMPT = "LLM_INVALID_PROMPT"
     LLM_TIMEOUT = "LLM_TIMEOUT"
 
     # Web request errors
@@ -89,6 +90,7 @@ class GenVMErrorCode(StrEnum):
 # Mapping from Lua error causes to standardized error codes
 LUA_CAUSE_TO_CODE: dict[str, GenVMErrorCode] = {
     "NO_PROVIDER_FOR_PROMPT": GenVMErrorCode.LLM_NO_PROVIDER,
+    "EMPTY_PROMPT": GenVMErrorCode.LLM_INVALID_PROMPT,
     "STATUS_NOT_OK": GenVMErrorCode.LLM_PROVIDER_ERROR,
     "WEBPAGE_LOAD_FAILED": GenVMErrorCode.WEB_REQUEST_FAILED,
     "TLD_FORBIDDEN": GenVMErrorCode.WEB_TLD_FORBIDDEN,

--- a/backend/node/llm.lua
+++ b/backend/node/llm.lua
@@ -72,6 +72,25 @@ local function get_mock_response_from_table(table, message)
 	}
 end
 
+local function validate_prompt(mapped_prompt)
+	local prompt = mapped_prompt and mapped_prompt.prompt
+	local user_message = prompt and prompt.user_message
+	local images = prompt and prompt.images
+	local has_images = type(images) == "table" and next(images) ~= nil
+
+	if not has_images and (type(user_message) ~= "string" or string.match(user_message, "%S") == nil) then
+		lib.rs.user_error({
+			message = "exec_prompt requires a non-empty prompt",
+			causes = {"EMPTY_PROMPT"},
+			fatal = false,
+			ctx = {
+				reason = "empty_prompt",
+				format = mapped_prompt and mapped_prompt.format,
+			}
+		})
+	end
+end
+
 local function handle_custom_plugin(ctx, args, mapped_prompt)
 	local custom_plugin_data = ctx.host_data.custom_plugin_data
 	local content
@@ -255,6 +274,8 @@ end
 local function just_in_backend(ctx, args, mapped_prompt)
 	---@cast mapped_prompt MappedPrompt
 	---@cast args LLMExecPromptPayload | LLMExecPromptTemplatePayload
+
+	validate_prompt(mapped_prompt)
 
 	-- Return mock response if it exists and matches
 	if ctx.host_data.mock_response then

--- a/tests/db-sqlalchemy/test_finalization_starvation.py
+++ b/tests/db-sqlalchemy/test_finalization_starvation.py
@@ -69,6 +69,8 @@ def _insert_tx(
     consensus_data: dict | None = None,
     consensus_history: dict | None = None,
     blocked_at_offset_seconds: int | None = None,  # negative = past
+    worker_id: str | None = None,
+    recovery_count: int = 0,
 ):
     """Insert a transaction directly, bypassing TransactionsProcessor's
     PENDING-default and other defaults — we want full control over the row
@@ -88,7 +90,7 @@ def _insert_tx(
                 appeal_processing_time,
                 timestamp_awaiting_finalization,
                 consensus_data, consensus_history,
-                blocked_at, recovery_count, value_credited
+                blocked_at, worker_id, recovery_count, value_credited
             ) VALUES (
                 :hash, CAST(:status AS transaction_status), :from_addr, :to_addr,
                 CAST(:data AS jsonb), 0, 2, :nonce,
@@ -98,7 +100,7 @@ def _insert_tx(
                 0,
                 :timestamp_awaiting_finalization,
                 CAST(:consensus_data AS jsonb), CAST(:consensus_history AS jsonb),
-                {blocked_at_clause}, 0, false
+                {blocked_at_clause}, :worker_id, :recovery_count, false
             )
             """
         ),
@@ -120,6 +122,8 @@ def _insert_tx(
                 if consensus_history is None
                 else __import__("json").dumps(consensus_history)
             ),
+            "worker_id": worker_id,
+            "recovery_count": recovery_count,
         },
     )
     session.commit()
@@ -311,6 +315,87 @@ async def test_recover_still_resets_stuck_consensus_txs(
     assert row.status == TransactionStatus.PENDING.value
     assert row.recovery_count == 1
     assert row.consensus_data is None
+    assert row.consensus_history is None
+
+
+def test_direct_genvm_reset_increments_recovery_count(
+    engine: Engine, worker: ConsensusWorker, session: Session
+):
+    """The direct GenVM reset path must count as a recovery cycle.
+
+    Fatal leader GenVM errors call reset_transaction immediately instead of
+    waiting for recover_stuck_transactions. Without this increment, a poison
+    tx can be reset to PENDING forever and keep killing fresh workers.
+    """
+    _setup_contract(engine)
+    tx_hash = "0x" + "89" * 32
+
+    _insert_tx(
+        session,
+        tx_hash=tx_hash,
+        status="PROPOSING",
+        nonce=0,
+        consensus_data={"partial": True},
+        consensus_history={"attempts": [1]},
+        blocked_at_offset_seconds=0,
+        worker_id=worker.worker_id,
+    )
+
+    worker.reset_transaction(session, tx_hash)
+
+    row = session.execute(
+        text(
+            "SELECT status, recovery_count, blocked_at, worker_id, "
+            "consensus_data, consensus_history "
+            "FROM transactions WHERE hash = :h"
+        ),
+        {"h": tx_hash},
+    ).one()
+    assert row.status == TransactionStatus.PENDING.value
+    assert row.recovery_count == 1
+    assert row.blocked_at is None
+    assert row.worker_id is None
+    assert row.consensus_data is None
+    assert row.consensus_history is None
+
+
+def test_direct_genvm_reset_cancels_at_recovery_limit(
+    engine: Engine, worker: ConsensusWorker, session: Session
+):
+    """After the configured reset cap, direct GenVM recovery cancels the tx."""
+    _setup_contract(engine)
+    tx_hash = "0x" + "8a" * 32
+
+    _insert_tx(
+        session,
+        tx_hash=tx_hash,
+        status="PROPOSING",
+        nonce=0,
+        consensus_data={"partial": True},
+        consensus_history={"attempts": [1, 2, 3]},
+        blocked_at_offset_seconds=0,
+        worker_id=worker.worker_id,
+        recovery_count=worker._max_recovery_cycles - 1,
+    )
+
+    worker.reset_transaction(session, tx_hash)
+
+    row = session.execute(
+        text(
+            "SELECT status, recovery_count, blocked_at, worker_id, "
+            "consensus_data, consensus_history "
+            "FROM transactions WHERE hash = :h"
+        ),
+        {"h": tx_hash},
+    ).one()
+    assert row.status == TransactionStatus.CANCELED.value
+    assert row.recovery_count == worker._max_recovery_cycles
+    assert row.blocked_at is None
+    assert row.worker_id is None
+    assert row.consensus_data == {
+        "error": "max_recovery_cycles_exceeded",
+        "recovery_count": worker._max_recovery_cycles,
+    }
     assert row.consensus_history is None
 
 

--- a/tests/unit/test_error_codes.py
+++ b/tests/unit/test_error_codes.py
@@ -65,6 +65,15 @@ class TestExtractErrorCode:
         }
         assert extract_error_code(result_data) == GenVMErrorCode.LLM_NO_PROVIDER
 
+    def test_dict_with_empty_prompt_cause(self):
+        """Dict with EMPTY_PROMPT cause should return LLM_INVALID_PROMPT."""
+        result_data = {
+            "message": "exec_prompt requires a non-empty prompt",
+            "causes": ["EMPTY_PROMPT"],
+            "fatal": False,
+        }
+        assert extract_error_code(result_data) == GenVMErrorCode.LLM_INVALID_PROMPT
+
     def test_dict_with_status_429_in_ctx(self):
         """Dict with status 429 in ctx should return LLM_RATE_LIMITED."""
         result_data = {
@@ -200,6 +209,7 @@ class TestLuaCauseMapping:
         """All expected Lua causes should be in the mapping."""
         expected_causes = [
             "NO_PROVIDER_FOR_PROMPT",
+            "EMPTY_PROMPT",
             "STATUS_NOT_OK",
             "WEBPAGE_LOAD_FAILED",
             "TLD_FORBIDDEN",

--- a/tests/unit/test_llm_lua_prompt_validation.py
+++ b/tests/unit/test_llm_lua_prompt_validation.py
@@ -1,0 +1,126 @@
+import shutil
+import subprocess
+import textwrap
+from pathlib import Path
+
+import pytest
+
+
+def test_exec_prompt_rejects_blank_prompt_before_provider(tmp_path):
+    lua = shutil.which("lua")
+    if lua is None:
+        pytest.skip("lua interpreter not available")
+
+    (tmp_path / "lib-genvm.lua").write_text(
+        textwrap.dedent(
+            """
+            local lib = {}
+
+            function lib.log(_) end
+
+            function lib.get_first_from_table(table)
+              for key, value in pairs(table) do
+                return { key = key, value = value }
+              end
+              return nil
+            end
+
+            lib.rs = {}
+
+            function lib.rs.user_error(payload)
+              error(
+                payload.message
+                .. "|" .. payload.causes[1]
+                .. "|" .. tostring(payload.fatal),
+                0
+              )
+            end
+
+            function lib.rs.as_user_error(_) return nil end
+            function lib.rs.json_stringify(_) return "{}" end
+            function lib.rs.json_parse(_) return {} end
+
+            return lib
+            """
+        )
+    )
+    (tmp_path / "lib-llm.lua").write_text(
+        textwrap.dedent(
+            """
+            local llm = {}
+
+            llm.providers = {
+              ["provider-1"] = {
+                models = {
+                  ["model-1"] = {
+                    use_max_completion_tokens = false,
+                    meta = { config = {} },
+                  },
+                },
+              },
+            }
+            llm.overloaded_statuses = {}
+            llm.rs = {
+              templates = {},
+              exec_prompt_in_provider = function()
+                error("provider should not be called", 0)
+              end,
+            }
+
+            function llm.exec_prompt_transform(args)
+              return {
+                prompt = {
+                  user_message = args.prompt,
+                  images = {},
+                  max_tokens = 0,
+                  use_max_completion_tokens = false,
+                },
+                format = "text",
+              }
+            end
+
+            return llm
+            """
+        )
+    )
+
+    test_script = tmp_path / "test_empty_prompt.lua"
+    test_script.write_text(
+        textwrap.dedent(
+            f"""
+            package.path = [[{tmp_path}/?.lua;]] .. package.path
+            dofile([[{Path("backend/node/llm.lua").resolve()}]])
+
+            local function assert_rejected(prompt)
+              local ok, err = pcall(function()
+                ExecPrompt({{ host_data = {{ studio_llm_id = "provider-1" }} }}, {{ prompt = prompt }}, 0)
+              end)
+
+              if ok then
+                error("expected empty prompt to be rejected")
+              end
+              local err_str = tostring(err)
+              if not string.find(err_str, "exec_prompt requires a non-empty prompt", 1, true) then
+                error("missing empty prompt message: " .. err_str)
+              end
+              if not string.find(err_str, "EMPTY_PROMPT", 1, true) then
+                error("missing EMPTY_PROMPT cause: " .. err_str)
+              end
+              if not string.find(err_str, "false", 1, true) then
+                error("empty prompt should be non-fatal: " .. err_str)
+              end
+            end
+
+            assert_rejected("")
+            assert_rejected(" \\n\\t ")
+            """
+        )
+    )
+
+    subprocess.run(
+        [lua, str(test_script)],
+        cwd=Path(__file__).resolve().parents[2],
+        check=True,
+        capture_output=True,
+        text=True,
+    )


### PR DESCRIPTION
## Summary
- cap direct GenVM transaction resets so poison transactions cancel instead of looping workers
- reject empty/blank LLM prompts before provider dispatch with non-fatal EMPTY_PROMPT
- add regression coverage for reset cap and Studio LLM Lua prompt validation

## Testing
- luac -p backend/node/llm.lua
- .venv/bin/python -m pytest tests/unit/test_error_codes.py tests/unit/test_llm_lua_prompt_validation.py tests/unit/test_leader_llm_recovery.py tests/unit/test_worker_leader_crash_retry.py -q
- .venv/bin/python -m pytest tests/direct/test_error_llm_direct.py -q
- .venv/bin/python -m pytest tests/unit/test_worker_leader_crash_retry.py -q
- .venv/bin/python -m py_compile backend/consensus/worker.py tests/db-sqlalchemy/test_finalization_starvation.py

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automatic transaction recovery mechanism with configurable retry limits; transactions escalate to canceled state with error details after exceeding the limit.
  * Prompt validation that rejects empty or missing prompts before processing.

* **Bug Fixes**
  * Improved error handling and messaging for invalid prompt submissions.
  * Enhanced transaction state cleanup during recovery operations.

* **Tests**
  * Added test coverage for transaction recovery behavior and prompt validation logic.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/genlayerlabs/genlayer-studio/pull/1634?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->