### PR TITLE
fix: detect consensus alert outage patterns

### DIFF
--- a/backend/protocol_rpc/endpoints.py
+++ b/backend/protocol_rpc/endpoints.py
@@ -296,43 +296,52 @@ def reset_defaults_llm_providers(llm_provider_registry: LLMProviderRegistry) -> 
 async def check_provider_is_available(
     genvm_manager: GenVMManager, provider: LLMProvider | dict
 ) -> bool:
-    if isinstance(provider, LLMProvider):
-        model = provider.model
-        url = provider.plugin_config["api_url"]
-        plugin = provider.plugin
-        key = provider.plugin_config["api_key_env_var"]
-        temperature = provider.config.get("temperature", 1)
-        use_max_completion_tokens = provider.config.get(
-            "use_max_completion_tokens", False
+    try:
+        if isinstance(provider, LLMProvider):
+            model = provider.model
+            url = provider.plugin_config["api_url"]
+            plugin = provider.plugin
+            key = provider.plugin_config["api_key_env_var"]
+            temperature = provider.config.get("temperature", 1)
+            use_max_completion_tokens = provider.config.get(
+                "use_max_completion_tokens", False
+            )
+        else:
+            model = provider["model"]
+            url = provider["plugin_config"]["api_url"]
+            plugin = provider["plugin"]
+            key = provider["plugin_config"]["api_key_env_var"]
+            temperature = provider["config"].get("temperature", 1)
+            use_max_completion_tokens = provider["config"].get(
+                "use_max_completion_tokens", False
+            )
+        key = f"${{ENV[{key}]}}"
+        res = await genvm_manager.try_llms(
+            [
+                {
+                    "host": url,
+                    "model": model,
+                    "provider": plugin,
+                    "key": key,
+                }
+            ],
+            prompt={
+                "system_message": "",
+                "user_message": "respond with two letters 'ok' and nothing else. No quotes, no repetition",
+                "temperature": temperature,
+                "max_tokens": 500,
+                "use_max_completion_tokens": use_max_completion_tokens,
+                "images": [],
+            },
         )
-    else:
-        model = provider["model"]
-        url = provider["plugin_config"]["api_url"]
-        plugin = provider["plugin"]
-        key = provider["plugin_config"]["api_key_env_var"]
-        temperature = provider["config"].get("temperature", 1)
-        use_max_completion_tokens = provider["config"].get(
-            "use_max_completion_tokens", False
+    except Exception as exc:
+        genvm_manager.logger.error(
+            "LLM provider availability check failed",
+            provider=provider,
+            error=str(exc),
         )
-    key = f"${{ENV[{key}]}}"
-    res = await genvm_manager.try_llms(
-        [
-            {
-                "host": url,
-                "model": model,
-                "provider": plugin,
-                "key": key,
-            }
-        ],
-        prompt={
-            "system_message": "",
-            "user_message": "respond with two letters 'ok' and nothing else. No quotes, no repetition",
-            "temperature": temperature,
-            "max_tokens": 500,
-            "use_max_completion_tokens": use_max_completion_tokens,
-            "images": [],
-        },
-    )
+        return False
+
     if len(res) != 1:
         genvm_manager.logger.error(
             f"LLM provider check failed", provider=provider, result=res

--- a/backend/protocol_rpc/health.py
+++ b/backend/protocol_rpc/health.py
@@ -259,6 +259,17 @@ async def _run_health_checks() -> None:
             "stuck_finalization_count": consensus_health.get(
                 "stuck_finalization_count", 0
             ),
+            "recovery_storm_count": consensus_health.get("recovery_storm_count", 0),
+            "max_recovery_count": consensus_health.get("max_recovery_count", 0),
+            "no_consensus_progress": consensus_health.get(
+                "no_consensus_progress", False
+            ),
+            "no_progress_backlog_count": consensus_health.get(
+                "no_progress_backlog_count", 0
+            ),
+            "seconds_since_consensus_progress": consensus_health.get(
+                "seconds_since_consensus_progress"
+            ),
             "active_workers": consensus_health.get("active_workers", 0),
             "status": consensus_status,
         }
@@ -275,6 +286,14 @@ async def _run_health_checks() -> None:
                 if overall_status == "healthy":
                     overall_status = "degraded"
                 issues.append("stuck_finalizations")
+            if consensus_health.get("recovery_storm_count", 0) > 0:
+                if overall_status == "healthy":
+                    overall_status = "degraded"
+                issues.append("transaction_recovery_storm")
+            if consensus_health.get("no_consensus_progress", False):
+                if overall_status == "healthy":
+                    overall_status = "degraded"
+                issues.append("no_consensus_progress")
 
         # 3. LLM provider health (per-provider failure-rate detection)
         # Catches cases like a provider returning HTTP 402 / "tier required"
@@ -566,6 +585,13 @@ async def _check_consensus_health() -> Dict[str, Any]:
     DEGRADED_AT_STUCK_FINALIZATIONS = int(
         os.environ.get("HEALTH_DEGRADED_AT_STUCK_FINALIZATIONS", "3")
     )
+    NO_PROGRESS_WINDOW_MINUTES = int(
+        os.environ.get("HEALTH_NO_PROGRESS_WINDOW_MINUTES", "30")
+    )
+    NO_PROGRESS_MIN_BACKLOG = int(os.environ.get("HEALTH_NO_PROGRESS_MIN_BACKLOG", "3"))
+    RECOVERY_STORM_MIN_RECOVERIES = int(
+        os.environ.get("HEALTH_RECOVERY_STORM_MIN_RECOVERIES", "2")
+    )
 
     # Statuses where the consensus state machine is actively working.
     # The "head of queue stuck" check uses ONLY these: ACCEPTED-class
@@ -582,6 +608,9 @@ async def _check_consensus_health() -> Dict[str, Any]:
     )
     FINALIZATION_ELIGIBLE_STATUSES_SQL = (
         "'ACCEPTED','UNDETERMINED','LEADER_TIMEOUT','VALIDATORS_TIMEOUT'"
+    )
+    PRE_CONSENSUS_BACKLOG_STATUSES_SQL = (
+        "'PENDING','ACTIVATED','PROPOSING','COMMITTING','REVEALING'"
     )
 
     try:
@@ -690,6 +719,126 @@ async def _check_consensus_health() -> Dict[str, Any]:
                 ).fetchone()
                 stuck_finalization_count = stuck_fin_row.n if stuck_fin_row else 0
 
