### PR TITLE
fix: avoid expensive no-progress health scan

### DIFF
--- a/backend/protocol_rpc/health.py
+++ b/backend/protocol_rpc/health.py
@@ -598,6 +598,9 @@ async def _check_consensus_health() -> Dict[str, Any]:
         os.environ.get("HEALTH_NO_PROGRESS_WINDOW_MINUTES", "30")
     )
     NO_PROGRESS_MIN_BACKLOG = int(os.environ.get("HEALTH_NO_PROGRESS_MIN_BACKLOG", "3"))
+    NO_PROGRESS_QUERY_TIMEOUT_MS = int(
+        os.environ.get("HEALTH_NO_PROGRESS_QUERY_TIMEOUT_MS", "5000")
+    )
     RECOVERY_STORM_MIN_RECOVERIES = int(
         os.environ.get("HEALTH_RECOVERY_STORM_MIN_RECOVERIES", "2")
     )
@@ -751,103 +754,6 @@ async def _check_consensus_health() -> Dict[str, Any]:
                     recovery_row.max_recovery_count if recovery_row else 0
                 )
 
-                # No-progress detector: if there is an old pre-consensus
-                # backlog and nothing has reached ACCEPTED/FINALIZED recently,
-                # workers may be busy but not producing outcomes. This is
-                # intentionally backlog-age gated to avoid alerting on normal
-                # short bursts or a single fresh long-running transaction.
-                progress_row = conn.execute(
-                    text(
-                        f"""
-                        WITH backlog AS (
-                            SELECT
-                                COUNT(*) AS backlog_count,
-                                MIN(created_at) AS oldest_created_at
-                            FROM transactions
-                            WHERE status IN ({PRE_CONSENSUS_BACKLOG_STATUSES_SQL})
-                        ),
-                        progress AS (
-                            SELECT
-                                MAX(
-                                    GREATEST(
-                                        COALESCE(
-                                            CASE
-                                                WHEN consensus_history
-                                                     -> 'current_monitoring'
-                                                     ->> 'ACCEPTED'
-                                                     ~ '^[0-9]+(\\.[0-9]+)?$'
-                                                THEN (
-                                                    consensus_history
-                                                    -> 'current_monitoring'
-                                                    ->> 'ACCEPTED'
-                                                )::double precision
-                                            END,
-                                            0
-                                        ),
-                                        COALESCE(
-                                            CASE
-                                                WHEN consensus_history
-                                                     -> 'current_monitoring'
-                                                     ->> 'FINALIZED'
-                                                     ~ '^[0-9]+(\\.[0-9]+)?$'
-                                                THEN (
-                                                    consensus_history
-                                                    -> 'current_monitoring'
-                                                    ->> 'FINALIZED'
-                                                )::double precision
-                                            END,
-                                            0
-                                        )
-                                    )
-                                ) AS last_progress_epoch
-                            FROM transactions
-                            WHERE consensus_history IS NOT NULL
-                        )
-                        SELECT
-                            backlog.backlog_count,
-                            EXTRACT(
-                                EPOCH FROM (NOW() - backlog.oldest_created_at)
-                            )::bigint AS oldest_backlog_age_seconds,
-                            COALESCE(progress.last_progress_epoch, 0)
-                                AS last_progress_epoch,
-                            CASE
-                                WHEN COALESCE(progress.last_progress_epoch, 0) > 0
-                                THEN (
-                                    EXTRACT(EPOCH FROM NOW())
-                                    - progress.last_progress_epoch
-                                )::bigint
-                                ELSE NULL
-                            END AS seconds_since_progress
-                        FROM backlog
-                        CROSS JOIN progress
-                        """
-                    )
-                ).fetchone()
-
-                no_progress_window_seconds = NO_PROGRESS_WINDOW_MINUTES * 60
-                no_progress_backlog_count = (
-                    progress_row.backlog_count if progress_row else 0
-                )
-                oldest_backlog_age_seconds = (
-                    progress_row.oldest_backlog_age_seconds if progress_row else None
-                )
-                seconds_since_consensus_progress = (
-                    progress_row.seconds_since_progress if progress_row else None
-                )
-                last_progress_epoch = (
-                    progress_row.last_progress_epoch if progress_row else 0
-                )
-                no_recent_progress = not last_progress_epoch or (
-                    seconds_since_consensus_progress is not None
-                    and seconds_since_consensus_progress > no_progress_window_seconds
-                )
-                no_consensus_progress = (
-                    no_progress_backlog_count >= NO_PROGRESS_MIN_BACKLOG
-                    and oldest_backlog_age_seconds is not None
-                    and oldest_backlog_age_seconds > no_progress_window_seconds
-                    and no_recent_progress
-                )
-
                 # Total in-flight (non-final) tx count, for context.
                 # Consensus-active only — finalization-pending rows
                 # are tracked separately via stuck_finalization_count.
