### PR TITLE
fix: avoid false no-progress alerts on scan timeout

### DIFF
--- a/backend/protocol_rpc/health.py
+++ b/backend/protocol_rpc/health.py
@@ -319,6 +319,9 @@ async def _run_health_checks() -> None:
             "seconds_since_consensus_progress": consensus_health.get(
                 "seconds_since_consensus_progress"
             ),
+            "no_progress_check_error": consensus_health.get(
+                "no_progress_check_error", False
+            ),
             "active_workers": consensus_health.get("active_workers", 0),
             "status": consensus_status,
         }
@@ -870,12 +873,19 @@ async def _check_consensus_health() -> Dict[str, Any]:
                             exc,
                         )
 
-                no_recent_progress = should_scan_progress and (
-                    not last_progress_epoch
-                    or (
-                        seconds_since_consensus_progress is not None
-                        and seconds_since_consensus_progress
-                        > no_progress_window_seconds
+                # The progress scan is an alert-quality check, not a liveness
+                # requirement. If it times out on a large table, surface that
+                # as check_error but do not assert a consensus outage.
+                no_recent_progress = (
+                    should_scan_progress
+                    and not no_progress_check_error
+                    and (
+                        not last_progress_epoch
+                        or (
+                            seconds_since_consensus_progress is not None
+                            and seconds_since_consensus_progress
+                            > no_progress_window_seconds
+                        )
                     )
                 )
                 no_consensus_progress = (

--- a/tests/db-sqlalchemy/test_health_orphan_detection.py
+++ b/tests/db-sqlalchemy/test_health_orphan_detection.py
@@ -689,6 +689,50 @@ async def test_no_progress_detector_skips_history_scan_without_backlog(engine: E
 
 
 @pytest.mark.asyncio
+async def test_no_progress_scan_error_does_not_assert_outage(
+    engine: Engine, monkeypatch: pytest.MonkeyPatch
+):
+    """If the optional JSON history scan times out, surface the check error
+    but don't turn an unknown progress signal into a consensus outage."""
+    monkeypatch.setenv("HEALTH_NO_PROGRESS_WINDOW_MINUTES", "10")
+    monkeypatch.setenv("HEALTH_NO_PROGRESS_MIN_BACKLOG", "3")
+
+    Session_ = sessionmaker(bind=engine, expire_on_commit=False)
+    now = datetime.now(timezone.utc)
+
+    with Session_() as s:
+        for i in range(3):
+            _insert_tx(
+                s,
+                tx_hash=f"0xd0{i:062x}",
+                to_address="0x" + "d0" * 20,
+                status="PENDING",
+                nonce=i,
+                created_at=now - timedelta(minutes=20 + i),
+            )
+        s.commit()
+
+    def fail_on_progress_scan(
+        conn, cursor, statement, parameters, context, executemany
+    ):
+        if "current_monitoring" in statement:
+            raise RuntimeError("simulated progress scan timeout")
+
+    event.listen(engine, "before_cursor_execute", fail_on_progress_scan)
+    try:
+        from backend.protocol_rpc import health as health_module
+
+        result = await health_module._check_consensus_health()
+    finally:
+        event.remove(engine, "before_cursor_execute", fail_on_progress_scan)
+
+    assert result["no_progress_check_error"] is True
+    assert result["no_consensus_progress"] is False
+    assert result["no_progress_backlog_count"] == 3
+    assert result["status"] == "healthy"
+
+
+@pytest.mark.asyncio
 async def test_recent_consensus_progress_suppresses_no_progress_alert(
     engine: Engine, monkeypatch: pytest.MonkeyPatch
 ):


### PR DESCRIPTION
## Summary
- do not assert no_consensus_progress when the optional JSON history scan times out
- expose no_progress_check_error in /health consensus details
- add DB regression coverage for scan timeout fallback

## Verification
- .venv/bin/python -m py_compile backend/protocol_rpc/health.py
- .venv/bin/python -m black --check backend/protocol_rpc/health.py tests/db-sqlalchemy/test_health_orphan_detection.py
- .venv/bin/python -m pytest tests/unit/test_rpc_health_genvm_tracking.py -q
- .venv/bin/python -m pytest tests/db-sqlalchemy/test_health_orphan_detection.py -q (blocked locally: POSTGRES_URL not set)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed health monitoring to correctly handle database query timeouts and errors during consensus checks. Previously, temporary database issues would incorrectly trigger consensus outage alerts and degrade system status. The system now distinguishes between actual consensus failures and transient query problems, preventing false alerts while maintaining accurate health status reporting for operators.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/genlayerlabs/genlayer-studio/pull/1639?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->