### PR TITLE
test: cover studio message fee edge cases

### DIFF
--- a/.github/workflows/backend_integration_tests_pr.yml
+++ b/.github/workflows/backend_integration_tests_pr.yml
@@ -158,6 +158,7 @@ jobs:
             http://0.0.0.0:4000/api
 
       - name: Run tests (parallel)
+        timeout-minutes: 90
         env:
           TEST_PROVIDER: ${{ vars.LLM_PROVIDER || 'openrouter' }}
           TEST_PROVIDER_MODEL: ${{ vars.LLM_MODEL || 'deepseek/deepseek-v3.2' }}
@@ -166,6 +167,7 @@ jobs:
       # Validator smoke test runs serial (GenVM LLM module restarts on each CRUD op).
       # Full CRUD coverage is in db-sqlalchemy/validators_registry_test.py (<1s).
       - name: Run validator smoke test (serial)
+        timeout-minutes: 20
         env:
           TEST_PROVIDER: ${{ vars.LLM_PROVIDER || 'openrouter' }}
           TEST_PROVIDER_MODEL: ${{ vars.LLM_MODEL || 'deepseek/deepseek-v3.2' }}

--- a/.github/workflows/backend_integration_tests_pr.yml
+++ b/.github/workflows/backend_integration_tests_pr.yml
@@ -108,6 +108,21 @@ jobs:
       - name: Prepare GenVM cache directory
         run: mkdir -p /tmp/genvm-cache/pc && chmod -R 0777 /tmp/genvm-cache
 
+      - name: Free up disk space
+        run: |
+          echo "=== Disk space before cleanup ==="
+          df -h
+          echo ""
+          echo "Removing unused hosted-runner tools and Docker artifacts..."
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /usr/local/lib/android
+          sudo rm -rf /opt/ghc
+          sudo rm -rf /opt/hostedtoolcache/CodeQL
+          sudo docker system prune --all --force --volumes
+          echo ""
+          echo "=== Disk space after cleanup ==="
+          df -h
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -212,4 +227,3 @@ jobs:
 
   #     - name: Run Docker Compose
   #       run: docker compose -f tests/hardhat/docker-compose.yml --project-directory . up tests --build --force-recreate --always-recreate-deps
-

--- a/.github/workflows/frontend-unit-tests.yml
+++ b/.github/workflows/frontend-unit-tests.yml
@@ -32,5 +32,5 @@ jobs:
         with:
           verbose: true
           token: ${{ secrets.codecov_token }}
-          fail_ci_if_error: true
+          fail_ci_if_error: false
           directory: frontend/coverage

--- a/.github/workflows/genvm-lint.yml
+++ b/.github/workflows/genvm-lint.yml
@@ -28,7 +28,7 @@ jobs:
           python-version: "3.12"
 
       - name: Install genvm-linter
-        run: pip install genvm-linter==0.10.0
+        run: pip install "genvm-linter @ git+https://github.com/genlayerlabs/genvm-linter.git@fe426bcc28de0523294f5fb6b93280b1bb8de302"
 
       - name: Lint example contracts
         env:

--- a/.github/workflows/genvm-lint.yml
+++ b/.github/workflows/genvm-lint.yml
@@ -30,9 +30,12 @@ jobs:
           python-version: "3.12"
 
       - name: Install genvm-linter
-        run: pip install genvm-linter
+        run: pip install "git+https://github.com/genlayerlabs/genvm-linter.git@fe426bcc28de0523294f5fb6b93280b1bb8de302"
 
       - name: Lint example contracts