@@ -862,6 +768,122 @@ async def _check_consensus_health() -> Dict[str, Any]:
                     )
                 ).fetchone()
                 total_processing = processing_row.n if processing_row else 0
+
+                no_progress_window_seconds = NO_PROGRESS_WINDOW_MINUTES * 60
+                no_progress_check_error = False
+
+                # No-progress detector: first do a cheap backlog gate. The
+                # progress scan has to inspect JSON history and can be expensive
+                # on large Rally-style datasets; if there is no old backlog,
+                # scanning history cannot change the alert decision.
+                backlog_row = conn.execute(
+                    text(
+                        f"""
+                        SELECT
+                            COUNT(*) AS backlog_count,
+                            MIN(created_at) AS oldest_created_at,
+                            EXTRACT(EPOCH FROM (NOW() - MIN(created_at)))::bigint
+                                AS oldest_backlog_age_seconds
+                        FROM transactions
+                        WHERE status IN ({PRE_CONSENSUS_BACKLOG_STATUSES_SQL})
+                        """
+                    )
+                ).fetchone()
+
+                no_progress_backlog_count = (
+                    backlog_row.backlog_count if backlog_row else 0
+                )
+                oldest_backlog_age_seconds = (
+                    backlog_row.oldest_backlog_age_seconds
+                    if backlog_row and backlog_row.oldest_created_at
+                    else None
+                )
+
+                should_scan_progress = (
+                    no_progress_backlog_count >= NO_PROGRESS_MIN_BACKLOG
+                    and oldest_backlog_age_seconds is not None
+                    and oldest_backlog_age_seconds > no_progress_window_seconds
+                )
+
+                seconds_since_consensus_progress = None
+                last_progress_epoch = 0
+                if should_scan_progress:
+                    try:
+                        conn.execute(
+                            text(
+                                f"SET LOCAL statement_timeout = {NO_PROGRESS_QUERY_TIMEOUT_MS}"
+                            )
+                        )
+                        progress_row = conn.execute(
+                            text(
+                                """
+                                SELECT
+                                    MAX(
+                                        GREATEST(
+                                            COALESCE(
+                                                CASE
+                                                    WHEN consensus_history
+                                                         -> 'current_monitoring'
+                                                         ->> 'ACCEPTED'
+                                                         ~ '^[0-9]+(\\.[0-9]+)?$'
+                                                    THEN (
+                                                        consensus_history
+                                                        -> 'current_monitoring'
+                                                        ->> 'ACCEPTED'
+                                                    )::double precision
+                                                END,
+                                                0
+                                            ),
+                                            COALESCE(
+                                                CASE
+                                                    WHEN consensus_history
+                                                         -> 'current_monitoring'
+                                                         ->> 'FINALIZED'
+                                                         ~ '^[0-9]+(\\.[0-9]+)?$'
+                                                    THEN (
+                                                        consensus_history
+                                                        -> 'current_monitoring'
+                                                        ->> 'FINALIZED'
+                                                    )::double precision
+                                                END,
+                                                0
+                                            )
+                                        )
+                                    ) AS last_progress_epoch
+                                FROM transactions
+                                WHERE consensus_history IS NOT NULL
+                                """
+                            )
+                        ).fetchone()
+                        last_progress_epoch = (
+                            progress_row.last_progress_epoch if progress_row else 0
+                        )
+                        seconds_since_consensus_progress = (
+                            int(time.time() - last_progress_epoch)
+                            if last_progress_epoch
+                            else None
+                        )
+                    except Exception as exc:
+                        no_progress_check_error = True
+                        logger.warning(
+                            "No-progress health query skipped after timeout/error: %s",
+                            exc,
+                        )
+
+                no_recent_progress = should_scan_progress and (
+                    not last_progress_epoch
+                    or (
+                        seconds_since_consensus_progress is not None
+                        and seconds_since_consensus_progress
+                        > no_progress_window_seconds
+                    )
+                )
+                no_consensus_progress = (
+                    no_progress_backlog_count >= NO_PROGRESS_MIN_BACKLOG
+                    and oldest_backlog_age_seconds is not None
+                    and oldest_backlog_age_seconds > no_progress_window_seconds
+                    and no_recent_progress
+                )
 
                 status = (
                     "degraded"
@@ -890,6 +912,7 @@ async def _check_consensus_health() -> Dict[str, Any]:
                     "seconds_since_consensus_progress": (
                         seconds_since_consensus_progress
                     ),
+                    "no_progress_check_error": no_progress_check_error,
                     "no_progress_window_minutes": NO_PROGRESS_WINDOW_MINUTES,
                     "active_workers": active_workers_count,
                 }

