### PR TITLE
fix: avoid resetting active consensus progress

### DIFF
--- a/backend/consensus/worker.py
+++ b/backend/consensus/worker.py
@@ -664,7 +664,9 @@ class ConsensusWorker:
                     WHEN target.recovery_count + 1 >= :max_recovery_cycles
                     THEN jsonb_build_object(
                         'error', 'max_recovery_cycles_exceeded',
-                        'recovery_count', target.recovery_count + 1
+                        'recovery_count', target.recovery_count + 1,
+                        'max_recovery_exhausted_at',
+                        EXTRACT(EPOCH FROM NOW())::bigint
                     )
                     ELSE NULL
                 END
@@ -881,13 +883,33 @@ class ConsensusWorker:
                 consensus_data = COALESCE(consensus_data, '{}'::jsonb)
                                  || jsonb_build_object(
                                     'error', 'max_recovery_cycles_exceeded',
-                                    'recovery_count', recovery_count
+                                    'recovery_count', recovery_count,
+                                    'max_recovery_exhausted_at',
+                                    EXTRACT(EPOCH FROM NOW())::bigint
                                  )
             WHERE recovery_count >= :max_cycles
               AND status IN :consensus_statuses
               AND (
-                  (blocked_at IS NOT NULL
-                   AND blocked_at < NOW() - CAST(:timeout AS INTERVAL))
+                  (
+                   blocked_at IS NOT NULL
+                   AND blocked_at < NOW() - CAST(:timeout AS INTERVAL)
+                   -- blocked_at is a claim lease, not a heartbeat. Long
+                   -- consensus attempts with rotations can exceed it while
+                   -- still progressing, so require progress to be stale too.
+                   AND COALESCE(
+                       (
+                           SELECT to_timestamp(MAX(progress.value::double precision))
+                           FROM jsonb_each_text(
+                               COALESCE(
+                                   transactions.consensus_history->'current_monitoring',
+                                   '{}'::jsonb
+                               )
+                           ) AS progress(key, value)
+                           WHERE progress.value ~ '^[0-9]+(\\.[0-9]+)?$'
+                       ),
+                       blocked_at
+                   ) < NOW() - CAST(:timeout AS INTERVAL)
+                  )
                   OR
                   (blocked_at IS NULL
                    AND status IN ('PROPOSING', 'COMMITTING', 'REVEALING')
@@ -963,8 +985,26 @@ class ConsensusWorker:
               AND status IN :consensus_statuses
               AND (
                   -- Case 1: Transactions with expired blocks
-                  (blocked_at IS NOT NULL
-                   AND blocked_at < NOW() - CAST(:timeout AS INTERVAL))
+                  (
+                   blocked_at IS NOT NULL
+                   AND blocked_at < NOW() - CAST(:timeout AS INTERVAL)
+                   -- blocked_at is a claim lease, not a heartbeat. Long
+                   -- consensus attempts with rotations can exceed it while
+                   -- still progressing, so require progress to be stale too.
+                   AND COALESCE(
+                       (
+                           SELECT to_timestamp(MAX(progress.value::double precision))
+                           FROM jsonb_each_text(
+                               COALESCE(
+                                   transactions.consensus_history->'current_monitoring',
+                                   '{}'::jsonb
+                               )
+                           ) AS progress(key, value)
+                           WHERE progress.value ~ '^[0-9]+(\\.[0-9]+)?$'
+                       ),
+                       blocked_at
+                   ) < NOW() - CAST(:timeout AS INTERVAL)
+                  )
                   OR
                   -- Case 2: Orphaned transactions in processing states with no block
                   (blocked_at IS NULL

--- a/backend/protocol_rpc/health.py
+++ b/backend/protocol_rpc/health.py
@@ -310,6 +310,9 @@ async def _run_health_checks() -> None:
             ),
             "recovery_storm_count": consensus_health.get("recovery_storm_count", 0),
             "max_recovery_count": consensus_health.get("max_recovery_count", 0),
+            "max_recovery_exhausted_count": consensus_health.get(
+                "max_recovery_exhausted_count", 0
+            ),
             "no_consensus_progress": consensus_health.get(
                 "no_consensus_progress", False
             ),
@@ -342,6 +345,10 @@ async def _run_health_checks() -> None:
                 if overall_status == "healthy":
                     overall_status = "degraded"
                 issues.append("transaction_recovery_storm")
+            if consensus_health.get("max_recovery_exhausted_count", 0) > 0:
+                if overall_status == "healthy":
+                    overall_status = "degraded"
+                issues.append("max_recovery_cycles_exhausted")
             if consensus_health.get("no_consensus_progress", False):
                 if overall_status == "healthy":
                     overall_status = "degraded"
@@ -607,6 +614,9 @@ async def _check_consensus_health() -> Dict[str, Any]:
     RECOVERY_STORM_MIN_RECOVERIES = int(
         os.environ.get("HEALTH_RECOVERY_STORM_MIN_RECOVERIES", "2")
     )
+    MAX_RECOVERY_EXHAUSTED_NOTICE_WINDOW_MINUTES = int(
+        os.environ.get("HEALTH_MAX_RECOVERY_EXHAUSTED_NOTICE_WINDOW_MINUTES", "60")
+    )
 
     # Statuses where the consensus state machine is actively working.
     # The "head of queue stuck" check uses ONLY these: ACCEPTED-class
@@ -757,6 +767,38 @@ async def _check_consensus_health() -> Dict[str, Any]:
                     recovery_row.max_recovery_count if recovery_row else 0
                 )
 
+                max_recovery_exhausted_row = conn.execute(
+                    text(
+                        """
+                        SELECT COUNT(*) AS n
+                        FROM transactions
+                        WHERE status = 'CANCELED'
+                          AND consensus_data ->> 'error'
+                              = 'max_recovery_cycles_exceeded'
+                          AND CASE
+                              WHEN consensus_data
+                                   ->> 'max_recovery_exhausted_at'
+                                   ~ '^[0-9]+(\\.[0-9]+)?$'
+                              THEN to_timestamp(
+                                  (
+                                      consensus_data
+                                      ->> 'max_recovery_exhausted_at'
+                                  )::double precision
+                              )
+                              ELSE created_at
+                          END > NOW() - CAST(:notice_window AS INTERVAL)
+                        """
+                    ),
+                    {
+                        "notice_window": (
+                            f"{MAX_RECOVERY_EXHAUSTED_NOTICE_WINDOW_MINUTES} minutes"
+                        )
+                    },
+                ).fetchone()
+                max_recovery_exhausted_count = (
+                    max_recovery_exhausted_row.n if max_recovery_exhausted_row else 0
+                )
+
                 # Total in-flight (non-final) tx count, for context.
                 # Consensus-active only — finalization-pending rows
                 # are tracked separately via stuck_finalization_count.
@@ -901,6 +943,7 @@ async def _check_consensus_health() -> Dict[str, Any]:
                         stuck_head_contracts >= DEGRADED_AT_STUCK_HEADS
                         or stuck_finalization_count >= DEGRADED_AT_STUCK_FINALIZATIONS
                         or recovery_storm_count > 0
+                        or max_recovery_exhausted_count > 0
                         or no_consensus_progress
                     )
                     else "healthy"
@@ -916,6 +959,7 @@ async def _check_consensus_health() -> Dict[str, Any]:
                     "stuck_finalization_count": stuck_finalization_count,
                     "recovery_storm_count": recovery_storm_count,
                     "max_recovery_count": max_recovery_count,
+                    "max_recovery_exhausted_count": max_recovery_exhausted_count,
                     "no_consensus_progress": no_consensus_progress,
                     "no_progress_backlog_count": no_progress_backlog_count,
                     "oldest_backlog_age_seconds": oldest_backlog_age_seconds,

--- a/tests/db-sqlalchemy/test_finalization_starvation.py
+++ b/tests/db-sqlalchemy/test_finalization_starvation.py
@@ -332,6 +332,49 @@ async def test_recover_does_not_wipe_consensus_data_for_accepted(
 
 
 @pytest.mark.asyncio
+async def test_recover_does_not_reset_when_consensus_recently_progressed(
+    engine: Engine, worker: ConsensusWorker, session: Session
+):
+    """A long-running tx can legitimately exceed its original claim lease
+    while rotations/validator work are still advancing. Recovery should reset
+    only when both the claim and the latest consensus progress are stale."""
+    _setup_contract(engine)
+    tx_hash = "0x" + "66" * 32
+    consensus_history = {
+        "current_monitoring": {
+            "PENDING": time.time() - 25 * 60,
+            "PROPOSING": time.time() - 60,
+        }
+    }
+
+    _insert_tx(
+        session,
+        tx_hash=tx_hash,
+        status="PROPOSING",
+        nonce=0,
+        consensus_history=consensus_history,
+        blocked_at_offset_seconds=-25 * 60,
+        worker_id="worker-that-is-still-progressing",
+    )
+
+    recovered = await worker.recover_stuck_transactions(session)
+
+    row = session.execute(
+        text(
+            "SELECT status, recovery_count, consensus_history, blocked_at, worker_id "
+            "FROM transactions WHERE hash = :h"
+        ),
+        {"h": tx_hash},
+    ).one()
+    assert recovered == 0
+    assert row.status == TransactionStatus.PROPOSING.value
+    assert row.recovery_count == 0
+    assert row.consensus_history == consensus_history
+    assert row.blocked_at is not None
+    assert row.worker_id == "worker-that-is-still-progressing"
+
+
+@pytest.mark.asyncio
 async def test_recover_still_resets_stuck_consensus_txs(
     engine: Engine, worker: ConsensusWorker, session: Session
 ):
@@ -440,10 +483,10 @@ def test_direct_genvm_reset_cancels_at_recovery_limit(
     assert row.recovery_count == worker._max_recovery_cycles
     assert row.blocked_at is None
     assert row.worker_id is None
-    assert row.consensus_data == {
-        "error": "max_recovery_cycles_exceeded",
-        "recovery_count": worker._max_recovery_cycles,
-    }
+    assert row.consensus_data["error"] == "max_recovery_cycles_exceeded"
+    assert row.consensus_data["recovery_count"] == worker._max_recovery_cycles
+    assert isinstance(row.consensus_data["max_recovery_exhausted_at"], int)
+    assert row.consensus_data["max_recovery_exhausted_at"] > 0
     assert row.consensus_history is None
 
 

--- a/tests/db-sqlalchemy/test_health_orphan_detection.py
+++ b/tests/db-sqlalchemy/test_health_orphan_detection.py
@@ -73,6 +73,7 @@ def _insert_tx(
     timestamp_awaiting_finalization: int | None = None,
     recovery_count: int = 0,
     consensus_history: dict | None = None,
+    consensus_data: dict | None = None,
 ):
     """Direct INSERT — bypass the processor so we can backdate created_at."""
     session.execute(
@@ -84,7 +85,7 @@ def _insert_tx(
                 appeal_undetermined, appeal_leader_timeout,
                 appeal_validators_timeout, appeal_processing_time,
                 recovery_count, value_credited,
-                consensus_history,
+                consensus_history, consensus_data,
                 created_at, blocked_at, worker_id,
                 timestamp_awaiting_finalization
             ) VALUES (
@@ -92,7 +93,7 @@ def _insert_tx(
                 '0xfromaddress', :to_addr, CAST('{}' AS jsonb), 0, 2,
                 :nonce, false, 'NORMAL', false, 0,
                 false, false, false, 0, :recovery_count, false,
-                CAST(:consensus_history AS jsonb),
+                CAST(:consensus_history AS jsonb), CAST(:consensus_data AS jsonb),
                 :created_at, :blocked_at, :worker_id,
                 :timestamp_awaiting_finalization
             )
@@ -110,6 +111,9 @@ def _insert_tx(
             "recovery_count": recovery_count,
             "consensus_history": (
                 json.dumps(consensus_history) if consensus_history is not None else None
+            ),
+            "consensus_data": (
+                json.dumps(consensus_data) if consensus_data is not None else None
             ),
         },
     )
@@ -627,6 +631,42 @@ async def test_recovery_storm_flags_poison_transaction(
 
     assert result["recovery_storm_count"] == 1
     assert result["max_recovery_count"] == 2
+    assert result["status"] == "degraded"
+
+
+@pytest.mark.asyncio
+async def test_recent_max_recovery_exhaustion_flags_notice(
+    engine: Engine, monkeypatch: pytest.MonkeyPatch
+):
+    """A transaction canceled after exhausting recovery cycles should surface
+    as a degraded notice even though it no longer appears in active backlog."""
+    monkeypatch.setenv("HEALTH_MAX_RECOVERY_EXHAUSTED_NOTICE_WINDOW_MINUTES", "60")
+
+    Session_ = sessionmaker(bind=engine, expire_on_commit=False)
+    now = datetime.now(timezone.utc)
+
+    with Session_() as s:
+        _insert_tx(
+            s,
+            tx_hash="0x" + "ab" * 32,
+            to_address="0x" + "ab" * 20,
+            status="CANCELED",
+            nonce=0,
+            created_at=now - timedelta(minutes=5),
+            recovery_count=3,
+            consensus_data={
+                "error": "max_recovery_cycles_exceeded",
+                "recovery_count": 3,
+                "max_recovery_exhausted_at": int(now.timestamp()),
+            },
+        )
+        s.commit()
+
+    from backend.protocol_rpc import health as health_module
+
+    result = await health_module._check_consensus_health()
+
+    assert result["max_recovery_exhausted_count"] == 1
     assert result["status"] == "degraded"
 
 


### PR DESCRIPTION
## Summary
- prevent recovery from resetting an in-flight consensus tx solely because its original blocked_at claim lease expired
- require both blocked_at and latest consensus_history.current_monitoring progress to be stale before recovery reset/cancel
- stamp max recovery exhaustion with max_recovery_exhausted_at and expose max_recovery_cycles_exhausted as a degraded health notice
- add DB regression tests for recent-progress recovery suppression and max-recovery exhaustion notice

## Incident context
The prod tx 0xedc723838cee384ebfd0823fb048204731fc2509d8cbb4eb3cf56413cf9fa6bf reset almost exactly every 30 minutes after claim. It had recent PROPOSING/COMMITTING/REVEALING progress inside those windows, so blocked_at was acting as a stale lease rather than an active-progress heartbeat.

## Verification
- git diff --check
- PYTHONPATH=. .venv/bin/python -m py_compile backend/consensus/worker.py backend/protocol_rpc/health.py tests/db-sqlalchemy/test_finalization_starvation.py tests/db-sqlalchemy/test_health_orphan_detection.py
- read-only prod SQL syntax validation for the new recovery and max-exhaustion health queries

DB-backed pytest was attempted but local POSTGRES_URL is not configured and Docker is not running on this remote machine.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Strengthened stuck-transaction detection by requiring recent per-transaction progress in addition to timing checks to avoid unnecessary resets.

* **Health Monitoring**
  * Added a health metric and degradation flag for transactions that exhausted recovery cycles, improving visibility into recovery failures.

* **Tests**
  * Added regression tests to ensure recovery logic respects recent progress and that exhaustion conditions are reported in health checks.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/genlayerlabs/genlayer-studio/pull/1640?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->