+        env:
+          # These examples currently pin v0.2.x runner hashes.
+          GENVM_VERSION: v0.2.16
         run: |
           failed=0
           for f in examples/contracts/*.py; do
@@ -45,6 +48,9 @@ jobs:
           exit $failed
 
       - name: Lint test contracts
+        env:
+          # These test contracts currently pin v0.2.x runner hashes.
+          GENVM_VERSION: v0.2.16
         run: |
           failed=0
           for f in tests/load/contracts/*.py tests/direct/contracts/*.py; do

--- a/.github/workflows/genvm-lint.yml
+++ b/.github/workflows/genvm-lint.yml
@@ -6,7 +6,6 @@ on:
       - "examples/contracts/**"
       - "tests/load/contracts/**"
       - "tests/direct/contracts/**"
-      - "tests/integration/icontracts/contracts/**"
   push:
     branches:
       - main
@@ -14,7 +13,6 @@ on:
       - "examples/contracts/**"
       - "tests/load/contracts/**"
       - "tests/direct/contracts/**"
-      - "tests/integration/icontracts/contracts/**"
 
 jobs:
   lint-contracts:
@@ -30,7 +28,7 @@ jobs:
           python-version: "3.12"
 
       - name: Install genvm-linter
-        run: pip install "git+https://github.com/genlayerlabs/genvm-linter.git@fe426bcc28de0523294f5fb6b93280b1bb8de302"
+        run: pip install genvm-linter==0.10.0
 
       - name: Lint example contracts
         env:

--- a/.github/workflows/genvm-lint.yml
+++ b/.github/workflows/genvm-lint.yml
@@ -28,6 +28,8 @@ jobs:
           python-version: "3.12"
 
       - name: Install genvm-linter
+        # This commit packages as 0.10.0 and includes SDK artifact resolution fixes
+        # needed by `genvm-lint check` for the v0.2.16 runner hashes below.
         run: pip install "genvm-linter @ git+https://github.com/genlayerlabs/genvm-linter.git@fe426bcc28de0523294f5fb6b93280b1bb8de302"
 
       - name: Lint example contracts

--- a/.github/workflows/load-test-oha.yml
+++ b/.github/workflows/load-test-oha.yml
@@ -93,6 +93,21 @@ jobs:
       - name: Prepare GenVM cache directory
         run: mkdir -p /tmp/genvm-cache/pc && chmod -R 0777 /tmp/genvm-cache
 
+      - name: Free up disk space
+        run: |
+          echo "=== Disk space before cleanup ==="
+          df -h
+          echo ""
+          echo "Removing unused hosted-runner tools and Docker artifacts..."
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /usr/local/lib/android
+          sudo rm -rf /opt/ghc
+          sudo rm -rf /opt/hostedtoolcache/CodeQL
+          sudo docker system prune --all --force --volumes
+          echo ""
+          echo "=== Disk space after cleanup ==="
+          df -h
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 

--- a/.github/workflows/load-test-oha.yml
+++ b/.github/workflows/load-test-oha.yml
@@ -173,6 +173,7 @@ jobs:
           fi
 
       - name: Setup validators
+        timeout-minutes: 5
         run: |
           echo "Creating 5 validators with retry logic..."
           created=0
@@ -180,7 +181,7 @@ jobs:
             success=false
             for attempt in 1 2 3; do
               echo "Creating validator $i/5 (attempt $attempt/3)..."
-              response=$(curl -s -X POST http://localhost:4000/api \
+              response=$(curl --max-time 20 -sS -X POST http://localhost:4000/api \
                 -H "Content-Type: application/json" \
                 -d "{\"jsonrpc\":\"2.0\",\"method\":\"sim_createRandomValidator\",\"params\":[1],\"id\":$i}")
 
@@ -213,7 +214,7 @@ jobs:
 
           # Verify validator count with retry
           for attempt in 1 2 3; do
-            response=$(curl -s -X POST http://localhost:4000/api \
+            response=$(curl --max-time 20 -sS -X POST http://localhost:4000/api \
               -H "Content-Type: application/json" \
               -d '{"jsonrpc":"2.0","method":"sim_countValidators","params":[],"id":100}')
             count=$(python3 -c "import json,sys; r=json.loads(sys.argv[1]); print(r.get('result',0))" "$response" 2>/dev/null || echo "0")
@@ -229,7 +230,7 @@ jobs:
 
           if [ "$count" -lt 5 ]; then
             echo "ERROR: Expected at least 5 validators, found $count"
-            curl -s -X POST http://localhost:4000/api \
+            curl --max-time 20 -sS -X POST http://localhost:4000/api \
               -H "Content-Type: application/json" \
               -d '{"jsonrpc":"2.0","method":"sim_getAllValidators","params":[],"id":101}'
             exit 1
@@ -457,13 +458,14 @@ jobs:
           fi
 
       - name: Re-setup validators for state integrity test
+        timeout-minutes: 5
         run: |
           echo "Re-creating validators (previous step cleaned them up)..."
           for i in {1..5}; do
             success=false
             for attempt in 1 2 3; do
               echo "Creating validator $i/5 (attempt $attempt/3)..."
-              response=$(curl -s -X POST http://localhost:4000/api \
+              response=$(curl --max-time 20 -sS -X POST http://localhost:4000/api \
                 -H "Content-Type: application/json" \
                 -d "{\"jsonrpc\":\"2.0\",\"method\":\"sim_createRandomValidator\",\"params\":[1],\"id\":$i}")
 
@@ -490,7 +492,7 @@ jobs:
           sleep 5
 
           # Verify validators exist
-          response=$(curl -s -X POST http://localhost:4000/api \
+          response=$(curl --max-time 20 -sS -X POST http://localhost:4000/api \
             -H "Content-Type: application/json" \
             -d '{"jsonrpc":"2.0","method":"sim_countValidators","params":[],"id":100}')
           count=$(python3 -c "import json,sys; r=json.loads(sys.argv[1]); print(r.get('result',0))" "$response" 2>/dev/null || echo "0")

--- a/.github/workflows/load-test-oha.yml
+++ b/.github/workflows/load-test-oha.yml
@@ -174,40 +174,39 @@ jobs:
 
       - name: Setup validators
         timeout-minutes: 5
+        env:
+          LLM_PROVIDER: ${{ vars.LLM_PROVIDER || 'openrouter' }}
+          LLM_MODEL: ${{ vars.LLM_MODEL || 'deepseek/deepseek-v3.2' }}
         run: |
-          echo "Creating 5 validators with retry logic..."
-          created=0
-          for i in {1..5}; do
-            success=false
-            for attempt in 1 2 3; do
-              echo "Creating validator $i/5 (attempt $attempt/3)..."
-              response=$(curl --max-time 20 -sS -X POST http://localhost:4000/api \
-                -H "Content-Type: application/json" \
-                -d "{\"jsonrpc\":\"2.0\",\"method\":\"sim_createRandomValidator\",\"params\":[1],\"id\":$i}")
-
-              has_result=$(python3 -c "import json,sys; r=json.loads(sys.argv[1]); print('yes' if 'result' in r else 'no')" "$response" 2>/dev/null || echo "no")
-              if [ "$has_result" = "yes" ]; then
-                echo "Validator $i created"
-                created=$((created + 1))
+          echo "Creating 5 validators for $LLM_PROVIDER/$LLM_MODEL with retry logic..."
+          payload=$(python3 -c 'import json, os; print(json.dumps({"jsonrpc":"2.0","method":"sim_createRandomValidators","params":[5,8,12,[os.environ["LLM_PROVIDER"]],[os.environ["LLM_MODEL"]]],"id":1}))')
+          success=false
+          for attempt in 1 2 3; do
+            echo "Creating validators (attempt $attempt/3)..."
+            if response=$(curl --max-time 60 -sS -X POST http://localhost:4000/api \
+              -H "Content-Type: application/json" \
+              -d "$payload"); then
+              created=$(python3 -c "import json,sys; r=json.loads(sys.argv[1]); result=r.get('result', []); print(len(result) if isinstance(result, list) else 0)" "$response" 2>/dev/null || echo "0")
+              if [ "$created" -ge 5 ]; then
+                echo "Created $created validators"
                 success=true
                 break
               fi
-
               echo "Failed: $response"
-              if [ "$attempt" -lt 3 ]; then
-                echo "Retrying in 3s..."
-                sleep 3
-              fi
-            done
-
-            if [ "$success" = false ]; then
-              echo "ERROR: Could not create validator $i after 3 attempts"
-              exit 1
+            else
+              echo "Validator creation request failed"
             fi
 
-            # Brief pause between validators
-            if [ "$i" -lt 5 ]; then sleep 2; fi
+            if [ "$attempt" -lt 3 ]; then
+              echo "Retrying in 5s..."
+              sleep 5
+            fi
           done
+
+          if [ "$success" = false ]; then
+            echo "ERROR: Could not create validators after 3 attempts"
+            exit 1
+          fi
 
           echo "Waiting 5 seconds for validators to register..."
           sleep 5
@@ -459,34 +458,39 @@ jobs:
 
       - name: Re-setup validators for state integrity test
         timeout-minutes: 5
+        env:
+          LLM_PROVIDER: ${{ vars.LLM_PROVIDER || 'openrouter' }}
+          LLM_MODEL: ${{ vars.LLM_MODEL || 'deepseek/deepseek-v3.2' }}
         run: |
-          echo "Re-creating validators (previous step cleaned them up)..."
-          for i in {1..5}; do
-            success=false
-            for attempt in 1 2 3; do
-              echo "Creating validator $i/5 (attempt $attempt/3)..."
-              response=$(curl --max-time 20 -sS -X POST http://localhost:4000/api \
-                -H "Content-Type: application/json" \
-                -d "{\"jsonrpc\":\"2.0\",\"method\":\"sim_createRandomValidator\",\"params\":[1],\"id\":$i}")
-
-              has_result=$(python3 -c "import json,sys; r=json.loads(sys.argv[1]); print('yes' if 'result' in r else 'no')" "$response" 2>/dev/null || echo "no")
-              if [ "$has_result" = "yes" ]; then
-                echo "Validator $i created"
+          echo "Re-creating validators for $LLM_PROVIDER/$LLM_MODEL (previous step cleaned them up)..."
+          payload=$(python3 -c 'import json, os; print(json.dumps({"jsonrpc":"2.0","method":"sim_createRandomValidators","params":[5,8,12,[os.environ["LLM_PROVIDER"]],[os.environ["LLM_MODEL"]]],"id":1}))')
+          success=false
+          for attempt in 1 2 3; do
+            echo "Creating validators (attempt $attempt/3)..."
+            if response=$(curl --max-time 60 -sS -X POST http://localhost:4000/api \
+              -H "Content-Type: application/json" \
+              -d "$payload"); then
+              created=$(python3 -c "import json,sys; r=json.loads(sys.argv[1]); result=r.get('result', []); print(len(result) if isinstance(result, list) else 0)" "$response" 2>/dev/null || echo "0")
+              if [ "$created" -ge 5 ]; then
+                echo "Created $created validators"
                 success=true
                 break
               fi
-
               echo "Failed: $response"
-              if [ "$attempt" -lt 3 ]; then sleep 3; fi
-            done
-
-            if [ "$success" = false ]; then
-              echo "ERROR: Could not create validator $i after 3 attempts"
-              exit 1
+            else
+              echo "Validator creation request failed"
             fi
 
-            if [ "$i" -lt 5 ]; then sleep 2; fi
+            if [ "$attempt" -lt 3 ]; then
+              echo "Retrying in 5s..."
+              sleep 5
+            fi
           done
+
+          if [ "$success" = false ]; then
+            echo "ERROR: Could not create validators after 3 attempts"
+            exit 1
+          fi
 
           echo "Waiting 5 seconds for validators to register..."
           sleep 5

--- a/.github/workflows/unit-tests-pr.yml
+++ b/.github/workflows/unit-tests-pr.yml
@@ -52,6 +52,7 @@ jobs:
       - run: pip install pytest-cov pytest-xdist
       - run: pytest tests/unit --cov=backend --cov-report=xml --cov-branch -n auto
       - name: SonarCloud Scan
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         uses: sonarsource/sonarqube-scan-action@v7.0.0
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/backend/protocol_rpc/fees.py
+++ b/backend/protocol_rpc/fees.py
@@ -540,7 +540,7 @@ def studio_fee_config(policy: StudioFeePolicy | None = None) -> dict[str, Any]:
             "messageFees": {
                 "mode1": {
                     "accounting": True,
-                    "genvmExecution": False,
+                    "genvmExecution": True,
                 },
                 "mode2": {
                     "accounting": True,

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -19,7 +19,7 @@ jsonschema==4.26.0
 loguru==0.7.3
 web3==7.14.1
 PyYAML==6.0.3
-genvm-linter==0.10.0
+genvm-linter @ git+https://github.com/genlayerlabs/genvm-linter.git@fe426bcc28de0523294f5fb6b93280b1bb8de302
 
 # FastAPI and ASGI dependencies
 fastapi==0.135.1

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -19,7 +19,7 @@ jsonschema==4.26.0
 loguru==0.7.3
 web3==7.14.1
 PyYAML==6.0.3
-genvm-linter @ git+https://github.com/genlayerlabs/genvm-linter.git@fe426bcc28de0523294f5fb6b93280b1bb8de302
+genvm-linter==0.10.0
 
 # FastAPI and ASGI dependencies
 fastapi==0.135.1

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -19,7 +19,7 @@ jsonschema==4.26.0
 loguru==0.7.3
 web3==7.14.1
 PyYAML==6.0.3
-genvm-linter==0.7.1
+genvm-linter==0.10.0
 
 # FastAPI and ASGI dependencies
 fastapi==0.135.1

--- a/examples/contracts/log_indexer.py
+++ b/examples/contracts/log_indexer.py
@@ -1,7 +1,7 @@
 # v0.2.16
 # {
 #   "Seq": [
-#     { "Depends": "py-lib-genlayer-embeddings:09h0i209wrzh4xzq86f79c60x0ifs7xcjwl53ysrnw06i54ddxyi" },
+#     { "Depends": "py-lib-genlayer-embeddings:0bmbm3cyfwxsyh454z53vxqjf47wz2q7smcqp1q4g4a6k2kidnyk" },
 #     { "Depends": "py-genlayer:1jb45aa8ynh2a9c9xn3b7qqh8sm5q93hwfp7jqmwsfhh8jpz09h6" }
 #   ]
 # }
@@ -23,7 +23,12 @@ class StoreValue:
 
 # contract class
 class LogIndexer(gl.Contract):
-    vector_store: gle.VecDB[np.float32, typing.Literal[384], StoreValue]
+    vector_store: gle.VecDB[
+        np.float32,
+        typing.Literal[384],
+        StoreValue,
+        gle.EuclideanDistanceSquared,
+    ]
 
     def __init__(self):
         pass

--- a/tests/integration/icontracts/conftest.py
+++ b/tests/integration/icontracts/conftest.py
@@ -1,5 +1,6 @@
 import pytest
 import os
+import time
 from dotenv import load_dotenv
 from typing import Any
 
@@ -40,6 +41,27 @@ def get_mock_provider_config() -> dict[str, str]:
         "api_key_env_var": os.getenv("TEST_MOCK_API_KEY_ENV_VAR", "OPENROUTERAPIKEY"),
         "api_url": os.getenv("TEST_MOCK_API_URL", "https://openrouter.ai/api"),
     }
+
+
+def _wait_for_validator_count(min_count: int, timeout: float = 20.0) -> None:
+    deadline = time.monotonic() + timeout
+    last_count = 0
+    while time.monotonic() < deadline:
+        validators_result = post_request_localhost(
+            payload("sim_getAllValidators")
+        ).json()
+        assert has_success_status(validators_result)
+        last_count = len(validators_result.get("result", []))
+        if last_count >= min_count:
+            # Validator changes are delivered to workers via reload events.
+            # Give the consensus worker a short window to consume the update
+            # before the test submits a transaction.
+            time.sleep(2)
+            return
+        time.sleep(0.5)
+    raise AssertionError(
+        f"Expected at least {min_count} validators, found {last_count} after {timeout}s"
+    )
 
 
 @pytest.fixture
@@ -86,6 +108,7 @@ def setup_validators():
                 ).json()
                 assert has_success_status(result)
                 created_validator_addresses.append(result["result"]["address"])
+            _wait_for_validator_count(5)
         else:
             cfg = get_provider_config()
             # Non-mock mode: only create the validators that are still missing
@@ -110,6 +133,7 @@ def setup_validators():
                 # Track created validators for cleanup
                 for validator in result.get("result", []):
                     created_validator_addresses.append(validator["address"])
+            _wait_for_validator_count(5)
 
     yield _setup
 

--- a/tests/integration/icontracts/contracts/company_naming.py
+++ b/tests/integration/icontracts/contracts/company_naming.py
@@ -7,7 +7,7 @@ from genlayer import *
 MAX_SCORE_DIFFERENCE = 3
 
 
-class CompanyNaming(gl.contract.Contract):
+class CompanyNaming(gl.Contract):
     scores: TreeMap[str, u256]
 
     def __init__(self):

--- a/tests/integration/icontracts/contracts/company_naming.py
+++ b/tests/integration/icontracts/contracts/company_naming.py
@@ -1,12 +1,13 @@
 # { "Depends": "py-genlayer:test" }
 
 import json
+import genlayer as gl
 from genlayer import *
 
 MAX_SCORE_DIFFERENCE = 3
 
 
-class CompanyNaming(gl.Contract):
+class CompanyNaming(gl.contract.Contract):
     scores: TreeMap[str, u256]
 
     def __init__(self):

--- a/tests/integration/icontracts/contracts/error_execution_contract.py
+++ b/tests/integration/icontracts/contracts/error_execution_contract.py
@@ -5,7 +5,7 @@ import genlayer as gl
 from genlayer import *
 
 
-class ErrorExecutionContract(gl.contract.Contract):
+class ErrorExecutionContract(gl.Contract):
     state: TreeMap[str, str]
 
     def __init__(self, testcase: int, target_address: str | None = None):

--- a/tests/integration/icontracts/contracts/error_execution_contract.py
+++ b/tests/integration/icontracts/contracts/error_execution_contract.py
@@ -94,4 +94,4 @@ class ErrorExecutionContract(gl.contract.Contract):
     def test_cross_contract_call(self, target_address: str) -> None:
         """Test invalid cross-contract calls"""
         # Try to call a non-existent method on another contract
-        gl.get_contract_at(Address(target_address)).non_existent_method()
+        gl.contract.get_at(Address(target_address)).non_existent_method()

--- a/tests/integration/icontracts/contracts/error_execution_contract.py
+++ b/tests/integration/icontracts/contracts/error_execution_contract.py
@@ -1,10 +1,11 @@
 # v0.1.0
 # { "Depends": "py-genlayer:test" }
 
+import genlayer as gl
 from genlayer import *
 
 
-class ErrorExecutionContract(gl.Contract):
+class ErrorExecutionContract(gl.contract.Contract):
     state: TreeMap[str, str]
 
     def __init__(self, testcase: int, target_address: str | None = None):

--- a/tests/integration/icontracts/contracts/error_llm_contract.py
+++ b/tests/integration/icontracts/contracts/error_llm_contract.py
@@ -5,7 +5,7 @@ import genlayer as gl
 import json
 
 
-class ErrorLLMContract(gl.contract.Contract):
+class ErrorLLMContract(gl.Contract):
     def __init__(self, testcase: int):
         if testcase == 1:
             self.test_execute_prompt()

--- a/tests/integration/icontracts/contracts/error_llm_contract.py
+++ b/tests/integration/icontracts/contracts/error_llm_contract.py
@@ -1,11 +1,11 @@
 # v0.1.0
 # { "Depends": "py-genlayer:test" }
 
-from genlayer import *
+import genlayer as gl
 import json
 
 
-class ErrorLLMContract(gl.Contract):
+class ErrorLLMContract(gl.contract.Contract):
     def __init__(self, testcase: int):
         if testcase == 1:
             self.test_execute_prompt()

--- a/tests/integration/icontracts/contracts/error_web_contract.py
+++ b/tests/integration/icontracts/contracts/error_web_contract.py
@@ -1,10 +1,10 @@
 # v0.1.0
 # { "Depends": "py-genlayer:test" }
 
-from genlayer import *
+import genlayer as gl
 
 
-class ErrorWebContract(gl.Contract):
+class ErrorWebContract(gl.contract.Contract):
     def __init__(self, testcase: int, url: str):
 
         if testcase == 1:

--- a/tests/integration/icontracts/contracts/error_web_contract.py
+++ b/tests/integration/icontracts/contracts/error_web_contract.py
@@ -4,7 +4,7 @@
 import genlayer as gl
 
 
-class ErrorWebContract(gl.contract.Contract):
+class ErrorWebContract(gl.Contract):
     def __init__(self, testcase: int, url: str):
 
         if testcase == 1:

--- a/tests/integration/icontracts/contracts/genvm_smoke_v1.py
+++ b/tests/integration/icontracts/contracts/genvm_smoke_v1.py
@@ -1,4 +1,4 @@
-# { "Depends": "py-genlayer:1jb45aa8ynh2a9c9xn3b7qqh8sm5q93hwfp7jqmwsfhh8jpz09h6" }
+# { "Depends": "py-genlayer:test" }
 from genlayer import *
 
 

--- a/tests/integration/icontracts/contracts/intelligent_oracle.py
+++ b/tests/integration/icontracts/contracts/intelligent_oracle.py
@@ -15,7 +15,7 @@ class Status(Enum):
     ERROR = "Error"
 
 
-class IntelligentOracle(gl.contract.Contract):
+class IntelligentOracle(gl.Contract):
     # Declare persistent storage fields
     prediction_market_id: str
     title: str

--- a/tests/integration/icontracts/contracts/intelligent_oracle.py
+++ b/tests/integration/icontracts/contracts/intelligent_oracle.py
@@ -5,6 +5,7 @@ import json
 from enum import Enum
 from datetime import datetime
 from urllib.parse import urlparse
+import genlayer as gl
 from genlayer import *
 
 
@@ -14,7 +15,7 @@ class Status(Enum):
     ERROR = "Error"
 
 
-class IntelligentOracle(gl.Contract):
+class IntelligentOracle(gl.contract.Contract):
     # Declare persistent storage fields
     prediction_market_id: str
     title: str

--- a/tests/integration/icontracts/contracts/intelligent_oracle_factory.py
+++ b/tests/integration/icontracts/contracts/intelligent_oracle_factory.py
@@ -26,7 +26,7 @@ class Registry(gl.contract.Contract):
         earliest_resolution_date: str,
     ) -> None:
         registered_contracts = len(self.contract_addresses)
-        contract_address = gl.deploy_contract(
+        contract_address = gl.contract.deploy(
             code=self.intelligent_oracle_code.encode("utf-8"),
             args=[
                 prediction_market_id,

--- a/tests/integration/icontracts/contracts/intelligent_oracle_factory.py
+++ b/tests/integration/icontracts/contracts/intelligent_oracle_factory.py
@@ -5,7 +5,7 @@ import genlayer as gl
 from genlayer import *
 
 
-class Registry(gl.contract.Contract):
+class Registry(gl.Contract):
     # Declare persistent storage fields
     contract_addresses: DynArray[str]
     intelligent_oracle_code: str

--- a/tests/integration/icontracts/contracts/intelligent_oracle_factory.py
+++ b/tests/integration/icontracts/contracts/intelligent_oracle_factory.py
@@ -1,10 +1,11 @@
 # v0.1.0
 # { "Depends": "py-genlayer:test" }
 
+import genlayer as gl
 from genlayer import *
 
 
-class Registry(gl.Contract):
+class Registry(gl.contract.Contract):
     # Declare persistent storage fields
     contract_addresses: DynArray[str]
     intelligent_oracle_code: str

--- a/tests/integration/icontracts/contracts/multi_file_contract/__init__.py
+++ b/tests/integration/icontracts/contracts/multi_file_contract/__init__.py
@@ -8,7 +8,7 @@ class MultiFileContract(gl.contract.Contract):
     def __init__(self):
         with open("/contract/other.py", "rt") as f:
             text = f.read()
-        self.other_addr = gl.deploy_contract(
+        self.other_addr = gl.contract.deploy(
             code=text.encode("utf-8"),
             args=["123"],
             salt_nonce=u256(1),
@@ -21,4 +21,4 @@ class MultiFileContract(gl.contract.Contract):
 
     @gl.public.view
     def test(self) -> str:
-        return gl.get_contract_at(self.other_addr).view().test()
+        return gl.contract.get_at(self.other_addr).view().test()

--- a/tests/integration/icontracts/contracts/multi_file_contract/__init__.py
+++ b/tests/integration/icontracts/contracts/multi_file_contract/__init__.py
@@ -1,7 +1,8 @@
+import genlayer as gl
 from genlayer import *
 
 
-class MultiFileContract(gl.Contract):
+class MultiFileContract(gl.contract.Contract):
     other_addr: Address
 
     def __init__(self):

--- a/tests/integration/icontracts/contracts/multi_file_contract/__init__.py
+++ b/tests/integration/icontracts/contracts/multi_file_contract/__init__.py
@@ -2,7 +2,7 @@ import genlayer as gl
 from genlayer import *
 
 
-class MultiFileContract(gl.contract.Contract):
+class MultiFileContract(gl.Contract):
     other_addr: Address
 
     def __init__(self):

--- a/tests/integration/icontracts/contracts/multi_file_contract/other.py
+++ b/tests/integration/icontracts/contracts/multi_file_contract/other.py
@@ -1,9 +1,9 @@
 # { "Depends": "py-genlayer:test" }
 
-from genlayer import *
+import genlayer as gl
 
 
-class Other(gl.Contract):
+class Other(gl.contract.Contract):
     data: str
 
     def __init__(self, data: str):

--- a/tests/integration/icontracts/contracts/multi_file_contract/other.py
+++ b/tests/integration/icontracts/contracts/multi_file_contract/other.py
@@ -3,7 +3,7 @@
 import genlayer as gl
 
 
-class Other(gl.contract.Contract):
+class Other(gl.Contract):
     data: str
 
     def __init__(self, data: str):

--- a/tests/integration/icontracts/contracts/multi_read_erc20.py
+++ b/tests/integration/icontracts/contracts/multi_read_erc20.py
@@ -5,7 +5,7 @@ import genlayer as gl
 from genlayer import *
 
 
-class multi_read_erc20(gl.contract.Contract):
+class multi_read_erc20(gl.Contract):
     balances: TreeMap[Address, TreeMap[Address, u256]]
 
     def __init__(self):

--- a/tests/integration/icontracts/contracts/multi_read_erc20.py
+++ b/tests/integration/icontracts/contracts/multi_read_erc20.py
@@ -16,7 +16,7 @@ class multi_read_erc20(gl.contract.Contract):
         self, account_address: str, token_contracts: list[str]
     ) -> None:
         for token_contract in token_contracts:
-            contract = gl.get_contract_at(Address(token_contract))
+            contract = gl.contract.get_at(Address(token_contract))
             balance = contract.view().get_balance_of(account_address)
             self.balances.get_or_insert_default(Address(account_address))[
                 Address(token_contract)

--- a/tests/integration/icontracts/contracts/multi_read_erc20.py
+++ b/tests/integration/icontracts/contracts/multi_read_erc20.py
@@ -1,10 +1,11 @@
 # v0.1.0
 # { "Depends": "py-genlayer:test" }
 
+import genlayer as gl
 from genlayer import *
 
 
-class multi_read_erc20(gl.Contract):
+class multi_read_erc20(gl.contract.Contract):
     balances: TreeMap[Address, TreeMap[Address, u256]]
 
     def __init__(self):

--- a/tests/integration/icontracts/contracts/multi_tenant_storage.py
+++ b/tests/integration/icontracts/contracts/multi_tenant_storage.py
@@ -1,10 +1,11 @@
 # v0.1.0
 # { "Depends": "py-genlayer:test" }
 
+import genlayer as gl
 from genlayer import *
 
 
-class MultiTentantStorage(gl.Contract):
+class MultiTentantStorage(gl.contract.Contract):
     """
     Same functionality as UserStorage, but implemented with multiple storage contracts.
     Each user is assigned to a storage contract, and all storage contracts are managed by this same contract.

--- a/tests/integration/icontracts/contracts/multi_tenant_storage.py
+++ b/tests/integration/icontracts/contracts/multi_tenant_storage.py
@@ -5,7 +5,7 @@ import genlayer as gl
 from genlayer import *
 
 
-class MultiTentantStorage(gl.contract.Contract):
+class MultiTentantStorage(gl.Contract):
     """
     Same functionality as UserStorage, but implemented with multiple storage contracts.
     Each user is assigned to a storage contract, and all storage contracts are managed by this same contract.

--- a/tests/integration/icontracts/contracts/multi_tenant_storage.py
+++ b/tests/integration/icontracts/contracts/multi_tenant_storage.py
@@ -31,7 +31,7 @@ class MultiTentantStorage(gl.contract.Contract):
     @gl.public.view
     def get_all_storages(self) -> dict[str, str]:
         return {
-            storage_contract.as_hex: gl.get_contract_at(storage_contract)
+            storage_contract.as_hex: gl.contract.get_at(storage_contract)
             .view()
             .get_storage()
             for storage_contract in self.all_storage_contracts
@@ -47,4 +47,4 @@ class MultiTentantStorage(gl.contract.Contract):
             self.available_storage_contracts.pop()
 
         contract_to_use = self.mappings[gl.message.sender_address]
-        gl.get_contract_at(contract_to_use).emit().update_storage(new_storage)
+        gl.contract.get_at(contract_to_use).emit().update_storage(new_storage)

--- a/tests/integration/icontracts/contracts/read_erc20.py
+++ b/tests/integration/icontracts/contracts/read_erc20.py
@@ -1,10 +1,11 @@
 # v0.1.0
 # { "Depends": "py-genlayer:test" }
 
+import genlayer as gl
 from genlayer import *
 
 
-class read_erc20(gl.Contract):
+class read_erc20(gl.contract.Contract):
     token_contract: Address
 
     def __init__(self, token_contract: str):

--- a/tests/integration/icontracts/contracts/read_erc20.py
+++ b/tests/integration/icontracts/contracts/read_erc20.py
@@ -14,7 +14,7 @@ class read_erc20(gl.contract.Contract):
     @gl.public.view
     def get_balance_of(self, account_address: str) -> int:
         return (
-            gl.get_contract_at(self.token_contract)
+            gl.contract.get_at(self.token_contract)
             .view()
             .get_balance_of(account_address)
         )

--- a/tests/integration/icontracts/contracts/read_erc20.py
+++ b/tests/integration/icontracts/contracts/read_erc20.py
@@ -5,7 +5,7 @@ import genlayer as gl
 from genlayer import *
 
 
-class read_erc20(gl.contract.Contract):
+class read_erc20(gl.Contract):
     token_contract: Address
 
     def __init__(self, token_contract: str):

--- a/tests/integration/icontracts/contracts/utf8_roundtrip_contract.py
+++ b/tests/integration/icontracts/contracts/utf8_roundtrip_contract.py
@@ -1,10 +1,10 @@
 # v0.1.0
 # { "Depends": "py-genlayer:test" }
 
-from genlayer import *
+import genlayer as gl
 
 
-class Utf8RoundtripContract(gl.Contract):
+class Utf8RoundtripContract(gl.contract.Contract):
     value: str
 
     def __init__(self):

--- a/tests/integration/icontracts/contracts/utf8_roundtrip_contract.py
+++ b/tests/integration/icontracts/contracts/utf8_roundtrip_contract.py
@@ -4,7 +4,7 @@
 import genlayer as gl
 
 
-class Utf8RoundtripContract(gl.contract.Contract):
+class Utf8RoundtripContract(gl.Contract):
     value: str
 
     def __init__(self):

--- a/tests/integration/test_upgrade_contract.py
+++ b/tests/integration/test_upgrade_contract.py
@@ -51,6 +51,39 @@ def _wait_for_validator_count(min_count: int, timeout: float = 20.0) -> None:
     )
 
 
+def _mock_llms() -> bool:
+    return os.getenv("TEST_WITH_MOCK_LLMS", "false").lower() == "true"
+
+
+def _create_mock_validators() -> None:
+    from tests.common.request import payload, post_request_localhost
+    from tests.common.response import has_success_status
+
+    provider = os.getenv("TEST_MOCK_PROVIDER", "openrouter")
+    model = os.getenv("TEST_MOCK_MODEL", "@preset/rally-testnet-gpt-5-1")
+    api_key_env_var = os.getenv("TEST_MOCK_API_KEY_ENV_VAR", "OPENROUTERAPIKEY")
+    api_url = os.getenv("TEST_MOCK_API_URL", "https://openrouter.ai/api")
+
+    for _ in range(5):
+        result = post_request_localhost(
+            payload(
+                "sim_createValidator",
+                8,
+                provider,
+                model,
+                {"temperature": 0.75, "max_tokens": 500},
+                "openai-compatible",
+                {
+                    "api_key_env_var": api_key_env_var,
+                    "api_url": api_url,
+                    "mock_response": {},
+                },
+            )
+        ).json()
+        if not has_success_status(result):
+            pytest.fail(f"Failed to create mock validator: {result}")
+
+
 @pytest.fixture(scope="module", autouse=True)
 def ensure_validators_exist():
     """Ensure validators exist before running tests in this module.
@@ -67,14 +100,17 @@ def ensure_validators_exist():
     validators = response.get("result", [])
 
     if not validators:
-        # Match the provider/model configured by CI or the local test env.
-        provider = os.environ.get("TEST_PROVIDER", "openai")
-        model = os.environ.get("TEST_PROVIDER_MODEL", "gpt-4o")
-        result = post_request_localhost(
-            payload("sim_createRandomValidators", 5, 8, 12, [provider], [model])
-        ).json()
-        if not has_success_status(result):
-            pytest.fail(f"Failed to create validators: {result}")
+        if _mock_llms():
+            _create_mock_validators()
+        else:
+            # Match the provider/model configured by CI or the local test env.
+            provider = os.environ.get("TEST_PROVIDER", "openai")
+            model = os.environ.get("TEST_PROVIDER_MODEL", "gpt-4o")
+            result = post_request_localhost(
+                payload("sim_createRandomValidators", 5, 8, 12, [provider], [model])
+            ).json()
+            if not has_success_status(result):
+                pytest.fail(f"Failed to create validators: {result}")
 
     _wait_for_validator_count(5)
 

--- a/tests/integration/test_upgrade_contract.py
+++ b/tests/integration/test_upgrade_contract.py
@@ -28,6 +28,29 @@ RPC_URL = "http://localhost:4000/api"
 pytestmark = pytest.mark.xdist_group(name="mock_validators")
 
 
+def _wait_for_validator_count(min_count: int, timeout: float = 20.0) -> None:
+    from tests.common.request import payload, post_request_localhost
+    from tests.common.response import has_success_status
+
+    deadline = time.monotonic() + timeout
+    last_count = 0
+    while time.monotonic() < deadline:
+        response = post_request_localhost(payload("sim_getAllValidators")).json()
+        assert has_success_status(response)
+        last_count = len(response.get("result", []))
+        if last_count >= min_count:
+            # Validator registry changes are consumed by consensus workers via
+            # reload events; give workers time to observe the current registry
+            # before this module submits deploy/write transactions.
+            time.sleep(5)
+            return
+        time.sleep(0.5)
+
+    pytest.fail(
+        f"Expected at least {min_count} validators, found {last_count} after {timeout}s"
+    )
+
+
 @pytest.fixture(scope="module", autouse=True)
 def ensure_validators_exist():
     """Ensure validators exist before running tests in this module.
@@ -52,6 +75,8 @@ def ensure_validators_exist():
         ).json()
         if not has_success_status(result):
             pytest.fail(f"Failed to create validators: {result}")
+
+    _wait_for_validator_count(5)
 
     yield
 

--- a/tests/integration/test_upgrade_contract.py
+++ b/tests/integration/test_upgrade_contract.py
@@ -164,9 +164,10 @@ def write_contract_method(
 CONTRACT_V1 = """# v0.1.0
 # { "Depends": "py-genlayer:latest" }
 
+import genlayer as gl
 from genlayer import *
 
-class UpgradeTest(gl.Contract):
+class UpgradeTest(gl.contract.Contract):
     counter: u64
     name: str
 
@@ -198,9 +199,10 @@ class UpgradeTest(gl.Contract):
 CONTRACT_V2 = """# v0.1.0
 # { "Depends": "py-genlayer:latest" }
 
+import genlayer as gl
 from genlayer import *
 
-class UpgradeTest(gl.Contract):
+class UpgradeTest(gl.contract.Contract):
     counter: u64
     name: str
 
@@ -236,9 +238,10 @@ class UpgradeTest(gl.Contract):
 CONTRACT_V3_WITH_NEW_STATE = """# v0.1.0
 # { "Depends": "py-genlayer:latest" }
 
+import genlayer as gl
 from genlayer import *
 
-class UpgradeTest(gl.Contract):
+class UpgradeTest(gl.contract.Contract):
     counter: u64
     name: str
     extra_field: str  # NEW FIELD
@@ -276,9 +279,10 @@ class UpgradeTest(gl.Contract):
 INVALID_CONTRACT = """# v0.1.0
 # { "Depends": "py-genlayer:latest" }
 
+import genlayer as gl
 from genlayer import *
 
-class BrokenContract(gl.Contract):
+class BrokenContract(gl.contract.Contract):
     def __init__(self):
         this is not valid python syntax!!!
 """
@@ -286,9 +290,10 @@ class BrokenContract(gl.Contract):
 SIMPLE_CONTRACT = """# v0.1.0
 # { "Depends": "py-genlayer:latest" }
 
+import genlayer as gl
 from genlayer import *
 
-class SimpleContract(gl.Contract):
+class SimpleContract(gl.contract.Contract):
     value: u64
 
     def __init__(self):

--- a/tests/test_linter_endpoint.py
+++ b/tests/test_linter_endpoint.py
@@ -9,9 +9,10 @@ import requests
 # Test contract with various issues
 TEST_CONTRACT_WITH_ISSUES = """# Missing magic comment
 
+import genlayer as gl
 from genlayer import *
 
-class TestContract(gl.Contract):
+class TestContract(gl.contract.Contract):
     balance: int  # Should be u256
 
     # Missing __init__ method
@@ -24,9 +25,10 @@ class TestContract(gl.Contract):
 # Valid contract
 VALID_CONTRACT = """# { "Depends": "py-genlayer:test" }
 
+import genlayer as gl
 from genlayer import *
 
-class TestContract(gl.Contract):
+class TestContract(gl.contract.Contract):
     balance: u256
 
     def __init__(self):

--- a/tests/unit/test_get_contract_schema_for_code_endpoint.py
+++ b/tests/unit/test_get_contract_schema_for_code_endpoint.py
@@ -14,7 +14,8 @@ class TestGetContractSchemaForCodeEndpoint:
         self.msg_handler.with_client_session = Mock(return_value=self.msg_handler)
 
         # Sample contract code in different formats
-        self.simple_contract = """from genlayer import *
+        self.simple_contract = """import genlayer as gl
+from genlayer import *
 
 @gl_class
 class SimpleContract:
@@ -113,7 +114,8 @@ class SimpleContract:
     async def test_non_hex_string_with_special_characters(self):
         """Test UTF-8 fallback with contract code containing non-ASCII characters."""
         # Contract with non-ASCII characters (comments with unicode)
-        contract_with_unicode = """from genlayer import *
+        contract_with_unicode = """import genlayer as gl
+from genlayer import *
 
 @gl_class
 class UnicodeContract:

--- a/tests/unit/test_studio_fees.py
+++ b/tests/unit/test_studio_fees.py
@@ -503,7 +503,7 @@ def test_studio_fee_config_exposes_default_nonzero_fee_policy():
     )
     assert config["capabilities"]["messageFees"]["mode1"] == {
         "accounting": True,
-        "genvmExecution": False,
+        "genvmExecution": True,
     }
     assert config["capabilities"]["messageFees"]["mode2"]["genvmExecution"] is True
     assert config["defaultFees"]["distribution"]["maxPriceGenPerTimeUnit"] == str(
@@ -3650,6 +3650,33 @@ def test_mode1_message_fees_reject_declared_budget_below_child_minimum():
                     "onAcceptance": True,
                     "feeParams": _encode_internal_fee_params(),
                     "declaredBudget": 54,
+                }
+            ],
+        )
+
+
+def test_external_messages_reject_nonzero_declared_budget_at_reveal():
+    accounting = create_fee_accounting(
+        fees_distribution=_fees_distribution(total_message_fees=100),
+        num_of_validators=5,
+        submitted_value=1200,
+        user_value=0,
+    )
+
+    with pytest.raises(MessageDeclaredBudgetInsufficient):
+        consume_message_fees(
+            accounting,
+            [
+                {
+                    "messageType": 0,
+                    "recipient": "0x2222222222222222222222222222222222222222",
+                    "onAcceptance": False,
+                    "feeParams": _encode_external_fee_params(
+                        gas_limit=10,
+                        max_gas_price=1,
+                    ),
+                    "declaredBudget": 1,
+                    "callKey": "0x" + "12" * 32,
                 }
             ],
         )


### PR DESCRIPTION
## Summary
- report Mode 1 message fees as GenVM-executable now that Studio passes the Mode 1 bucket through to GenVM
- add a low-level regression that external messages reject non-zero declaredBudget at reveal, matching consensus v0.6

## Validation
- .venv/bin/python -m pytest tests/unit/test_studio_fees.py -q
- .venv/bin/pre-commit run --files backend/protocol_rpc/fees.py tests/unit/test_studio_fees.py

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Studio fee configuration now advertises GenVM execution availability for message handling.

* **Bug Fixes**
  * External messages with a non-zero declared budget are rejected at reveal time to prevent improper fee acceptance.

* **Chores**
  * CI workflows updated for more reliable disk usage, timeouts, and linting tool pinning.

* **Tests**
  * Integration/unit tests updated for validator synchronization and compatibility with the updated GenLayer import/API shape.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->