+                # Recovery storm: a non-terminal transaction that has already
+                # been reset several times is a high-confidence poison-tx
+                # signal. This catches the crash-loop pattern even when each
+                # individual retry creates fresh blocked_at activity and masks
+                # the stuck-head detector.
+                recovery_row = conn.execute(
+                    text(
+                        f"""
+                        SELECT
+                            COUNT(*) AS n,
+                            COALESCE(MAX(recovery_count), 0) AS max_recovery_count
+                        FROM transactions
+                        WHERE status IN ({PRE_CONSENSUS_BACKLOG_STATUSES_SQL})
+                          AND recovery_count >= :min_recoveries
+                        """
+                    ),
+                    {"min_recoveries": RECOVERY_STORM_MIN_RECOVERIES},
+                ).fetchone()
+                recovery_storm_count = recovery_row.n if recovery_row else 0
+                max_recovery_count = (
+                    recovery_row.max_recovery_count if recovery_row else 0
+                )
+
+                # No-progress detector: if there is an old pre-consensus
+                # backlog and nothing has reached ACCEPTED/FINALIZED recently,
+                # workers may be busy but not producing outcomes. This is
+                # intentionally backlog-age gated to avoid alerting on normal
+                # short bursts or a single fresh long-running transaction.
+                progress_row = conn.execute(
+                    text(
+                        f"""
+                        WITH backlog AS (
+                            SELECT
+                                COUNT(*) AS backlog_count,
+                                MIN(created_at) AS oldest_created_at
+                            FROM transactions
+                            WHERE status IN ({PRE_CONSENSUS_BACKLOG_STATUSES_SQL})
+                        ),
+                        progress AS (
+                            SELECT
+                                MAX(
+                                    GREATEST(
+                                        COALESCE(
+                                            CASE
+                                                WHEN consensus_history
+                                                     -> 'current_monitoring'
+                                                     ->> 'ACCEPTED'
+                                                     ~ '^[0-9]+(\\.[0-9]+)?$'
+                                                THEN (
+                                                    consensus_history
+                                                    -> 'current_monitoring'
+                                                    ->> 'ACCEPTED'
+                                                )::double precision
+                                            END,
+                                            0
+                                        ),
+                                        COALESCE(
+                                            CASE
+                                                WHEN consensus_history
+                                                     -> 'current_monitoring'
+                                                     ->> 'FINALIZED'
+                                                     ~ '^[0-9]+(\\.[0-9]+)?$'
+                                                THEN (
+                                                    consensus_history
+                                                    -> 'current_monitoring'
+                                                    ->> 'FINALIZED'
+                                                )::double precision
+                                            END,
+                                            0
+                                        )
+                                    )
+                                ) AS last_progress_epoch
+                            FROM transactions
+                            WHERE consensus_history IS NOT NULL
+                        )
+                        SELECT
+                            backlog.backlog_count,
+                            EXTRACT(
+                                EPOCH FROM (NOW() - backlog.oldest_created_at)
+                            )::bigint AS oldest_backlog_age_seconds,
+                            COALESCE(progress.last_progress_epoch, 0)
+                                AS last_progress_epoch,
+                            CASE
+                                WHEN COALESCE(progress.last_progress_epoch, 0) > 0
+                                THEN (
+                                    EXTRACT(EPOCH FROM NOW())
+                                    - progress.last_progress_epoch
+                                )::bigint
+                                ELSE NULL
+                            END AS seconds_since_progress
+                        FROM backlog
+                        CROSS JOIN progress
+                        """
+                    )
+                ).fetchone()
+
+                no_progress_window_seconds = NO_PROGRESS_WINDOW_MINUTES * 60
+                no_progress_backlog_count = (
+                    progress_row.backlog_count if progress_row else 0
+                )
+                oldest_backlog_age_seconds = (
+                    progress_row.oldest_backlog_age_seconds if progress_row else None
+                )
+                seconds_since_consensus_progress = (
+                    progress_row.seconds_since_progress if progress_row else None
+                )
+                last_progress_epoch = (
+                    progress_row.last_progress_epoch if progress_row else 0
+                )
+                no_recent_progress = not last_progress_epoch or (
+                    seconds_since_consensus_progress is not None
+                    and seconds_since_consensus_progress > no_progress_window_seconds
+                )
+                no_consensus_progress = (
+                    no_progress_backlog_count >= NO_PROGRESS_MIN_BACKLOG
+                    and oldest_backlog_age_seconds is not None
+                    and oldest_backlog_age_seconds > no_progress_window_seconds
+                    and no_recent_progress
+                )
+
                 # Total in-flight (non-final) tx count, for context.
                 # Consensus-active only — finalization-pending rows
                 # are tracked separately via stuck_finalization_count.
