### PR TITLE
fix: derive rate limit identity from forwarded client ip

### DIFF
--- a/backend/protocol_rpc/rate_limit_middleware.py
+++ b/backend/protocol_rpc/rate_limit_middleware.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import logging
+import os
+from ipaddress import ip_address, ip_network
 from typing import Optional
 
 from starlette.middleware.base import BaseHTTPMiddleware
@@ -14,9 +16,39 @@ from backend.protocol_rpc.rate_limiter import RateLimiterService
 
 logger = logging.getLogger(__name__)
 
+DEFAULT_TRUSTED_PROXY_CIDRS = (
+    "127.0.0.0/8",
+    "10.0.0.0/8",
+    "172.16.0.0/12",
+    "192.168.0.0/16",
+    "::1/128",
+    "fc00::/7",
+)
+
+
+def _load_trusted_proxy_networks():
+    raw = os.environ.get(
+        "RATE_LIMIT_TRUSTED_PROXIES",
+        ",".join(DEFAULT_TRUSTED_PROXY_CIDRS),
+    )
+    networks = []
+    for value in raw.split(","):
+        value = value.strip()
+        if not value:
+            continue
+        try:
+            networks.append(ip_network(value, strict=False))
+        except ValueError:
+            logger.warning("Ignoring invalid RATE_LIMIT_TRUSTED_PROXIES entry")
+    return tuple(networks)
+
 
 class RateLimitMiddleware(BaseHTTPMiddleware):
     """Intercepts /api requests to enforce tiered rate limits."""
+
+    def __init__(self, app, dispatch=None):
+        super().__init__(app, dispatch=dispatch)
+        self._trusted_proxy_networks = _load_trusted_proxy_networks()
 
     async def dispatch(self, request: Request, call_next) -> Response:
         # Only rate-limit the JSON-RPC endpoint
@@ -30,7 +62,7 @@ class RateLimitMiddleware(BaseHTTPMiddleware):
             return await call_next(request)
 
         api_key = request.headers.get("X-API-Key")
-        client_ip = request.client.host if request.client else "unknown"
+        client_ip = self._client_ip(request)
 
         try:
             await rate_limiter.check_rate_limit(api_key, client_ip)
@@ -54,3 +86,60 @@ class RateLimitMiddleware(BaseHTTPMiddleware):
             )
 
         return await call_next(request)
+
+    def _client_ip(self, request: Request) -> str:
+        peer_host = request.client.host if request.client else "unknown"
+        if not self._is_trusted_proxy(peer_host):
+            return peer_host
+
+        forwarded_for = request.headers.get("X-Forwarded-For")
+        if forwarded_for:
+            forwarded_ip = self._forwarded_client_ip(forwarded_for)
+            if forwarded_ip is not None:
+                return forwarded_ip
+
+        real_ip = self._valid_ip_header(request.headers.get("X-Real-IP"))
+        if real_ip:
+            return real_ip
+
+        return peer_host
+
+    def _forwarded_client_ip(self, forwarded_for: str) -> Optional[str]:
+        parsed = self._parse_forwarded_for(forwarded_for)
+        for value, parsed_ip in reversed(parsed):
+            if not self._is_trusted_ip(parsed_ip):
+                return value
+        if parsed:
+            return parsed[0][0]
+        return None
+
+    def _parse_forwarded_for(self, forwarded_for: str) -> list[tuple[str, object]]:
+        parsed = []
+        for value in forwarded_for.split(","):
+            value = value.strip()
+            if not value:
+                continue
+            try:
+                parsed.append((value, ip_address(value)))
+            except ValueError:
+                continue
+        return parsed
+
+    def _valid_ip_header(self, value: Optional[str]) -> Optional[str]:
+        if not value:
+            return None
+        value = value.strip()
+        try:
+            ip_address(value)
+        except ValueError:
+            return None
+        return value
+
+    def _is_trusted_proxy(self, host: str) -> bool:
+        try:
+            return self._is_trusted_ip(ip_address(host))
+        except ValueError:
+            return False
+
+    def _is_trusted_ip(self, parsed_ip) -> bool:
+        return any(parsed_ip in network for network in self._trusted_proxy_networks)

--- a/backend/protocol_rpc/rate_limiter.py
+++ b/backend/protocol_rpc/rate_limiter.py
@@ -20,6 +20,9 @@ from backend.protocol_rpc.exceptions import RateLimitExceeded
 logger = logging.getLogger(__name__)
 
 TIER_CACHE_TTL = 300  # 5 minutes
+DEFAULT_ANON_PER_MINUTE = 30
+DEFAULT_ANON_PER_HOUR = 500
+DEFAULT_ANON_PER_DAY = 5000
 
 # Lua script that atomically prunes, checks, and records in one round-trip.
 # This eliminates the TOCTOU race where concurrent requests could all read the
@@ -75,9 +78,9 @@ class RateLimiterService:
         redis_client: aioredis.Redis,
         get_session: Callable[[], Session],
         enabled: bool = True,
