### PR TITLE
fix: deprioritize recovered transaction claims

### DIFF
--- a/backend/consensus/worker.py
+++ b/backend/consensus/worker.py
@@ -456,7 +456,7 @@ class ConsensusWorker:
         query = text(
             """
             WITH candidate_transactions AS (
-                SELECT t.hash, t.to_address, t.type, t.created_at
+                SELECT t.hash, t.to_address, t.type, t.created_at, t.recovery_count
                 FROM transactions t
                 WHERE t.status IN ('PENDING', 'ACTIVATED')
                     AND (t.blocked_at IS NULL
@@ -511,11 +511,17 @@ class ConsensusWorker:
             ),
             single_transaction AS (
                 -- Select only ONE transaction (oldest across all contracts)
-                -- Upgrade transactions (type=3) are prioritized ahead of regular txs
+                -- Prefer transactions that have not already needed recovery, so
+                -- one repeatedly reset poison tx does not monopolize all workers.
+                -- Upgrade transactions (type=3) are prioritized ahead of regular
+                -- txs within each recovery class.
                 SELECT *
                 FROM oldest_per_contract
                 WHERE rn = 1
-                ORDER BY CASE WHEN type = 3 THEN 0 ELSE 1 END, created_at ASC
+                ORDER BY CASE WHEN recovery_count > 0 THEN 1 ELSE 0 END,
+                         CASE WHEN type = 3 THEN 0 ELSE 1 END,
+                         created_at ASC,
+                         hash ASC
                 LIMIT 1
             )
             UPDATE transactions

--- a/tests/db-sqlalchemy/test_finalization_starvation.py
+++ b/tests/db-sqlalchemy/test_finalization_starvation.py
@@ -17,6 +17,8 @@ These tests cover:
 3. recover_stuck_transactions preserves consensus_data for finalization-
    eligible statuses (ACCEPTED/UNDETERMINED/*_TIMEOUT).
 4. Safety-net log fires when an ACCEPTED tx's wait exceeds N×finality_window.
+5. Recovered PENDING txs are deprioritized across contracts so other
+   contracts keep making progress.
 """
 
 import time
@@ -41,12 +43,12 @@ CONTRACT_ADDRESS = "0xfinalization_starvation_test_contract"
 SENDER = "0x" + "ab" * 20
 
 
-def _setup_contract(engine: Engine):
+def _setup_contract(engine: Engine, contract_address: str = CONTRACT_ADDRESS):
     Session_ = sessionmaker(bind=engine)
     with Session_() as s:
         s.add(
             CurrentState(
-                id=CONTRACT_ADDRESS,
+                id=contract_address,
                 data={
                     "state": {
                         "accepted": {"slot": "init"},
@@ -69,6 +71,7 @@ def _insert_tx(
     consensus_data: dict | None = None,
     consensus_history: dict | None = None,
     blocked_at_offset_seconds: int | None = None,  # negative = past
+    created_at_offset_seconds: int | None = None,  # negative = past
     worker_id: str | None = None,
     recovery_count: int = 0,
 ):
@@ -78,6 +81,9 @@ def _insert_tx(
     blocked_at_clause = "NULL"
     if blocked_at_offset_seconds is not None:
         blocked_at_clause = f"NOW() + INTERVAL '{blocked_at_offset_seconds} seconds'"
+    created_at_clause = "NOW()"
+    if created_at_offset_seconds is not None:
+        created_at_clause = f"NOW() + INTERVAL '{created_at_offset_seconds} seconds'"
     session.execute(
         text(
             f"""
@@ -90,7 +96,8 @@ def _insert_tx(
                 appeal_processing_time,
                 timestamp_awaiting_finalization,
                 consensus_data, consensus_history,
-                blocked_at, worker_id, recovery_count, value_credited
+                blocked_at, worker_id, recovery_count, value_credited,
+                created_at
             ) VALUES (
                 :hash, CAST(:status AS transaction_status), :from_addr, :to_addr,
                 CAST(:data AS jsonb), 0, 2, :nonce,
@@ -100,7 +107,8 @@ def _insert_tx(
                 0,
                 :timestamp_awaiting_finalization,
                 CAST(:consensus_data AS jsonb), CAST(:consensus_history AS jsonb),
-                {blocked_at_clause}, :worker_id, :recovery_count, false
+                {blocked_at_clause}, :worker_id, :recovery_count, false,
+                {created_at_clause}
             )
             """
         ),
@@ -234,6 +242,46 @@ async def test_claim_next_transaction_proceeds_when_finalization_window_not_yet_
 
     assert claimed is not None
     assert claimed["hash"] == "0x" + "55" * 32
+
+
+@pytest.mark.asyncio
+async def test_claim_next_transaction_prefers_unrecovered_contract_head(
+    engine: Engine, worker: ConsensusWorker, session: Session
+):
+    """A recovered old tx should not monopolize the global worker queue when
+    another contract has fresh work ready. Contract-local ordering still holds
+    because only the head tx from each contract is considered."""
+    recovered_contract = CONTRACT_ADDRESS
+    fresh_contract = "0xclaim_recovery_fresh_contract"
+    _setup_contract(engine, recovered_contract)
+    _setup_contract(engine, fresh_contract)
+
+    recovered_hash = "0x" + "56" * 32
+    fresh_hash = "0x" + "57" * 32
+
+    _insert_tx(
+        session,
+        tx_hash=recovered_hash,
+        status="PENDING",
+        nonce=0,
+        recovery_count=1,
+        created_at_offset_seconds=-600,
+        to_address=recovered_contract,
+    )
+    _insert_tx(
+        session,
+        tx_hash=fresh_hash,
+        status="PENDING",
+        nonce=0,
+        recovery_count=0,
+        created_at_offset_seconds=-60,
+        to_address=fresh_contract,
+    )
+
+    claimed = await worker.claim_next_transaction(session)
+
+    assert claimed is not None
+    assert claimed["hash"] == fresh_hash
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- prefer unrecovered contract-head transactions when selecting global worker claims
- keep per-contract ordering and upgrade priority within each recovery class
- add db-sqlalchemy regression coverage for recovered txs not monopolizing the queue

## Tests
- .venv/bin/python -m py_compile backend/consensus/worker.py tests/db-sqlalchemy/test_finalization_starvation.py
- git diff --check
- .venv/bin/python -m black --check backend/consensus/worker.py tests/db-sqlalchemy/test_finalization_starvation.py
- .venv/bin/python -m pytest tests/unit/test_worker_leader_crash_retry.py tests/unit/test_leader_llm_recovery.py -q

Note: Docker is not running on this remote, so the new db-sqlalchemy Postgres test could not be run locally; it should run in CI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced transaction processing fairness by prioritizing fresher transactions over previously attempted ones, preventing resource monopolization in multi-contract environments.

* **Tests**
  * Extended test coverage to validate fair transaction selection behavior across multiple contract deployments.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/genlayerlabs/genlayer-studio/pull/1635?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->