@@ -710,6 +859,8 @@ async def _check_consensus_health() -> Dict[str, Any]:
                     if (
                         stuck_head_contracts >= DEGRADED_AT_STUCK_HEADS
                         or stuck_finalization_count >= DEGRADED_AT_STUCK_FINALIZATIONS
+                        or recovery_storm_count > 0
+                        or no_consensus_progress
                     )
                     else "healthy"
                 )
@@ -722,6 +873,15 @@ async def _check_consensus_health() -> Dict[str, Any]:
                     # whose consensus head is stuck.
                     "total_orphaned_transactions": stuck_head_contracts,
                     "stuck_finalization_count": stuck_finalization_count,
+                    "recovery_storm_count": recovery_storm_count,
+                    "max_recovery_count": max_recovery_count,
+                    "no_consensus_progress": no_consensus_progress,
+                    "no_progress_backlog_count": no_progress_backlog_count,
+                    "oldest_backlog_age_seconds": oldest_backlog_age_seconds,
+                    "seconds_since_consensus_progress": (
+                        seconds_since_consensus_progress
+                    ),
+                    "no_progress_window_minutes": NO_PROGRESS_WINDOW_MINUTES,
                     "active_workers": active_workers_count,
                 }
 

--- a/tests/db-sqlalchemy/test_health_orphan_detection.py
+++ b/tests/db-sqlalchemy/test_health_orphan_detection.py
@@ -23,6 +23,7 @@ The head is "stuck" when:
 this state, not the count of in-flight txs in tail of queues.
 """
 
+import json
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 
@@ -70,6 +71,8 @@ def _insert_tx(
     blocked_at: datetime | None = None,
     worker_id: str | None = None,
     timestamp_awaiting_finalization: int | None = None,
+    recovery_count: int = 0,
+    consensus_history: dict | None = None,
 ):
     """Direct INSERT — bypass the processor so we can backdate created_at."""
     session.execute(
@@ -81,13 +84,15 @@ def _insert_tx(
                 appeal_undetermined, appeal_leader_timeout,
                 appeal_validators_timeout, appeal_processing_time,
                 recovery_count, value_credited,
+                consensus_history,
                 created_at, blocked_at, worker_id,
                 timestamp_awaiting_finalization
             ) VALUES (
                 :hash, CAST(:status AS transaction_status),
                 '0xfromaddress', :to_addr, CAST('{}' AS jsonb), 0, 2,
                 :nonce, false, 'NORMAL', false, 0,
-                false, false, false, 0, 0, false,
+                false, false, false, 0, :recovery_count, false,
+                CAST(:consensus_history AS jsonb),
                 :created_at, :blocked_at, :worker_id,
                 :timestamp_awaiting_finalization
             )
@@ -102,6 +107,10 @@ def _insert_tx(
             "blocked_at": blocked_at,
             "worker_id": worker_id,
             "timestamp_awaiting_finalization": timestamp_awaiting_finalization,
+            "recovery_count": recovery_count,
+            "consensus_history": (
+                json.dumps(consensus_history) if consensus_history is not None else None
+            ),
         },
     )
 
@@ -587,3 +596,116 @@ async def test_stuck_finalization_flips_status_at_threshold(engine: Engine):
     assert (
         result["status"] == "degraded"
     ), f"3 stuck finalizations must flip consensus.status. Got: {result}"
+
+
+@pytest.mark.asyncio
+async def test_recovery_storm_flags_poison_transaction(
+    engine: Engine, monkeypatch: pytest.MonkeyPatch
+):
+    """A tx that has been recovered repeatedly is a high-confidence
+    poison-tx signal even when blocked_at keeps looking fresh."""
+    monkeypatch.setenv("HEALTH_RECOVERY_STORM_MIN_RECOVERIES", "2")
+
+    Session_ = sessionmaker(bind=engine, expire_on_commit=False)
+    now = datetime.now(timezone.utc)
+
+    with Session_() as s:
+        _insert_tx(
+            s,
+            tx_hash="0x" + "aa" * 32,
+            to_address="0x" + "aa" * 20,
+            status="PENDING",
+            nonce=0,
+            created_at=now - timedelta(minutes=1),
+            recovery_count=2,
+        )
+        s.commit()
+
+    from backend.protocol_rpc import health as health_module
+
+    result = await health_module._check_consensus_health()
+
+    assert result["recovery_storm_count"] == 1
+    assert result["max_recovery_count"] == 2
+    assert result["status"] == "degraded"
+
+
+@pytest.mark.asyncio
+async def test_old_backlog_without_recent_progress_is_flagged(
+    engine: Engine, monkeypatch: pytest.MonkeyPatch
+):
+    """If an old backlog exists and no tx has reached ACCEPTED/FINALIZED
+    recently, consensus is not producing outcomes."""
+    monkeypatch.setenv("HEALTH_NO_PROGRESS_WINDOW_MINUTES", "10")
+    monkeypatch.setenv("HEALTH_NO_PROGRESS_MIN_BACKLOG", "3")
+
+    Session_ = sessionmaker(bind=engine, expire_on_commit=False)
+    now = datetime.now(timezone.utc)
+
+    with Session_() as s:
+        for i in range(3):
+            _insert_tx(
+                s,
+                tx_hash=f"0xb0{i:062x}",
+                to_address="0x" + "b0" * 20,
+                status="PENDING",
+                nonce=i,
+                created_at=now - timedelta(minutes=20 + i),
+            )
+        s.commit()
+
+    from backend.protocol_rpc import health as health_module
+
+    result = await health_module._check_consensus_health()
+
+    assert result["no_consensus_progress"] is True
+    assert result["no_progress_backlog_count"] == 3
+    assert result["status"] == "degraded"
+
+
+@pytest.mark.asyncio
+async def test_recent_consensus_progress_suppresses_no_progress_alert(
+    engine: Engine, monkeypatch: pytest.MonkeyPatch
+):
+    """A fresh ACCEPTED/FINALIZED timestamp means the queue is draining,
+    even if an older backlog still exists."""
+    import time
+
+    monkeypatch.setenv("HEALTH_NO_PROGRESS_WINDOW_MINUTES", "10")
+    monkeypatch.setenv("HEALTH_NO_PROGRESS_MIN_BACKLOG", "3")
+
+    Session_ = sessionmaker(bind=engine, expire_on_commit=False)
+    now = datetime.now(timezone.utc)
+
+    with Session_() as s:
+        for i in range(3):
+            _insert_tx(
+                s,
+                tx_hash=f"0xc0{i:062x}",
+                to_address="0x" + "c0" * 20,
+                status="PENDING",
+                nonce=i,
+                created_at=now - timedelta(minutes=20 + i),
+            )
+        _insert_tx(
+            s,
+            tx_hash="0x" + "c1" * 32,
+            to_address="0x" + "c1" * 20,
+            status="FINALIZED",
+            nonce=99,
+            created_at=now - timedelta(minutes=1),
+            consensus_history={
+                "current_monitoring": {
+                    "ACCEPTED": time.time(),
+                    "FINALIZED": time.time(),
+                }
+            },
+        )
+        s.commit()
+
+    from backend.protocol_rpc import health as health_module
+
+    result = await health_module._check_consensus_health()
+
+    assert result["no_consensus_progress"] is False
+    assert result["no_progress_backlog_count"] == 3

--- a/tests/integration/test_upgrade_contract.py
+++ b/tests/integration/test_upgrade_contract.py
@@ -13,6 +13,7 @@ Run with containers up:
     .venv/bin/pytest tests/integration/test_upgrade_contract.py -xvs
 """
 
