### PR TITLE
fix: allow studio mode1 message fee buckets

### DIFF
--- a/backend/database_handler/transactions_processor.py
+++ b/backend/database_handler/transactions_processor.py
@@ -108,7 +108,11 @@ class TransactionsProcessor:
             "from_address": transaction_data.from_address,
             "to_address": transaction_data.to_address,
             "data": TransactionsProcessor._json_safe_numbers(transaction_data.data),
-            "value": TransactionsProcessor._json_safe_numbers(transaction_data.value),
+            "value": (
+                int(transaction_data.value)
+                if transaction_data.value is not None
+                else None
+            ),
             "type": transaction_data.type,
             "status": transaction_data.status.value,
             "result": TransactionsProcessor._decode_base64_data(result),

--- a/backend/protocol_rpc/fees.py
+++ b/backend/protocol_rpc/fees.py
@@ -121,10 +121,6 @@ class InvalidFeeParams(FeeValidationError):
     pass
 
 
-class Mode1MessageFeesRequireGenVMPerEmissionSupport(FeeValidationError):
-    """GenVM must expose per-emission feeParams/declaredBudget before Mode 1 is safe."""
-
-
 class InvalidAppealBond(FeeValidationError):
     pass
 
@@ -758,12 +754,8 @@ def genvm_message_fee_allocation(
         return _genvm_unmetered_message_fee_allocation()
 
     if not accounting.get("message_allocations"):
-        if int(accounting.get("message_fee_budget", 0) or 0) > 0:
-            raise Mode1MessageFeesRequireGenVMPerEmissionSupport(
-                "Mode1MessageFeesRequireGenVMPerEmissionSupport: GenVM v0.3.x "
-                "message emissions do not carry per-emission feeParams/"
-                "declaredBudget without a message allocation tree"
-            )
+        # Mode 1 is bucket-only: GenVM receives the message bucket via
+        # bucket_totals[2] and each emission supplies feeParams/declaredBudget.
         return []
 
     nodes: list[dict[str, Any]] = []

--- a/tests/unit/test_node_state_proxy_metrics.py
+++ b/tests/unit/test_node_state_proxy_metrics.py
@@ -396,7 +396,7 @@ async def test_run_genvm_passes_mode2_message_fee_allocations_to_genvm():
 
 
 @pytest.mark.asyncio
-async def test_run_genvm_rejects_fee_bearing_mode1_before_genvm():
+async def test_run_genvm_passes_mode1_message_bucket_with_empty_allocations():
     node = _make_node()
     execution_result = ExecutionResult(
         result=ExecutionReturn(ret=b"\x00\x00"),
@@ -443,21 +443,15 @@ async def test_run_genvm_rejects_fee_bearing_mode1_before_genvm():
             fee_accounting=fee_accounting,
         )
 
-    run_genvm_host.assert_not_awaited()
-    assert receipt.execution_result == ExecutionResultStatus.ERROR
-    assert (
-        receipt.genvm_result["error_code"]
-        == "Mode1MessageFeesRequireGenVMPerEmissionSupport"
-    )
-    assert receipt.genvm_result["raw_error"] == {
-        "fatal": False,
-        "causes": [
-            "Mode1MessageFeesRequireGenVMPerEmissionSupport: GenVM v0.3.x "
-            "message emissions do not carry per-emission feeParams/declaredBudget "
-            "without a message allocation tree"
-        ],
-        "ctx": {"source": "studio_fee_accounting"},
-    }
+    run_genvm_host.assert_awaited_once()
+    assert receipt.execution_result == ExecutionResultStatus.SUCCESS
+    fee_context = run_genvm_host.await_args.kwargs["fee_context"]
+    assert fee_context.bucket_totals == [
+        (1 << 256) - 1,
+        (1 << 256) - 1,
+        55,
+    ]
+    assert fee_context.message_fee_allocation == []
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_studio_fees.py
+++ b/tests/unit/test_studio_fees.py
@@ -44,7 +44,6 @@ from backend.protocol_rpc.fees import (
     MessageAllocationsNotEqualBudget,
     MessageFeesReportMismatch,
     MessageNoMatchingAllocation,
-    Mode1MessageFeesRequireGenVMPerEmissionSupport,
     CALL_KEY_WILDCARD,
     MESSAGE_ALLOCATION_NODE_ABI_TYPE,
     MIN_RECEIPT_BYTES,
@@ -1666,7 +1665,7 @@ def test_genvm_message_fee_allocation_uses_empty_allocation_list_without_message
     assert genvm_message_fee_allocation(accounting) == []
 
 
-def test_genvm_message_fee_allocation_rejects_fee_bearing_mode1_until_genvm_supports_it():
+def test_genvm_message_fee_allocation_uses_empty_allocation_list_for_fee_bearing_mode1():
     accounting = create_fee_accounting(
         fees_distribution=_fees_distribution(total_message_fees=55),
         num_of_validators=5,
@@ -1674,8 +1673,7 @@ def test_genvm_message_fee_allocation_rejects_fee_bearing_mode1_until_genvm_supp
         user_value=0,
     )
 
-    with pytest.raises(Mode1MessageFeesRequireGenVMPerEmissionSupport):
-        genvm_message_fee_allocation(accounting)
+    assert genvm_message_fee_allocation(accounting) == []
 
 
 def test_create_fee_accounting_records_user_side_budgets():

--- a/tests/unit/test_transactions_parser.py
+++ b/tests/unit/test_transactions_parser.py
@@ -1,5 +1,7 @@
 import pytest
 from unittest.mock import Mock, MagicMock
+from datetime import datetime, timezone
+from types import SimpleNamespace
 from backend.database_handler.transactions_processor import TransactionsProcessor
 from backend.database_handler.models import TransactionStatus
 from backend.protocol_rpc.transactions_parser import (
@@ -38,6 +40,54 @@ def test_transaction_rpc_payload_stringifies_unsafe_fee_integers():
     assert payload["fee_value"] == "1100000000001000000"
     assert payload["fee_accounting"]["primary_fee_budget"] == "1100000000001000000"
     assert payload["fee_accounting"]["execution_budget_total"] == 1_000_000
+
+
+def test_parsed_transaction_preserves_value_int_at_processor_boundary():
+    unsafe_value = 456 * 10**18
+    transaction_data = SimpleNamespace(
+        hash="0x" + "01" * 32,
+        from_address="0x4000000000000000000000000000000000000001",
+        to_address="0x5000000000000000000000000000000000000001",
+        data={"nested_value": unsafe_value},
+        value=unsafe_value,
+        type=2,
+        status=TransactionStatus.PENDING,
+        consensus_data=None,
+        nonce=0,
+        r=None,
+        s=None,
+        v=None,
+        created_at=datetime(2026, 1, 1, tzinfo=timezone.utc),
+        leader_only=False,
+        execution_mode="NORMAL",
+        origin_address="0x4000000000000000000000000000000000000001",
+        triggered_by_hash=None,
+        triggered_on=None,
+        triggered_transactions=[],
+        appealed=False,
+        timestamp_awaiting_finalization=None,
+        appeal_failed=0,
+        appeal_undetermined=False,
+        consensus_history={},
+        timestamp_appeal=None,
+        appeal_processing_time=0,
+        contract_snapshot=None,
+        config_rotation_rounds=3,
+        num_of_initial_validators=None,
+        last_vote_timestamp=None,
+        rotation_count=0,
+        appeal_leader_timeout=False,
+        leader_timeout_validators=None,
+        appeal_validators_timeout=False,
+        sim_config=None,
+        value_credited=False,
+    )
+
+    parsed = TransactionsProcessor._parse_transaction_data(transaction_data)
+
+    assert parsed["value"] == unsafe_value
+    assert isinstance(parsed["value"], int)
+    assert parsed["data"]["nested_value"] == str(unsafe_value)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Description

Allows fee-bearing Mode 1 message transactions in Studio to reach GenVM with a positive message bucket and an empty allocation list. Consensus v0.6 now defines Mode 1 as bucket-only, with per-emission feeParams/declaredBudget supplied by GenVM emissions, so Studio should not reject it before execution.

Updates unit coverage for:

- the fee adapter returning [] for fee-bearing Mode 1 allocations
- node execution passing bucket_totals[2] to GenVM while message_fee_allocation remains []

## Verification

- .venv/bin/python -m pytest tests/unit/test_studio_fees.py::test_genvm_message_fee_allocation_uses_empty_allocation_list_for_fee_bearing_mode1 tests/unit/test_node_state_proxy_metrics.py::test_run_genvm_passes_mode1_message_bucket_with_empty_allocations -q
- .venv/bin/python -m pytest tests/unit/test_studio_fees.py tests/unit/test_node_state_proxy_metrics.py -q
- .venv/bin/pre-commit run --files backend/protocol_rpc/fees.py tests/unit/test_node_state_proxy_metrics.py tests/unit/test_studio_fees.py

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Mode 1 message fee allocation now properly handles bucket-based scenarios without requiring per-emission support
* Transaction value conversion process refined

## Tests
* Test suite updated to verify Mode 1 message bucket handling with GenVM when emission allocations are absent

<!-- end of auto-generated comment: release notes by coderabbit.ai -->