-        anon_per_minute: int = 10,
-        anon_per_hour: int = 100,
-        anon_per_day: int = 1000,
+        anon_per_minute: int = DEFAULT_ANON_PER_MINUTE,
+        anon_per_hour: int = DEFAULT_ANON_PER_HOUR,
+        anon_per_day: int = DEFAULT_ANON_PER_DAY,
     ):
         self._redis = redis_client
         self._get_session = get_session
@@ -100,9 +103,15 @@ class RateLimiterService:
             redis_client=redis_client,
             get_session=get_session,
             enabled=os.environ.get("RATE_LIMIT_ENABLED", "false").lower() == "true",
-            anon_per_minute=int(os.environ.get("RATE_LIMIT_ANON_PER_MINUTE", "10")),
-            anon_per_hour=int(os.environ.get("RATE_LIMIT_ANON_PER_HOUR", "100")),
-            anon_per_day=int(os.environ.get("RATE_LIMIT_ANON_PER_DAY", "1000")),
+            anon_per_minute=int(
+                os.environ.get("RATE_LIMIT_ANON_PER_MINUTE", DEFAULT_ANON_PER_MINUTE)
+            ),
+            anon_per_hour=int(
+                os.environ.get("RATE_LIMIT_ANON_PER_HOUR", DEFAULT_ANON_PER_HOUR)
+            ),
+            anon_per_day=int(
+                os.environ.get("RATE_LIMIT_ANON_PER_DAY", DEFAULT_ANON_PER_DAY)
+            ),
         )
 
     @property

--- a/tests/unit/test_rate_limit_middleware.py
+++ b/tests/unit/test_rate_limit_middleware.py
@@ -9,15 +9,26 @@ from backend.protocol_rpc.rate_limit_middleware import RateLimitMiddleware
 from backend.protocol_rpc.exceptions import RateLimitExceeded
 
 
-def _make_request(path="/api", method="POST", api_key=None, client_host="127.0.0.1"):
+def _make_request(
+    path="/api",
+    method="POST",
+    api_key=None,
+    client_host="127.0.0.1",
+    headers=None,
+):
     """Create a mock Starlette Request."""
+    headers = headers or {}
     request = MagicMock()
     request.url.path = path
     request.method = method
     request.headers = MagicMock()
-    request.headers.get = MagicMock(
-        side_effect=lambda k, default=None: api_key if k == "X-API-Key" else default
-    )
+
+    def get_header(key, default=None):
+        if key == "X-API-Key":
+            return api_key
+        return headers.get(key, headers.get(key.lower(), default))
+
+    request.headers.get = MagicMock(side_effect=get_header)
     request.client = MagicMock()
     request.client.host = client_host
     # app.state for rate_limiter access
@@ -150,6 +161,116 @@ class TestMiddlewareRateLimiting:
         await middleware.dispatch(request, call_next)
 
         limiter.check_rate_limit.assert_called_once_with("glk_testkey123", "127.0.0.1")