+import os
 import time
 import requests
 import pytest
@@ -38,9 +39,11 @@ def ensure_validators_exist():
     validators = response.get("result", [])
 
     if not validators:
-        # Create validators if none exist (using same approach as icontracts tests)
+        # Match the provider/model configured by CI or the local test env.
+        provider = os.environ.get("TEST_PROVIDER", "openai")
+        model = os.environ.get("TEST_PROVIDER_MODEL", "gpt-4o")
         result = post_request_localhost(
-            payload("sim_createRandomValidators", 5, 8, 12, ["openai"], ["gpt-4o"])
+            payload("sim_createRandomValidators", 5, 8, 12, [provider], [model])
         ).json()
         if not has_success_status(result):
             pytest.fail(f"Failed to create validators: {result}")

--- a/tests/integration/test_upgrade_contract.py
+++ b/tests/integration/test_upgrade_contract.py
@@ -22,6 +22,11 @@ from genlayer_py import create_client, create_account, localnet
 
 RPC_URL = "http://localhost:4000/api"
 
+# Upgrade tests rely on the global validator registry for deploy/read/upgrade.
+# Keep them on the same xdist worker as icontract tests that temporarily wipe
+# validators while seeding mock responses.
+pytestmark = pytest.mark.xdist_group(name="mock_validators")
+
 
 @pytest.fixture(scope="module", autouse=True)
 def ensure_validators_exist():

