### PR TITLE
ci: disable scheduled studio release

### DIFF
--- a/.github/workflows/release-from-main.yml
+++ b/.github/workflows/release-from-main.yml
@@ -3,8 +3,6 @@ on:
   push:
     branches:
       - main
-  schedule:
-    - cron: "00 08 * * 1-4" # 08:00 AM (UTC) from Monday to Thursday
   workflow_dispatch:
 permissions:
   contents: read # for checkout


### PR DESCRIPTION
Summary: remove the weekday cron from the Create releases from main workflow. Main-push and manual workflow_dispatch entry points remain. Context: Docker image builds already listen for release tags, so the scheduled path can trigger unintended release-lane runs. Validation: git diff --check passed; YAML pre-commit passed during commit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release workflow configuration to optimize deployment triggers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->