--- a/tests/db-sqlalchemy/test_health_orphan_detection.py
+++ b/tests/db-sqlalchemy/test_health_orphan_detection.py
@@ -28,7 +28,7 @@ from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 
 import pytest
-from sqlalchemy import Engine, text
+from sqlalchemy import Engine, event, text
 from sqlalchemy.orm import sessionmaker
 
 
@@ -661,6 +661,31 @@ async def test_old_backlog_without_recent_progress_is_flagged(
     assert result["no_consensus_progress"] is True
     assert result["no_progress_backlog_count"] == 3
     assert result["status"] == "degraded"
+
+
+@pytest.mark.asyncio
+async def test_no_progress_detector_skips_history_scan_without_backlog(engine: Engine):
+    """No old backlog means consensus cannot be stalled, so the detector
+    must not scan JSON consensus history. On Rally-scale datasets that scan
+    can be expensive enough to wedge the background health task."""
+
+    def fail_on_progress_scan(
+        conn, cursor, statement, parameters, context, executemany
+    ):
+        if "current_monitoring" in statement:
+            raise AssertionError("progress history scan should be skipped")
+
+    event.listen(engine, "before_cursor_execute", fail_on_progress_scan)
+    try:
+        from backend.protocol_rpc import health as health_module
+
+        result = await health_module._check_consensus_health()
+    finally:
+        event.remove(engine, "before_cursor_execute", fail_on_progress_scan)
+
+    assert result["status"] == "healthy"
+    assert result["no_consensus_progress"] is False
+    assert result["no_progress_backlog_count"] == 0
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- split the no-consensus-progress detector into a cheap backlog gate followed by the JSON history scan only when an old backlog exists
- add a DB statement timeout around the expensive progress scan so the background health task cannot wedge indefinitely
- add regression coverage that verifies the progress-history scan is skipped when there is no backlog

## Verification
- .venv/bin/python -m py_compile backend/protocol_rpc/health.py
- .venv/bin/python -m pytest tests/unit/test_rpc_health_genvm_tracking.py -q
- .venv/bin/python -m black --check backend/protocol_rpc/health.py tests/db-sqlalchemy/test_health_orphan_detection.py

Note: tests/db-sqlalchemy/test_health_orphan_detection.py requires POSTGRES_URL locally; CI should run it in the DB-backed environment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Optimized consensus health check with more efficient progress detection logic
  * Enhanced reliability with timeout protection and error recovery for health monitoring queries
  * Added error tracking for failed health check operations

* **Tests**
  * Added regression test verifying optimized health check behavior during low-backlog scenarios

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/genlayerlabs/genlayer-studio/pull/1638?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->