### PR TITLE
ci: repoint release lane dispatch to AWS (devexp-argocd-apps)

### DIFF
--- a/.github/workflows/release-from-main.yml
+++ b/.github/workflows/release-from-main.yml
@@ -43,7 +43,7 @@ jobs:
     secrets: inherit
 
   trigger-workload-release-lane:
-    name: Trigger Workload Release Lane
+    name: Trigger AWS Release Lane
     runs-on: ubuntu-latest
     needs: push-docker-images
     steps:
@@ -52,12 +52,15 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Get CI Bot Token
-        id: ci_bot_token
-        uses: tibdex/github-app-token@v2
+      - name: Get release-lane token
+        id: release_lane_token
+        uses: actions/create-github-app-token@v3
         with:
-          app_id: ${{ secrets.CI_BOT_APP_ID }}
-          private_key: ${{ secrets.CI_BOT_SECRET }}
+          client-id: ${{ vars.RELEASE_LANE_APP_CLIENT_ID }}
+          private-key: ${{ secrets.RELEASE_LANE_APP_KEY }}
+          # Token scoped to the AWS release-lane repo we dispatch into.
+          owner: ${{ github.repository_owner }}
+          repositories: devexp-argocd-apps
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -210,10 +213,10 @@ jobs:
           echo "image=${image_digest_ref}" >> "$GITHUB_OUTPUT"
           echo "Resolved digest reference: ${image_digest_ref}"
 
-      - name: Trigger workload release lane
+      - name: Trigger AWS release lane (devexp-argocd-apps)
         run: |
           curl -sSfL -X POST \
             -H "Accept: application/vnd.github+json" \
-            -H "Authorization: Bearer ${{ steps.ci_bot_token.outputs.token }}" \
-            https://api.github.com/repos/genlayerlabs/devexp-apps-workload/actions/workflows/release-studio-backend-start.yml/dispatches \
-            -d "{\"ref\":\"main\",\"inputs\":{\"image\":\"${{ steps.digest.outputs.image }}\",\"consensus_worker_image\":\"${{ steps.worker_digest.outputs.image }}\",\"frontend_image\":\"${{ steps.frontend_digest.outputs.image }}\",\"explorer_image\":\"${{ steps.explorer_digest.outputs.image }}\",\"migration_image\":\"${{ steps.migration_digest.outputs.image }}\"}}"
+            -H "Authorization: Bearer ${{ steps.release_lane_token.outputs.token }}" \
+            https://api.github.com/repos/genlayerlabs/devexp-argocd-apps/dispatches \
+            -d "{\"event_type\":\"release-backend\",\"client_payload\":{\"image\":\"${{ steps.digest.outputs.image }}\",\"consensus_worker_image\":\"${{ steps.worker_digest.outputs.image }}\",\"frontend_image\":\"${{ steps.frontend_digest.outputs.image }}\",\"explorer_image\":\"${{ steps.explorer_digest.outputs.image }}\",\"migration_image\":\"${{ steps.migration_digest.outputs.image }}\"}}"


### PR DESCRIPTION
Repoints `release-from-main.yml`'s post-build dispatch from the GCP workload repo to the AWS release lane in `genlayerlabs/devexp-argocd-apps`.

- `trigger-workload-release-lane` now mints a token from the **release-lane GitHub App** (`actions/create-github-app-token@v3`, scoped to `devexp-argocd-apps`) instead of the shared CI bot via `tibdex/github-app-token`.
- Dispatch switched to `repository_dispatch` (`event_type=release-backend`); was a `workflow_dispatch` against the GCP `release-studio-backend-start.yml`.

Part of the dev+stg→AWS cutover: AWS owns dev/stg/rally-prd-tier and fans out to GCP for true-prd.

**Requires** repo var `RELEASE_LANE_APP_CLIENT_ID` + secret `RELEASE_LANE_APP_KEY` and the release-lane App installed on this repo.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release deployment workflow configuration to enhance the efficiency and security of the automated release process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->