+
+    @pytest.mark.asyncio
+    async def test_uses_forwarded_client_ip_from_trusted_proxy(self):
+        limiter = AsyncMock()
+        limiter.enabled = True
+        limiter.check_rate_limit = AsyncMock(return_value=None)
+        request = _make_request(
+            client_host="127.0.0.1",
+            headers={"X-Forwarded-For": "198.51.100.7, 10.0.12.34"},
+        )
+        request.app.state.rate_limiter = limiter
+        call_next = _make_call_next()
+
+        middleware = RateLimitMiddleware(app=MagicMock())
+        await middleware.dispatch(request, call_next)
+
+        limiter.check_rate_limit.assert_called_once_with(None, "198.51.100.7")
+
+    @pytest.mark.asyncio
+    async def test_ignores_forwarded_client_ip_from_untrusted_peer(self):
+        limiter = AsyncMock()
+        limiter.enabled = True
+        limiter.check_rate_limit = AsyncMock(return_value=None)
+        request = _make_request(
+            client_host="198.51.100.9",
+            headers={"X-Forwarded-For": "203.0.113.7"},
+        )
+        request.app.state.rate_limiter = limiter
+        call_next = _make_call_next()
+
+        middleware = RateLimitMiddleware(app=MagicMock())
+        await middleware.dispatch(request, call_next)
+
+        limiter.check_rate_limit.assert_called_once_with(None, "198.51.100.9")
+
+    @pytest.mark.asyncio
+    async def test_uses_first_forwarded_ip_when_all_hops_are_trusted(self):
+        limiter = AsyncMock()
+        limiter.enabled = True
+        limiter.check_rate_limit = AsyncMock(return_value=None)
+        request = _make_request(
+            client_host="127.0.0.1",
+            headers={"X-Forwarded-For": "10.0.12.7, 172.16.4.5"},
+        )
+        request.app.state.rate_limiter = limiter
+        call_next = _make_call_next()
+
+        middleware = RateLimitMiddleware(app=MagicMock())
+        await middleware.dispatch(request, call_next)
+
+        limiter.check_rate_limit.assert_called_once_with(None, "10.0.12.7")
+
+    @pytest.mark.asyncio
+    async def test_uses_real_ip_from_trusted_proxy_when_forwarded_for_missing(self):
+        limiter = AsyncMock()
+        limiter.enabled = True
+        limiter.check_rate_limit = AsyncMock(return_value=None)
+        request = _make_request(
+            client_host="127.0.0.1",
+            headers={"X-Real-IP": "203.0.113.12"},
+        )
+        request.app.state.rate_limiter = limiter
+        call_next = _make_call_next()
+
+        middleware = RateLimitMiddleware(app=MagicMock())
+        await middleware.dispatch(request, call_next)
+
+        limiter.check_rate_limit.assert_called_once_with(None, "203.0.113.12")
+
+    @pytest.mark.asyncio
+    async def test_falls_back_to_peer_when_forwarded_headers_are_invalid(self):
+        limiter = AsyncMock()
+        limiter.enabled = True
+        limiter.check_rate_limit = AsyncMock(return_value=None)
+        request = _make_request(
+            client_host="127.0.0.1",
+            headers={
+                "X-Forwarded-For": "not-an-ip, ",
+                "X-Real-IP": "also-not-an-ip",
+            },
+        )
+        request.app.state.rate_limiter = limiter
+        call_next = _make_call_next()
+
+        middleware = RateLimitMiddleware(app=MagicMock())
+        await middleware.dispatch(request, call_next)
+
+        limiter.check_rate_limit.assert_called_once_with(None, "127.0.0.1")
+
+    @pytest.mark.asyncio
+    async def test_invalid_trusted_proxy_config_is_ignored(self, monkeypatch, caplog):
+        monkeypatch.setenv(
+            "RATE_LIMIT_TRUSTED_PROXIES",
+            "127.0.0.1/32,not-a-cidr,",
+        )
+        limiter = AsyncMock()
+        limiter.enabled = True
+        limiter.check_rate_limit = AsyncMock(return_value=None)
+        request = _make_request(
+            client_host="127.0.0.1",
+            headers={"X-Forwarded-For": "198.51.100.7"},
+        )
+        request.app.state.rate_limiter = limiter
+        call_next = _make_call_next()
+
+        middleware = RateLimitMiddleware(app=MagicMock())
+        await middleware.dispatch(request, call_next)
+
+        assert "Ignoring invalid RATE_LIMIT_TRUSTED_PROXIES entry" in caplog.text
+        limiter.check_rate_limit.assert_called_once_with(None, "198.51.100.7")
 
     @pytest.mark.asyncio
     async def test_retry_after_header_with_no_data(self):

--- a/tests/unit/test_rate_limiter.py
+++ b/tests/unit/test_rate_limiter.py
@@ -275,3 +275,6 @@ class TestFromEnvironment:
                 get_session=MagicMock(),
             )
         assert service.enabled is False
+        assert service._anon_limits.rate_limit_minute == 30
+        assert service._anon_limits.rate_limit_hour == 500
+        assert service._anon_limits.rate_limit_day == 5000


### PR DESCRIPTION
## Summary

Fix JSON-RPC anonymous rate limiting so it keys on the original client IP when Studio is behind trusted proxies/sidecars, instead of always using the immediate peer address.

This targets the `v0.121` release branch for a `v0.121.5` patch release.

## Root Cause

The AWS Studio JSON-RPC deployment enables `RATE_LIMIT_ENABLED=true` and the nginx sidecar forwards requests to the app. The middleware was using `request.client.host`, which can be the sidecar or another trusted proxy hop. That means unrelated anonymous traffic can collapse into one Redis rate-limit bucket and hit the default anonymous ceiling.

## Changes

- Resolve client identity from `X-Forwarded-For` / `X-Real-IP` only when the immediate peer is trusted.
- Default trusted proxy networks to loopback, RFC1918, and ULA ranges, with `RATE_LIMIT_TRUSTED_PROXIES` as an override.
- Raise anonymous default limits to the prod baseline: `30/min`, `500/hour`, `5000/day`.
- Add unit coverage for trusted forwarded IP handling, untrusted spoof protection, fallback behavior, invalid proxy config, and the new defaults.

## Validation

- `.venv/bin/python -m pytest tests/unit/test_rate_limit_middleware.py tests/unit/test_rate_limiter.py` - 32 passed
- `git diff --check`

Note: the local venv reports one pytest config warning because `pytest-timeout` is not installed locally; the focused tests still passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Rate limiting now supports proxy-aware client IP resolution with configurable trusted proxies for accurate request tracking.
  * Anonymous user rate limits are now configurable with sensible defaults.

* **Tests**
  * Added comprehensive tests for proxy IP forwarding and rate limit configuration behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->