--- a/tests/unit/test_llm_provider_availability.py
+++ b/tests/unit/test_llm_provider_availability.py
@@ -1,0 +1,52 @@
+from unittest.mock import MagicMock
+
+import pytest
+
+from backend.protocol_rpc import endpoints
+
+
+class FakeLLMProviderRegistry:
+    async def get_all_dict(self):
+        return [
+            {
+                "provider": "bad-provider",
+                "model": "bad-model",
+                "config": {},
+                "plugin": "openai-compatible",
+                "plugin_config": {
+                    "api_key_env_var": "BAD_KEY",
+                    "api_url": "https://example.invalid/api",
+                },
+            },
+            {
+                "provider": "good-provider",
+                "model": "good-model",
+                "config": {},
+                "plugin": "openai-compatible",
+                "plugin_config": {
+                    "api_key_env_var": "GOOD_KEY",
+                    "api_url": "https://example.test/api",
+                },
+            },
+        ]
+
+
+class FakeGenVMManager:
+    def __init__(self):
+        self.logger = MagicMock()
+
+    async def try_llms(self, providers, prompt):
+        if providers[0]["model"] == "bad-model":
+            raise RuntimeError("provider unavailable")
+        return [{"response": "ok"}]
+
+
+@pytest.mark.asyncio
+async def test_get_providers_and_models_marks_failed_checks_unavailable():
+    providers = await endpoints.get_providers_and_models(
+        FakeLLMProviderRegistry(),
+        FakeGenVMManager(),
+    )
+
+    assert providers[0]["is_model_available"] is False
+    assert providers[1]["is_model_available"] is True


### PR DESCRIPTION
Summary:
- add transaction_recovery_storm when non-terminal txs hit repeated recovery_count resets
- add no_consensus_progress for old pre-consensus backlog with no recent ACCEPTED/FINALIZED progress
- include the new consensus health fields and issue tags in the health payload
- add DB regression coverage for recovery storms, no-progress detection, and recent-progress suppression

Tests:
- .venv/bin/python -m py_compile backend/protocol_rpc/health.py tests/db-sqlalchemy/test_health_orphan_detection.py
- .venv/bin/python -m black --check backend/protocol_rpc/health.py tests/db-sqlalchemy/test_health_orphan_detection.py
- git diff --check
- .venv/bin/python -m pytest tests/db-sqlalchemy/test_health_orphan_detection.py -q (not run locally: POSTGRES_URL is not set)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced consensus health monitoring with two new detectors; health endpoint now reports related metrics, backlog counts, time-since-progress, and lists corresponding issues when triggered.

* **Bug Fixes / Reliability**
  * Provider availability checks now handle unexpected errors gracefully, avoiding exceptions from propagating.

* **Tests**
  * Added regression and unit tests for the new health alerts and provider availability; integration test adjusted for validator creation environment.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/genlayerlabs/genlayer-studio/pull/1636?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->