### PR TITLE
fix: initialize genvm health before alert checks

### DIFF
--- a/backend/protocol_rpc/endpoints.py
+++ b/backend/protocol_rpc/endpoints.py
@@ -316,23 +316,29 @@ async def check_provider_is_available(
                 "use_max_completion_tokens", False
             )
         key = f"${{ENV[{key}]}}"
-        res = await genvm_manager.try_llms(
-            [
-                {
-                    "host": url,
-                    "model": model,
-                    "provider": plugin,
-                    "key": key,
-                }
-            ],
-            prompt={
-                "system_message": "",
-                "user_message": "respond with two letters 'ok' and nothing else. No quotes, no repetition",
-                "temperature": temperature,
-                "max_tokens": 500,
-                "use_max_completion_tokens": use_max_completion_tokens,
-                "images": [],
-            },
+        timeout_s = float(
+            os.environ.get("LLM_PROVIDER_AVAILABILITY_TIMEOUT_SECONDS", "20")
+        )
+        res = await asyncio.wait_for(
+            genvm_manager.try_llms(
+                [
+                    {
+                        "host": url,
+                        "model": model,
+                        "provider": plugin,
+                        "key": key,
+                    }
+                ],
+                prompt={
+                    "system_message": "",
+                    "user_message": "respond with two letters 'ok' and nothing else. No quotes, no repetition",
+                    "temperature": temperature,
+                    "max_tokens": 500,
+                    "use_max_completion_tokens": use_max_completion_tokens,
+                    "images": [],
+                },
+            ),
+            timeout=timeout_s,
         )
     except Exception as exc:
         genvm_manager.logger.error(

--- a/backend/protocol_rpc/health.py
+++ b/backend/protocol_rpc/health.py
@@ -221,6 +221,49 @@ def get_health_check_interval() -> float:
     return float(os.getenv("HEALTH_CHECK_INTERVAL_SECONDS", "10"))
 
 
+def _update_genvm_health_cache(
+    services: Dict[str, Any],
+    genvm_ok: bool,
+    genvm_error: Optional[str],
+    genvm_status: Dict[str, Any],
+) -> None:
+    services["genvm"] = {"status": "healthy" if genvm_ok else "unhealthy"}
+    _health_cache.genvm_healthy = genvm_ok
+    _health_cache.genvm_error = genvm_error
+
+    # Best-effort parse of permit info from /status.
+    # The manager returns: {"permits": {"current": N, "max": M}, "executions": {...}}
+    # where permits.current = available permits (semaphore value).
+    try:
+        permits_obj = genvm_status.get("permits") or {}
+        executions_obj = genvm_status.get("executions")
+
+        max_permits_i = int(permits_obj["max"]) if "max" in permits_obj else None
+        # permits.current IS the available count (semaphore value)
+        available_i = int(permits_obj["current"]) if "current" in permits_obj else None
+        active_i = len(executions_obj) if isinstance(executions_obj, dict) else None
+
+        _health_cache.genvm_max_permits = max_permits_i
+        _health_cache.genvm_available_permits = available_i
+        _health_cache.genvm_current_permits = active_i  # in-use count
+        _health_cache.genvm_active_executions = active_i
+
+        services["genvm"].update(
+            {
+                "max_permits": max_permits_i,
+                "available_permits": available_i,
+                "current_permits": active_i,
+                "active_executions": active_i,
+            }
+        )
+    except Exception as e:
+        logger.debug(f"Failed to parse GenVM permit info from /status: {e}")
+        _health_cache.genvm_max_permits = None
+        _health_cache.genvm_current_permits = None
+        _health_cache.genvm_available_permits = None
+        _health_cache.genvm_active_executions = None
+
+
 async def _run_health_checks() -> None:
     """Run all expensive health checks and update cache."""
     global _health_cache
@@ -231,7 +274,13 @@ async def _run_health_checks() -> None:
     services = {}
 
     try:
-        # 1. Database health
+        # 1. GenVM manager health. Keep readiness-critical state independent
+        # from slower dashboard/alert queries so new pods can become ready once
+        # their local GenVM manager is responsive.
+        genvm_ok, genvm_error, genvm_status = await _check_genvm_health()
+        _update_genvm_health_cache(services, genvm_ok, genvm_error, genvm_status)
+
+        # 2. Database health
         db_health = await _check_database_health()
         db_status = db_health.get("status", "unknown")
         services["database"] = {
@@ -246,7 +295,7 @@ async def _run_health_checks() -> None:
             if overall_status == "healthy":
                 overall_status = "degraded"
 
-        # 2. Consensus health
+        # 3. Consensus health
         consensus_health = await _check_consensus_health()
         consensus_status = consensus_health.get("status", "unknown")
         services["consensus"] = {
@@ -295,7 +344,7 @@ async def _run_health_checks() -> None:
                     overall_status = "degraded"
                 issues.append("no_consensus_progress")
 
-        # 3. LLM provider health (per-provider failure-rate detection)
+        # 4. LLM provider health (per-provider failure-rate detection)
         # Catches cases like a provider returning HTTP 402 / "tier required"
         # for every call from a specific (provider, model) entry — the
         # actual cause behind a recent stuck-shard incident that the
@@ -315,7 +364,7 @@ async def _run_health_checks() -> None:
                 overall_status = "degraded"
             issues.append("llm_provider_failure")
 
-        # 4. Memory health
+        # 5. Memory health
         memory_health = await _check_memory_health()
         memory_status = memory_health.get("status", "unknown")
         services["memory"] = {
@@ -329,53 +378,13 @@ async def _run_health_checks() -> None:
                 overall_status = "degraded"
             issues.append("memory_issue")
 
-        # 5. Redis health
+        # 6. Redis health
         redis_status = await _check_redis_health()
         services["redis"] = redis_status
         if redis_status == "unhealthy":
             if overall_status == "healthy":
                 overall_status = "degraded"
             issues.append("redis_unreachable")
-
-        # 6. GenVM manager health (+ capacity details when available)
-        genvm_ok, genvm_error, genvm_status = await _check_genvm_health()
-        services["genvm"] = {"status": "healthy" if genvm_ok else "unhealthy"}
-        _health_cache.genvm_healthy = genvm_ok
-        _health_cache.genvm_error = genvm_error
-
-        # Best-effort parse of permit info from /status.
-        # The manager returns: {"permits": {"current": N, "max": M}, "executions": {...}}
-        # where permits.current = available permits (semaphore value).
-        try:
-            permits_obj = genvm_status.get("permits") or {}
-            executions_obj = genvm_status.get("executions")
-
-            max_permits_i = int(permits_obj["max"]) if "max" in permits_obj else None
-            # permits.current IS the available count (semaphore value)
-            available_i = (
-                int(permits_obj["current"]) if "current" in permits_obj else None
-            )
-            active_i = len(executions_obj) if isinstance(executions_obj, dict) else None
-
-            _health_cache.genvm_max_permits = max_permits_i
-            _health_cache.genvm_available_permits = available_i
-            _health_cache.genvm_current_permits = active_i  # in-use count
-            _health_cache.genvm_active_executions = active_i
-
-            services["genvm"].update(
-                {
-                    "max_permits": max_permits_i,
-                    "available_permits": available_i,
-                    "current_permits": active_i,
-                    "active_executions": active_i,
-                }
-            )
-        except Exception as e:
-            logger.debug(f"Failed to parse GenVM permit info from /status: {e}")
-            _health_cache.genvm_max_permits = None
-            _health_cache.genvm_current_permits = None
-            _health_cache.genvm_available_permits = None
-            _health_cache.genvm_active_executions = None
 
         # 7. Aggregate counts for metrics
         decisions_count, users_count, pending_count = await _get_aggregate_counts()

--- a/tests/unit/test_llm_provider_availability.py
+++ b/tests/unit/test_llm_provider_availability.py
@@ -1,3 +1,4 @@
+import asyncio
 from unittest.mock import MagicMock
 
 import pytest
@@ -41,6 +42,15 @@ class FakeGenVMManager:
         return [{"response": "ok"}]
 
 
+class SlowGenVMManager:
+    def __init__(self):
+        self.logger = MagicMock()
+
+    async def try_llms(self, providers, prompt):
+        await asyncio.sleep(1)
+        return [{"response": "ok"}]
+
+
 @pytest.mark.asyncio
 async def test_get_providers_and_models_marks_failed_checks_unavailable():
     providers = await endpoints.get_providers_and_models(
@@ -50,3 +60,26 @@ async def test_get_providers_and_models_marks_failed_checks_unavailable():
 
     assert providers[0]["is_model_available"] is False
     assert providers[1]["is_model_available"] is True
+
+
+@pytest.mark.asyncio
+async def test_provider_availability_timeout_returns_unavailable(monkeypatch):
+    monkeypatch.setenv("LLM_PROVIDER_AVAILABILITY_TIMEOUT_SECONDS", "0.01")
+    manager = SlowGenVMManager()
+
+    available = await endpoints.check_provider_is_available(
+        manager,
+        {
+            "provider": "slow-provider",
+            "model": "slow-model",
+            "config": {},
+            "plugin": "openai-compatible",
+            "plugin_config": {
+                "api_key_env_var": "SLOW_KEY",
+                "api_url": "https://example.test/api",
+            },
+        },
+    )
+
+    assert available is False
+    manager.logger.error.assert_called_once()

--- a/tests/unit/test_rpc_health_genvm_tracking.py
+++ b/tests/unit/test_rpc_health_genvm_tracking.py
@@ -4,7 +4,7 @@ Mirrors test_worker_health_degradation.py pattern for jsonrpc process.
 """
 
 import pytest
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch, MagicMock, AsyncMock
 
 import backend.protocol_rpc.health as health_module
 
@@ -172,6 +172,111 @@ class TestReadinessWithExecutionFailures:
         payload = json.loads(response.body.decode())
         assert payload["status"] == "not_ready"
         assert payload["rpc_router_initialized"] is False
+
+
+class TestBackgroundHealthGenVMOrdering:
+    """GenVM readiness state must be initialized before slower alert queries."""
+
+    def setup_method(self):
+        health_module._health_cache = health_module.HealthCache()
+        health_module._genvm_consecutive_failures = 0
+
+    @pytest.mark.asyncio
+    async def test_genvm_cache_updates_before_database_and_consensus_checks(
+        self, monkeypatch
+    ):
+        events = []
+
+        async def fake_genvm_health():
+            events.append("genvm")
+            return (
+                True,
+                None,
+                {
+                    "permits": {"current": 4, "max": 5},
+                    "executions": {"tx-1": {}},
+                },
+            )
+
+        async def fake_database_health():
+            events.append(
+                (
+                    "database",
+                    health_module._health_cache.genvm_healthy,
+                    health_module._health_cache.genvm_available_permits,
+                )
+            )
+            return {
+                "status": "healthy",
+                "connection_pool": {"size": 10, "checked_out": 0},
+            }
+
+        async def fake_consensus_health():
+            events.append(
+                (
+                    "consensus",
+                    health_module._health_cache.genvm_healthy,
+                    health_module._health_cache.genvm_available_permits,
+                )
+            )
+            return {
+                "status": "healthy",
+                "total_processing_transactions": 0,
+                "total_orphaned_transactions": 0,
+                "stuck_finalization_count": 0,
+                "active_workers": 0,
+            }
+
+        async def fake_llm_health():
+            return {
+                "status": "no_data",
+                "alert_providers": [],
+                "window_minutes": 15,
+                "total_samples": 0,
+            }
+
+        async def fake_memory_health():
+            return {
+                "status": "healthy",
+                "memory_usage_mb": 1,
+                "memory_percent": 1,
+                "cpu_percent": 0,
+            }
+
+        monkeypatch.setattr(health_module, "_check_genvm_health", fake_genvm_health)
+        monkeypatch.setattr(
+            health_module, "_check_database_health", fake_database_health
+        )
+        monkeypatch.setattr(
+            health_module, "_check_consensus_health", fake_consensus_health
+        )
+        monkeypatch.setattr(
+            health_module, "_check_llm_provider_health", fake_llm_health
+        )
+        monkeypatch.setattr(health_module, "_check_memory_health", fake_memory_health)
+        monkeypatch.setattr(
+            health_module, "_check_redis_health", AsyncMock(return_value="healthy")
+        )
+        monkeypatch.setattr(
+            health_module,
+            "_get_aggregate_counts",
+            AsyncMock(return_value=(1, 2, 3)),
+        )
+        monkeypatch.setattr(
+            health_module, "_get_pending_contracts", AsyncMock(return_value=[])
+        )
+
+        await health_module._run_health_checks()
+
+        assert events == [
+            "genvm",
+            ("database", True, 4),
+            ("consensus", True, 4),
+        ]
+        assert health_module._health_cache.genvm_healthy is True
+        assert health_module._health_cache.genvm_max_permits == 5
+        assert health_module._health_cache.genvm_available_permits == 4
+        assert health_module._health_cache.genvm_active_executions == 1
 
 
 class TestThresholdConfig:


### PR DESCRIPTION
## Summary
- probe and cache local GenVM health before heavier DB/alert checks in the background health loop
- keep readiness-critical GenVM state from staying uninitialized when alert queries are slow
- add a unit test covering the ordering

## Verification
- python3 -m py_compile backend/protocol_rpc/health.py tests/unit/test_rpc_health_genvm_tracking.py
- pytest tests/unit/test_rpc_health_genvm_tracking.py -q (local env missing python-dotenv; full validation via CI)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved GenVM health tracking and permit/capacity reporting for more accurate service status.

* **New Features**
  * Provider availability checks now enforce a configurable timeout, causing slow providers to be marked unavailable sooner.

* **Tests**
  * Added tests to verify health-check ordering, GenVM state propagation, and provider timeout behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/genlayerlabs/genlayer-studio/pull/1637?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->