### PR TITLE
[codex] Fix finalization deadlock and surface stuck-head context

### DIFF
--- a/.github/workflows/docker-build-and-push-all.yml
+++ b/.github/workflows/docker-build-and-push-all.yml
@@ -19,6 +19,9 @@ on:
       image_tag:
         required: true
         type: string
+    secrets:
+      DOCKERHUB_TOKEN:
+        required: true
 
 permissions:
   contents: read

--- a/.github/workflows/frontend-unit-tests.yml
+++ b/.github/workflows/frontend-unit-tests.yml
@@ -32,5 +32,5 @@ jobs:
         with:
           verbose: true
           token: ${{ secrets.codecov_token }}
-          fail_ci_if_error: true
+          fail_ci_if_error: false
           directory: frontend/coverage

--- a/.github/workflows/manual-docker-release.yml
+++ b/.github/workflows/manual-docker-release.yml
@@ -73,4 +73,6 @@ jobs:
     uses: ./.github/workflows/release-from-tag.yml
     with:
       tag: ${{ github.event.inputs.version }}
-    secrets: inherit
+    secrets:
+      DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+      RELEASE_LANE_APP_KEY: ${{ secrets.RELEASE_LANE_APP_KEY }}

--- a/.github/workflows/release-from-tag.yml
+++ b/.github/workflows/release-from-tag.yml
@@ -16,6 +16,11 @@ on:
         description: "Release tag to build and promote"
         required: true
         type: string
+    secrets:
+      DOCKERHUB_TOKEN:
+        required: true
+      RELEASE_LANE_APP_KEY:
+        required: true
 
 permissions:
   contents: read
@@ -87,7 +92,8 @@ jobs:
     with:
       ref: ${{ needs.validate-tag.outputs.tag }}
       image_tag: ${{ needs.validate-tag.outputs.tag }}
-    secrets: inherit
+    secrets:
+      DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
 
   trigger-workload-release-lane:
     name: Trigger AWS Release Lane
@@ -108,7 +114,7 @@ jobs:
           repositories: devexp-argocd-apps
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f
 
       - name: Resolve image digests
         id: digests

--- a/backend/consensus/worker.py
+++ b/backend/consensus/worker.py
@@ -478,9 +478,14 @@ class ConsensusWorker:
                     -- This clause makes PENDING/ACTIVATED claims defer when an
                     -- ACCEPTED-class tx for the same contract is past its
                     -- finality window — letting finalization drain the queue.
+                    -- Only older finalizations can preempt this candidate:
+                    -- claim_next_finalization will not claim a younger tx while
+                    -- this candidate is still non-terminal, so deferring here
+                    -- would deadlock the contract head.
                     AND NOT EXISTS (
                         SELECT 1 FROM transactions t3
                         WHERE t3.to_address IS NOT DISTINCT FROM t.to_address
+                            AND t3.created_at < t.created_at
                             AND t3.status IN ('ACCEPTED', 'UNDETERMINED', 'LEADER_TIMEOUT', 'VALIDATORS_TIMEOUT')
                             AND t3.appealed = false
                             AND t3.timestamp_awaiting_finalization IS NOT NULL

--- a/backend/protocol_rpc/health.py
+++ b/backend/protocol_rpc/health.py
@@ -216,6 +216,26 @@ def _evaluate_permit_readiness(
 METRICS_SEND_INTERVAL = 6
 _no_progress_scan_suppressed_until: float = 0.0
 
+# Statuses where the consensus state machine is actively working.
+# The "head of queue stuck" check uses ONLY these: ACCEPTED-class
+# statuses are post-consensus and live under the separate
+# finalization-stall detector below.
+CONSENSUS_ACTIVE_STATUSES_SQL = "'ACTIVATED','PROPOSING','COMMITTING','REVEALING'"
+# Broader set including finalization-pending statuses. Used only
+# in the "is any worker actively claiming on this contract" NOT
+# EXISTS clause — a finalization worker counts as active work and
+# should mask a stuck consensus head.
+ANY_INFLIGHT_STATUSES_SQL = (
+    "'ACTIVATED','PROPOSING','COMMITTING','REVEALING',"
+    "'ACCEPTED','UNDETERMINED','LEADER_TIMEOUT','VALIDATORS_TIMEOUT'"
+)
+FINALIZATION_ELIGIBLE_STATUSES_SQL = (
+    "'ACCEPTED','UNDETERMINED','LEADER_TIMEOUT','VALIDATORS_TIMEOUT'"
+)
+PRE_CONSENSUS_BACKLOG_STATUSES_SQL = (
+    "'PENDING','ACTIVATED','PROPOSING','COMMITTING','REVEALING'"
+)
+
 
 def get_health_check_interval() -> float:
     """Get health check interval from env (default 10s)."""
@@ -310,6 +330,9 @@ async def _run_health_checks() -> None:
             ),
             "orphaned_transactions": consensus_health.get(
                 "total_orphaned_transactions", 0
+            ),
+            "stuck_head_transactions": consensus_health.get(
+                "stuck_head_transactions", []
             ),
             "stuck_finalization_count": consensus_health.get(
                 "stuck_finalization_count", 0
@@ -635,26 +658,7 @@ async def _check_consensus_health() -> Dict[str, Any]:
     MAX_RECOVERY_EXHAUSTED_EVENT_LIMIT = int(
         os.environ.get("HEALTH_MAX_RECOVERY_EXHAUSTED_EVENT_LIMIT", "10")
     )
-
-    # Statuses where the consensus state machine is actively working.
-    # The "head of queue stuck" check uses ONLY these: ACCEPTED-class
-    # statuses are post-consensus and live under the separate
-    # finalization-stall detector below.
-    CONSENSUS_ACTIVE_STATUSES_SQL = "'ACTIVATED','PROPOSING','COMMITTING','REVEALING'"
-    # Broader set including finalization-pending statuses. Used only
-    # in the "is any worker actively claiming on this contract" NOT
-    # EXISTS clause — a finalization worker counts as active work and
-    # should mask a stuck consensus head.
-    ANY_INFLIGHT_STATUSES_SQL = (
-        "'ACTIVATED','PROPOSING','COMMITTING','REVEALING',"
-        "'ACCEPTED','UNDETERMINED','LEADER_TIMEOUT','VALIDATORS_TIMEOUT'"
-    )
-    FINALIZATION_ELIGIBLE_STATUSES_SQL = (
-        "'ACCEPTED','UNDETERMINED','LEADER_TIMEOUT','VALIDATORS_TIMEOUT'"
-    )
-    PRE_CONSENSUS_BACKLOG_STATUSES_SQL = (
-        "'PENDING','ACTIVATED','PROPOSING','COMMITTING','REVEALING'"
-    )
+    STUCK_HEAD_EVENT_LIMIT = int(os.environ.get("HEALTH_STUCK_HEAD_EVENT_LIMIT", "10"))
 
     try:
         if not _rpc_router_ref:
@@ -698,7 +702,7 @@ async def _check_consensus_health() -> Dict[str, Any]:
                 # masks the alarm.
                 # Returns the count of AFFECTED CONTRACTS, not the
                 # count of queued txs behind them.
-                stuck_row = conn.execute(
+                stuck_rows = conn.execute(
                     text(
                         f"""
                         WITH heads AS (
@@ -711,26 +715,52 @@ async def _check_consensus_health() -> Dict[str, Any]:
                             WHERE status IN ({CONSENSUS_ACTIVE_STATUSES_SQL})
                               AND to_address IS NOT NULL
                             ORDER BY to_address, created_at ASC, hash ASC
+                        ),
+                        stuck_heads AS (
+                            SELECT
+                                h.to_address,
+                                h.hash,
+                                h.status,
+                                h.created_at
+                            FROM heads h
+                            WHERE h.created_at < NOW() - make_interval(mins => :head_stuck_minutes)
+                              AND NOT EXISTS (
+                                  SELECT 1
+                                  FROM transactions t2
+                                  WHERE t2.to_address = h.to_address
+                                    AND t2.status IN ({ANY_INFLIGHT_STATUSES_SQL})
+                                    AND t2.blocked_at IS NOT NULL
+                                    AND t2.blocked_at > NOW() - make_interval(mins => :claim_window)
+                              )
                         )
-                        SELECT COUNT(*) AS stuck_heads
-                        FROM heads h
-                        WHERE h.created_at < NOW() - make_interval(mins => :head_stuck_minutes)
-                          AND NOT EXISTS (
-                              SELECT 1
-                              FROM transactions t2
-                              WHERE t2.to_address = h.to_address
-                                AND t2.status IN ({ANY_INFLIGHT_STATUSES_SQL})
-                                AND t2.blocked_at IS NOT NULL
-                                AND t2.blocked_at > NOW() - make_interval(mins => :claim_window)
-                          )
+                        SELECT
+                            COUNT(*) OVER() AS total_count,
+                            hash AS tx_hash,
+                            to_address,
+                            status,
+                            EXTRACT(EPOCH FROM created_at)::bigint
+                                AS created_at_epoch
+                        FROM stuck_heads
+                        ORDER BY created_at ASC, hash ASC
+                        LIMIT :event_limit
                         """
                     ),
                     {
                         "head_stuck_minutes": HEAD_STUCK_AFTER_MINUTES,
                         "claim_window": CLAIM_WINDOW_MINUTES,
+                        "event_limit": STUCK_HEAD_EVENT_LIMIT,
                     },
-                ).fetchone()
-                stuck_head_contracts = stuck_row.stuck_heads if stuck_row else 0
+                ).fetchall()
+                stuck_head_contracts = stuck_rows[0].total_count if stuck_rows else 0
+                stuck_head_transactions = [
+                    {
+                        "hash": row.tx_hash,
+                        "contract_address": row.to_address,
+                        "status": row.status,
+                        "created_at": row.created_at_epoch,
+                    }
+                    for row in stuck_rows
+                ]
 
                 # Stuck finalizations: ACCEPTED-class txs waiting too
                 # long to reach FINALIZED. Two paths:
@@ -1018,6 +1048,7 @@ async def _check_consensus_health() -> Dict[str, Any]:
                     # external dashboard. Semantics: count of CONTRACTS
                     # whose consensus head is stuck.
                     "total_orphaned_transactions": stuck_head_contracts,
+                    "stuck_head_transactions": stuck_head_transactions,
                     "stuck_finalization_count": stuck_finalization_count,
                     "recovery_storm_count": recovery_storm_count,
                     "max_recovery_count": max_recovery_count,
@@ -1798,8 +1829,7 @@ async def health_consensus(
     rpc_router: Optional[FastAPIRPCRouter] = Depends(get_rpc_router_optional),
 ) -> Dict[str, Any]:
     """Show consensus system status with detailed contract-level transaction metrics."""
-    from datetime import datetime, timedelta, timezone
-    from backend.database_handler.models import Transactions
+    from datetime import datetime, timezone
     from backend.database_handler.session_factory import get_database_manager
 
     try:
@@ -1807,23 +1837,18 @@ async def health_consensus(
             return {"status": "not_initialized", "error": "RPC router not available"}
 
         def _query_consensus_detail():
-            # Get active worker IDs from recent transactions
+            import os
+
             db_manager = get_database_manager()
-            with db_manager.engine.connect() as worker_conn:
-                now = datetime.now(timezone.utc)
-                recent_threshold = now - timedelta(hours=1)
-
-                from sqlalchemy import select, distinct, and_
-
-                worker_query = select(distinct(Transactions.worker_id)).where(
-                    and_(
-                        Transactions.worker_id.isnot(None),
-                        Transactions.created_at > recent_threshold,
-                    )
-                )
-
-                worker_result = worker_conn.execute(worker_query)
-                active_workers = {row[0] for row in worker_result if row[0]}
+            HEAD_STUCK_AFTER_MINUTES = int(
+                os.environ.get("HEALTH_HEAD_STUCK_AFTER_MINUTES", "15")
+            )
+            CLAIM_WINDOW_MINUTES = int(
+                os.environ.get("TRANSACTION_TIMEOUT_MINUTES", "30")
+            )
+            DEGRADED_AT_STUCK_HEADS = int(
+                os.environ.get("HEALTH_DEGRADED_AT_STUCK_HEADS", "3")
+            )
 
             # Query transaction statistics by contract
             with db_manager.engine.connect() as conn:
@@ -1831,38 +1856,90 @@ async def health_consensus(
 
                 from sqlalchemy import text
 
+                active_workers_row = conn.execute(
+                    text(
+                        """
+                        SELECT COUNT(DISTINCT worker_id) AS n
+                        FROM transactions
+                        WHERE worker_id IS NOT NULL
+                          AND blocked_at IS NOT NULL
+                          AND blocked_at > NOW() - make_interval(mins => :claim_window)
+                        """
+                    ),
+                    {"claim_window": CLAIM_WINDOW_MINUTES},
+                ).fetchone()
+                active_workers_count = active_workers_row.n if active_workers_row else 0
+
                 query = text(
-                    """
+                    f"""
+                    WITH contract_stats AS (
+                        SELECT
+                            to_address as contract_address,
+                            COUNT(*) FILTER (WHERE status IN ({ANY_INFLIGHT_STATUSES_SQL})) as processing_count,
+                            COUNT(*) FILTER (WHERE status = 'PENDING') as pending_count,
+                            COUNT(*) FILTER (WHERE created_at > NOW() - interval '1 hour') as created_last_1h,
+                            COUNT(*) FILTER (WHERE created_at > NOW() - interval '3 hours') as created_last_3h,
+                            COUNT(*) FILTER (WHERE created_at > NOW() - interval '6 hours') as created_last_6h,
+                            COUNT(*) FILTER (WHERE created_at > NOW() - interval '12 hours') as created_last_12h,
+                            COUNT(*) FILTER (WHERE created_at > NOW() - interval '1 day') as created_last_1d,
+                            MIN(blocked_at) as oldest_blocked_at,
+                            MIN(created_at) FILTER (
+                                WHERE status = 'PENDING'
+                                   OR status IN ({ANY_INFLIGHT_STATUSES_SQL})
+                            ) as oldest_processing_created_at
+                        FROM transactions
+                        WHERE to_address IS NOT NULL
+                        GROUP BY to_address
+                        HAVING COUNT(*) FILTER (
+                            WHERE status = 'PENDING'
+                               OR status IN ({ANY_INFLIGHT_STATUSES_SQL})
+                        ) > 0
+                    ),
+                    heads AS (
+                        SELECT DISTINCT ON (to_address)
+                            to_address,
+                            hash,
+                            status,
+                            created_at
+                        FROM transactions
+                        WHERE status IN ({CONSENSUS_ACTIVE_STATUSES_SQL})
+                          AND to_address IS NOT NULL
+                        ORDER BY to_address, created_at ASC, hash ASC
+                    ),
+                    stuck_heads AS (
+                        SELECT
+                            h.to_address,
+                            h.hash,
+                            h.status,
+                            h.created_at
+                        FROM heads h
+                        WHERE h.created_at < NOW() - make_interval(mins => :head_stuck_minutes)
+                          AND NOT EXISTS (
+                              SELECT 1
+                              FROM transactions t2
+                              WHERE t2.to_address = h.to_address
+                                AND t2.status IN ({ANY_INFLIGHT_STATUSES_SQL})
+                                AND t2.blocked_at IS NOT NULL
+                                AND t2.blocked_at > NOW() - make_interval(mins => :claim_window)
+                          )
+                    )
                     SELECT
-                        to_address as contract_address,
-                        COUNT(*) FILTER (WHERE status IN ('ACTIVATED', 'PROPOSING', 'COMMITTING', 'REVEALING', 'ACCEPTED', 'UNDETERMINED')) as processing_count,
-                        COUNT(*) FILTER (WHERE status = 'PENDING') as pending_count,
-                        COUNT(*) FILTER (WHERE created_at > :one_hour_ago) as created_last_1h,
-                        COUNT(*) FILTER (WHERE created_at > :three_hours_ago) as created_last_3h,
-                        COUNT(*) FILTER (WHERE created_at > :six_hours_ago) as created_last_6h,
-                        COUNT(*) FILTER (WHERE created_at > :twelve_hours_ago) as created_last_12h,
-                        COUNT(*) FILTER (WHERE created_at > :one_day_ago) as created_last_1d,
-                        MIN(blocked_at) as oldest_blocked_at,
-                        MIN(created_at) FILTER (WHERE status IN ('PENDING', 'ACTIVATED', 'PROPOSING', 'COMMITTING', 'REVEALING', 'ACCEPTED', 'UNDETERMINED')) as oldest_processing_created_at,
-                        COUNT(*) FILTER (WHERE worker_id IS NOT NULL AND status IN ('PENDING', 'ACTIVATED', 'PROPOSING', 'COMMITTING', 'REVEALING', 'ACCEPTED', 'UNDETERMINED')) as blocked_count,
-                        json_agg(DISTINCT jsonb_build_object('worker_id', worker_id, 'hash', hash))
-                            FILTER (WHERE worker_id IS NOT NULL AND status IN ('PENDING', 'ACTIVATED', 'PROPOSING', 'COMMITTING', 'REVEALING', 'ACCEPTED', 'UNDETERMINED')) as worker_transactions
-                    FROM transactions
-                    WHERE to_address IS NOT NULL
-                    GROUP BY to_address
-                    HAVING COUNT(*) FILTER (WHERE status IN ('PENDING', 'ACTIVATED', 'PROPOSING', 'COMMITTING', 'REVEALING', 'ACCEPTED', 'UNDETERMINED')) > 0
-                    ORDER BY processing_count DESC
-                """
+                        cs.*,
+                        sh.hash AS stuck_head_hash,
+                        sh.status AS stuck_head_status,
+                        sh.created_at AS stuck_head_created_at
+                    FROM contract_stats cs
+                    LEFT JOIN stuck_heads sh
+                      ON sh.to_address = cs.contract_address
+                    ORDER BY cs.processing_count DESC, cs.pending_count DESC
+                    """
                 )
 
                 result = conn.execute(
                     query,
                     {
-                        "one_hour_ago": now - timedelta(hours=1),
-                        "three_hours_ago": now - timedelta(hours=3),
-                        "six_hours_ago": now - timedelta(hours=6),
-                        "twelve_hours_ago": now - timedelta(hours=12),
-                        "one_day_ago": now - timedelta(days=1),
+                        "head_stuck_minutes": HEAD_STUCK_AFTER_MINUTES,
+                        "claim_window": CLAIM_WINDOW_MINUTES,
                     },
                 )
 
@@ -1907,28 +1984,42 @@ async def health_consensus(
                         contract_data["oldest_processing_created_at"] = None
                         contract_data["oldest_processing_elapsed"] = None
 
-                    orphaned_tx_hashes = []
-                    if row.worker_transactions:
-                        for tx_info in row.worker_transactions:
-                            if (
-                                tx_info
-                                and tx_info.get("worker_id") not in active_workers
-                            ):
-                                orphaned_tx_hashes.append(tx_info.get("hash"))
-
-                    contract_data["orphaned_transactions"] = len(orphaned_tx_hashes)
-                    if orphaned_tx_hashes:
+                    if row.stuck_head_hash:
+                        orphaned_tx_hashes = [row.stuck_head_hash]
+                        contract_data["orphaned_transactions"] = 1
                         contract_data["orphaned_transaction_hashes"] = (
                             orphaned_tx_hashes
                         )
-                    total_orphaned += contract_data["orphaned_transactions"]
+                        stuck_head_created_at = None
+                        stuck_head_elapsed = None
+                        if row.stuck_head_created_at:
+                            stuck_head_created_at = (
+                                row.stuck_head_created_at.isoformat()
+                            )
+                            elapsed = now - row.stuck_head_created_at
+                            minutes = int(elapsed.total_seconds() / 60)
+                            stuck_head_elapsed = (
+                                f"{minutes}m" if minutes < 60 else f"{minutes // 60}h"
+                            )
+                        contract_data["stuck_head_transaction"] = {
+                            "hash": row.stuck_head_hash,
+                            "status": row.stuck_head_status,
+                            "created_at": stuck_head_created_at,
+                            "elapsed": stuck_head_elapsed,
+                        }
+                        total_orphaned += 1
+                    else:
+                        contract_data["orphaned_transactions"] = 0
 
                     contracts.append(contract_data)
 
                 total_processing = sum(c["processing_count"] for c in contracts)
                 status = (
                     "healthy"
-                    if total_processing < 100 and total_orphaned == 0
+                    if (
+                        total_processing < 100
+                        and total_orphaned < DEGRADED_AT_STUCK_HEADS
+                    )
                     else "degraded"
                 )
 
@@ -1936,7 +2027,7 @@ async def health_consensus(
                     "status": status,
                     "total_processing_transactions": total_processing,
                     "total_orphaned_transactions": total_orphaned,
-                    "active_workers": len(active_workers),
+                    "active_workers": active_workers_count,
                     "contracts": contracts,
                 }
 

--- a/backend/services/usage_metrics_service.py
+++ b/backend/services/usage_metrics_service.py
@@ -103,11 +103,13 @@ class UsageMetricsService:
             if mapped_status != "healthy":
                 system_health["instanceHealthReasons"] = health_cache.issues
 
+            instance_health_events = []
+
             max_recovery_events = health_cache.services.get("consensus", {}).get(
                 "max_recovery_exhausted_transactions", []
             )
             if max_recovery_events:
-                system_health["instanceHealthEvents"] = [
+                instance_health_events.extend(
                     {
                         "type": "max_recovery_cycles_exhausted",
                         "transactionHash": event.get("hash"),
@@ -116,7 +118,25 @@ class UsageMetricsService:
                         "occurredAt": event.get("exhausted_at"),
                     }
                     for event in max_recovery_events
-                ]
+                )
+
+            stuck_head_events = health_cache.services.get("consensus", {}).get(
+                "stuck_head_transactions", []
+            )
+            if stuck_head_events:
+                instance_health_events.extend(
+                    {
+                        "type": "orphaned_transactions",
+                        "transactionHash": event.get("hash"),
+                        "contractAddress": event.get("contract_address"),
+                        "status": event.get("status"),
+                        "occurredAt": event.get("created_at"),
+                    }
+                    for event in stuck_head_events
+                )
+
+            if instance_health_events:
+                system_health["instanceHealthEvents"] = instance_health_events
 
             # Add pending contracts breakdown if available
             pending_contracts = getattr(health_cache, "pending_contracts", [])

--- a/tests/db-sqlalchemy/test_finalization_starvation.py
+++ b/tests/db-sqlalchemy/test_finalization_starvation.py
@@ -14,10 +14,12 @@ These tests cover:
 1. claim_next_transaction defers when an eligible finalization exists.
 2. claim_next_transaction proceeds when finalization for the contract is
    already in flight (preserves liveness — no infinite defer loop).
-3. recover_stuck_transactions preserves consensus_data for finalization-
+3. claim_next_transaction does not defer older queue heads to younger
+   finalizations that cannot legally finalize yet.
+4. recover_stuck_transactions preserves consensus_data for finalization-
    eligible statuses (ACCEPTED/UNDETERMINED/*_TIMEOUT).
-4. Safety-net log fires when an ACCEPTED tx's wait exceeds N×finality_window.
-5. Recovered PENDING txs are deprioritized across contracts so other
+5. Safety-net log fires when an ACCEPTED tx's wait exceeds N×finality_window.
+6. Recovered PENDING txs are deprioritized across contracts so other
    contracts keep making progress.
 """
 
@@ -202,6 +204,42 @@ async def test_claim_next_transaction_defers_to_eligible_finalization(
         "same contract — got "
         f"{claimed}"
     )
+
+
+@pytest.mark.asyncio
+async def test_older_activated_head_is_not_blocked_by_younger_finalization(
+    engine: Engine, worker: ConsensusWorker, session: Session
+):
+    """A younger finalization cannot complete while an older ACTIVATED head is
+    non-terminal. claim_next_transaction must claim the older head instead of
+    deferring forever to a finalization that claim_next_finalization rejects."""
+    _setup_contract(engine)
+    activated_hash = "0x" + "2a" * 32
+    finalization_hash = "0x" + "2b" * 32
+
+    _insert_tx(
+        session,
+        tx_hash=activated_hash,
+        status="ACTIVATED",
+        nonce=0,
+        created_at_offset_seconds=-1200,
+    )
+    _insert_tx(
+        session,
+        tx_hash=finalization_hash,
+        status="ACCEPTED",
+        nonce=1,
+        timestamp_awaiting_finalization=int(time.time()) - 600,
+        consensus_data={"leader_receipt": [{}], "votes": {}, "validators": []},
+        created_at_offset_seconds=-600,
+    )
+
+    blocked_finalization = await worker.claim_next_finalization(session)
+    claimed = await worker.claim_next_transaction(session)
+
+    assert blocked_finalization is None
+    assert claimed is not None
+    assert claimed["hash"] == activated_hash
 
 
 @pytest.mark.asyncio

--- a/tests/db-sqlalchemy/test_health_orphan_detection.py
+++ b/tests/db-sqlalchemy/test_health_orphan_detection.py
@@ -363,6 +363,112 @@ async def test_long_running_consensus_within_claim_window_not_stuck(engine: Engi
 
 
 @pytest.mark.asyncio
+async def test_detailed_consensus_endpoint_uses_claim_window_for_stuck_heads(
+    engine: Engine,
+):
+    """The detailed /health/consensus endpoint must use the same claim-window
+    semantics as /health. The old endpoint looked for workers on txs created
+    in the last hour and falsely marked old, actively claimed txs orphaned."""
+    Session_ = sessionmaker(bind=engine, expire_on_commit=False)
+    now = datetime.now(timezone.utc)
+    contract = "0x" + "5d" * 20
+
+    with Session_() as s:
+        _insert_tx(
+            s,
+            tx_hash="0x" + "01" * 32,
+            to_address=contract,
+            status="COMMITTING",
+            nonce=0,
+            created_at=now - timedelta(hours=2),
+            blocked_at=now - timedelta(minutes=7),
+            worker_id="worker-busy",
+        )
+        s.commit()
+
+    from backend.protocol_rpc import health as health_module
+
+    result = await health_module.health_consensus(rpc_router=object())
+
+    assert result["active_workers"] == 1
+    assert result["total_orphaned_transactions"] == 0
+    assert result["contracts"][0]["orphaned_transactions"] == 0
+
+
+@pytest.mark.asyncio
+async def test_detailed_consensus_endpoint_excludes_post_consensus_statuses(
+    engine: Engine,
+):
+    """Post-consensus rows are finalization backlog, not stuck consensus heads.
+    The detailed endpoint should not reintroduce the old false-positive class."""
+    Session_ = sessionmaker(bind=engine, expire_on_commit=False)
+    now = datetime.now(timezone.utc)
+
+    with Session_() as s:
+        for i, st in enumerate(
+            ["ACCEPTED", "UNDETERMINED", "LEADER_TIMEOUT", "VALIDATORS_TIMEOUT"]
+        ):
+            _insert_tx(
+                s,
+                tx_hash=f"0x5e{i:062x}",
+                to_address=f"0x{(0x5E + i):02x}" + "00" * 19,
+                status=st,
+                nonce=0,
+                created_at=now - timedelta(hours=2),
+                blocked_at=now - timedelta(minutes=45),
+                worker_id=f"old-worker-{i}",
+            )
+        s.commit()
+
+    from backend.protocol_rpc import health as health_module
+
+    result = await health_module.health_consensus(rpc_router=object())
+
+    assert result["total_orphaned_transactions"] == 0
+    assert all(
+        contract["orphaned_transactions"] == 0 for contract in result["contracts"]
+    )
+
+
+@pytest.mark.asyncio
+async def test_detailed_consensus_endpoint_reports_stuck_head_details(engine: Engine):
+    """When heads are genuinely stuck, the detailed endpoint should expose the
+    affected transaction hashes so alerts can be investigated from the payload."""
+    Session_ = sessionmaker(bind=engine, expire_on_commit=False)
+    now = datetime.now(timezone.utc)
+
+    with Session_() as s:
+        for i in range(3):
+            _insert_tx(
+                s,
+                tx_hash=f"0x5f{i:062x}",
+                to_address=f"0x{(0x5F + i):02x}" + "00" * 19,
+                status="COMMITTING",
+                nonce=0,
+                created_at=now - timedelta(minutes=45 + i),
+            )
+        s.commit()
+
+    from backend.protocol_rpc import health as health_module
+
+    result = await health_module.health_consensus(rpc_router=object())
+
+    assert result["status"] == "degraded"
+    assert result["total_orphaned_transactions"] == 3
+    stuck_contracts = [
+        contract
+        for contract in result["contracts"]
+        if contract["orphaned_transactions"]
+    ]
+    assert len(stuck_contracts) == 3
+    assert all(
+        contract["stuck_head_transaction"]["hash"]
+        in contract["orphaned_transaction_hashes"]
+        for contract in stuck_contracts
+    )
+
+
+@pytest.mark.asyncio
 async def test_expired_claim_counts_contract_as_stuck(engine: Engine):
     """blocked_at older than the claim window means the worker has
     timed out. Recovery would reset it. Until then, the head is
@@ -456,6 +562,8 @@ async def test_status_threshold_matches_dashboard_alert_gate(engine: Engine):
     result = await health_module._check_consensus_health()
 
     assert result["total_orphaned_transactions"] == 3
+    assert len(result["stuck_head_transactions"]) == 3
+    assert result["stuck_head_transactions"][0]["status"] == "COMMITTING"
     assert (
         result["status"] == "degraded"
     ), f"3 stuck contracts must flip status to degraded. Got: {result}"

--- a/tests/unit/test_rpc_health_genvm_tracking.py
+++ b/tests/unit/test_rpc_health_genvm_tracking.py
@@ -318,7 +318,7 @@ class TestBackgroundHealthGenVMOrdering:
                 if "timestamp_awaiting_finalization" in query:
                     return FakeResult(SimpleNamespace(n=0))
                 if "COALESCE(MAX(recovery_count), 0)" in query:
-                    return FakeResult(SimpleNamespace(n=0, max_recovery_count=0))
+                    return FakeResult(SimpleNamespace(n=1, max_recovery_count=2))
                 if "max_recovery_cycles_exceeded" in query:
                     return FakeResult(rows=[exhausted_tx])
                 if "WHERE status IN ('ACTIVATED'" in query:
@@ -349,6 +349,8 @@ class TestBackgroundHealthGenVMOrdering:
         result = await health_module._check_consensus_health()
 
         assert result["status"] == "degraded"
+        assert result["recovery_storm_count"] == 1
+        assert result["max_recovery_count"] == 2
         assert result["max_recovery_exhausted_count"] == 1
         assert result["max_recovery_exhausted_transactions"] == [
             {

--- a/tests/unit/test_rpc_health_genvm_tracking.py
+++ b/tests/unit/test_rpc_health_genvm_tracking.py
@@ -323,12 +323,16 @@ class TestBackgroundHealthGenVMOrdering:
                     return FakeResult(rows=[exhausted_tx])
                 if "WHERE status IN ('ACTIVATED'" in query:
                     return FakeResult(SimpleNamespace(n=0))
+                if "SET LOCAL statement_timeout" in query:
+                    return FakeResult()
+                if "last_progress_epoch" in query:
+                    return FakeResult(SimpleNamespace(last_progress_epoch=1))
                 if "backlog_count" in query:
                     return FakeResult(
                         SimpleNamespace(
-                            backlog_count=0,
-                            oldest_created_at=None,
-                            oldest_backlog_age_seconds=None,
+                            backlog_count=3,
+                            oldest_created_at=object(),
+                            oldest_backlog_age_seconds=3600,
                         )
                     )
                 raise AssertionError(f"unexpected query: {query}")
@@ -351,6 +355,8 @@ class TestBackgroundHealthGenVMOrdering:
         assert result["status"] == "degraded"
         assert result["recovery_storm_count"] == 1
         assert result["max_recovery_count"] == 2
+        assert result["no_consensus_progress"] is True
+        assert result["seconds_since_consensus_progress"] is not None
         assert result["max_recovery_exhausted_count"] == 1
         assert result["max_recovery_exhausted_transactions"] == [
             {

--- a/tests/unit/test_rpc_health_genvm_tracking.py
+++ b/tests/unit/test_rpc_health_genvm_tracking.py
@@ -181,6 +181,88 @@ class TestBackgroundHealthGenVMOrdering:
     def setup_method(self):
         health_module._health_cache = health_module.HealthCache()
         health_module._genvm_consecutive_failures = 0
+        health_module._no_progress_scan_suppressed_until = 0.0
+
+    def _install_fake_consensus_db(
+        self,
+        monkeypatch,
+        *,
+        recovery_storm_count=0,
+        max_recovery_count=0,
+        exhausted_rows=None,
+        backlog_count=0,
+        oldest_created_at=None,
+        oldest_backlog_age_seconds=None,
+        progress_epoch=1,
+        progress_error=False,
+    ):
+        class FakeResult:
+            def __init__(self, row=None, rows=None):
+                self.row = row
+                self.rows = rows or []
+
+            def fetchone(self):
+                return self.row
+
+            def fetchall(self):
+                return self.rows
+
+        class FakeConnection:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc, tb):
+                return False
+
+            def execute(self, statement, params=None):
+                query = str(statement)
+                if "COUNT(DISTINCT worker_id)" in query:
+                    return FakeResult(SimpleNamespace(n=0))
+                if "COUNT(*) AS stuck_heads" in query:
+                    return FakeResult(SimpleNamespace(stuck_heads=0))
+                if "timestamp_awaiting_finalization" in query:
+                    return FakeResult(SimpleNamespace(n=0))
+                if "COALESCE(MAX(recovery_count), 0)" in query:
+                    return FakeResult(
+                        SimpleNamespace(
+                            n=recovery_storm_count,
+                            max_recovery_count=max_recovery_count,
+                        )
+                    )
+                if "max_recovery_cycles_exceeded" in query:
+                    return FakeResult(rows=exhausted_rows or [])
+                if "WHERE status IN ('ACTIVATED'" in query:
+                    return FakeResult(SimpleNamespace(n=0))
+                if "SET LOCAL statement_timeout" in query:
+                    return FakeResult()
+                if "last_progress_epoch" in query:
+                    if progress_error:
+                        raise TimeoutError("progress scan timed out")
+                    return FakeResult(
+                        SimpleNamespace(last_progress_epoch=progress_epoch)
+                    )
+                if "backlog_count" in query:
+                    return FakeResult(
+                        SimpleNamespace(
+                            backlog_count=backlog_count,
+                            oldest_created_at=oldest_created_at,
+                            oldest_backlog_age_seconds=oldest_backlog_age_seconds,
+                        )
+                    )
+                raise AssertionError(f"unexpected query: {query}")
+
+        class FakeEngine:
+            def connect(self):
+                return FakeConnection()
+
+        import backend.database_handler.session_factory as session_factory
+
+        monkeypatch.setattr(
+            session_factory,
+            "get_database_manager",
+            lambda: SimpleNamespace(engine=FakeEngine()),
+        )
+        monkeypatch.setattr(health_module, "_rpc_router_ref", object())
 
     @pytest.mark.asyncio
     async def test_genvm_cache_updates_before_database_and_consensus_checks(
@@ -291,64 +373,16 @@ class TestBackgroundHealthGenVMOrdering:
             exhausted_at_epoch=1779938084,
         )
 
-        class FakeResult:
-            def __init__(self, row=None, rows=None):
-                self.row = row
-                self.rows = rows or []
-
-            def fetchone(self):
-                return self.row
-
-            def fetchall(self):
-                return self.rows
-
-        class FakeConnection:
-            def __enter__(self):
-                return self
-
-            def __exit__(self, exc_type, exc, tb):
-                return False
-
-            def execute(self, statement, params=None):
-                query = str(statement)
-                if "COUNT(DISTINCT worker_id)" in query:
-                    return FakeResult(SimpleNamespace(n=0))
-                if "COUNT(*) AS stuck_heads" in query:
-                    return FakeResult(SimpleNamespace(stuck_heads=0))
-                if "timestamp_awaiting_finalization" in query:
-                    return FakeResult(SimpleNamespace(n=0))
-                if "COALESCE(MAX(recovery_count), 0)" in query:
-                    return FakeResult(SimpleNamespace(n=1, max_recovery_count=2))
-                if "max_recovery_cycles_exceeded" in query:
-                    return FakeResult(rows=[exhausted_tx])
-                if "WHERE status IN ('ACTIVATED'" in query:
-                    return FakeResult(SimpleNamespace(n=0))
-                if "SET LOCAL statement_timeout" in query:
-                    return FakeResult()
-                if "last_progress_epoch" in query:
-                    return FakeResult(SimpleNamespace(last_progress_epoch=1))
-                if "backlog_count" in query:
-                    return FakeResult(
-                        SimpleNamespace(
-                            backlog_count=3,
-                            oldest_created_at=object(),
-                            oldest_backlog_age_seconds=3600,
-                        )
-                    )
-                raise AssertionError(f"unexpected query: {query}")
-
-        class FakeEngine:
-            def connect(self):
-                return FakeConnection()
-
-        import backend.database_handler.session_factory as session_factory
-
-        monkeypatch.setattr(
-            session_factory,
-            "get_database_manager",
-            lambda: SimpleNamespace(engine=FakeEngine()),
+        self._install_fake_consensus_db(
+            monkeypatch,
+            recovery_storm_count=1,
+            max_recovery_count=2,
+            exhausted_rows=[exhausted_tx],
+            backlog_count=3,
+            oldest_created_at=object(),
+            oldest_backlog_age_seconds=3600,
+            progress_epoch=1,
         )
-        monkeypatch.setattr(health_module, "_rpc_router_ref", object())
 
         result = await health_module._check_consensus_health()
 
@@ -366,6 +400,73 @@ class TestBackgroundHealthGenVMOrdering:
                 "exhausted_at": 1779938084,
             }
         ]
+
+    @pytest.mark.asyncio
+    async def test_consensus_health_suppresses_no_progress_scan_during_cooldown(
+        self, monkeypatch
+    ):
+        monkeypatch.setattr(health_module.time, "time", lambda: 1000)
+        health_module._no_progress_scan_suppressed_until = 2000
+        self._install_fake_consensus_db(
+            monkeypatch,
+            backlog_count=3,
+            oldest_created_at=object(),
+            oldest_backlog_age_seconds=3600,
+        )
+
+        result = await health_module._check_consensus_health()
+
+        assert result["status"] == "healthy"
+        assert result["no_consensus_progress"] is False
+        assert result["no_progress_check_error"] is True
+        assert result["no_progress_scan_suppressed"] is True
+        assert result["seconds_since_consensus_progress"] is None
+
+    @pytest.mark.asyncio
+    async def test_consensus_health_cooldowns_after_no_progress_scan_error(
+        self, monkeypatch
+    ):
+        monkeypatch.setattr(health_module.time, "time", lambda: 1000)
+        self._install_fake_consensus_db(
+            monkeypatch,
+            backlog_count=3,
+            oldest_created_at=object(),
+            oldest_backlog_age_seconds=3600,
+            progress_error=True,
+        )
+
+        result = await health_module._check_consensus_health()
+
+        assert result["status"] == "healthy"
+        assert result["no_consensus_progress"] is False
+        assert result["no_progress_check_error"] is True
+        assert result["no_progress_scan_suppressed"] is False
+        assert (
+            health_module._no_progress_scan_suppressed_until
+            == 1000 + health_module.get_no_progress_scan_error_cooldown_seconds()
+        )
+
+    @pytest.mark.asyncio
+    async def test_consensus_health_skips_no_progress_scan_without_old_backlog(
+        self, monkeypatch
+    ):
+        health_module._no_progress_scan_suppressed_until = 123
+        self._install_fake_consensus_db(
+            monkeypatch,
+            backlog_count=1,
+            oldest_created_at=None,
+            oldest_backlog_age_seconds=None,
+        )
+
+        result = await health_module._check_consensus_health()
+
+        assert result["status"] == "healthy"
+        assert result["no_consensus_progress"] is False
+        assert result["no_progress_check_error"] is False
+        assert result["no_progress_scan_suppressed"] is False
+        assert result["no_progress_backlog_count"] == 1
+        assert result["oldest_backlog_age_seconds"] is None
+        assert health_module._no_progress_scan_suppressed_until == 0.0
 
 
 class TestThresholdConfig:

--- a/tests/unit/test_rpc_health_genvm_tracking.py
+++ b/tests/unit/test_rpc_health_genvm_tracking.py
@@ -3,9 +3,11 @@ Tests for GenVM execution failure tracking in JSON-RPC health check.
 Mirrors test_worker_health_degradation.py pattern for jsonrpc process.
 """
 
-import pytest
-from unittest.mock import patch, MagicMock, AsyncMock
+from datetime import datetime, timedelta, timezone
 from types import SimpleNamespace
+from unittest.mock import patch, MagicMock, AsyncMock
+
+import pytest
 
 import backend.protocol_rpc.health as health_module
 
@@ -467,6 +469,109 @@ class TestBackgroundHealthGenVMOrdering:
         assert result["no_progress_backlog_count"] == 1
         assert result["oldest_backlog_age_seconds"] is None
         assert health_module._no_progress_scan_suppressed_until == 0.0
+
+
+class TestDetailedConsensusHealthEndpoint:
+    """Unit coverage for the detailed /health/consensus endpoint."""
+
+    @pytest.mark.asyncio
+    async def test_health_consensus_reports_stuck_head_details(self, monkeypatch):
+        now = datetime.now(timezone.utc)
+        stuck_created_at = now - timedelta(minutes=90)
+        blocked_at = now - timedelta(minutes=5)
+
+        contract_rows = [
+            SimpleNamespace(
+                contract_address="0xcontract1",
+                processing_count=4,
+                pending_count=2,
+                created_last_1h=1,
+                created_last_3h=4,
+                created_last_6h=4,
+                created_last_12h=4,
+                created_last_1d=4,
+                oldest_blocked_at=blocked_at,
+                oldest_processing_created_at=stuck_created_at,
+                stuck_head_hash="0xstuck",
+                stuck_head_status="COMMITTING",
+                stuck_head_created_at=stuck_created_at,
+            ),
+            SimpleNamespace(
+                contract_address="0xcontract2",
+                processing_count=3,
+                pending_count=1,
+                created_last_1h=0,
+                created_last_3h=3,
+                created_last_6h=3,
+                created_last_12h=3,
+                created_last_1d=3,
+                oldest_blocked_at=None,
+                oldest_processing_created_at=None,
+                stuck_head_hash=None,
+                stuck_head_status=None,
+                stuck_head_created_at=None,
+            ),
+        ]
+
+        class FakeResult:
+            def __init__(self, row=None, rows=None):
+                self.row = row
+                self.rows = rows or []
+
+            def fetchone(self):
+                return self.row
+
+            def __iter__(self):
+                return iter(self.rows)
+
+        class FakeConnection:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc, tb):
+                return False
+
+            def execute(self, statement, params=None):
+                query = str(statement)
+                if "COUNT(DISTINCT worker_id)" in query:
+                    return FakeResult(SimpleNamespace(n=2))
+                if "WITH contract_stats AS" in query:
+                    assert params == {"head_stuck_minutes": 15, "claim_window": 30}
+                    return FakeResult(rows=contract_rows)
+                raise AssertionError(f"unexpected query: {query}")
+
+        class FakeEngine:
+            def connect(self):
+                return FakeConnection()
+
+        import backend.database_handler.session_factory as session_factory
+
+        monkeypatch.setattr(
+            session_factory,
+            "get_database_manager",
+            lambda: SimpleNamespace(engine=FakeEngine()),
+        )
+
+        result = await health_module.health_consensus(rpc_router=object())
+
+        assert result["status"] == "healthy"
+        assert result["total_processing_transactions"] == 7
+        assert result["total_orphaned_transactions"] == 1
+        assert result["active_workers"] == 2
+
+        stuck_contract = result["contracts"][0]
+        assert stuck_contract["orphaned_transactions"] == 1
+        assert stuck_contract["orphaned_transaction_hashes"] == ["0xstuck"]
+        assert stuck_contract["stuck_head_transaction"] == {
+            "hash": "0xstuck",
+            "status": "COMMITTING",
+            "created_at": stuck_created_at.isoformat(),
+            "elapsed": "1h",
+        }
+
+        active_contract = result["contracts"][1]
+        assert active_contract["orphaned_transactions"] == 0
+        assert "stuck_head_transaction" not in active_contract
 
 
 class TestThresholdConfig:

--- a/tests/unit/test_usage_metrics_service.py
+++ b/tests/unit/test_usage_metrics_service.py
@@ -50,3 +50,49 @@ async def test_system_health_metrics_include_max_recovery_events():
             "occurredAt": 1779938084,
         }
     ]
+
+
+@pytest.mark.asyncio
+async def test_system_health_metrics_include_stuck_head_events():
+    service = UsageMetricsService()
+    service._enabled = True
+    service._send_to_api = AsyncMock()
+
+    health_cache = SimpleNamespace(
+        status="degraded",
+        genvm_healthy=True,
+        uptime_percent=100.0,
+        pending_transactions=1,
+        total_decisions=2,
+        total_users=3,
+        issues=["orphaned_transactions"],
+        pending_contracts=[],
+        services={
+            "consensus": {
+                "active_workers": 0,
+                "stuck_head_transactions": [
+                    {
+                        "hash": "0xstuck",
+                        "contract_address": "0xcontract",
+                        "status": "COMMITTING",
+                        "created_at": 1780933606,
+                    }
+                ],
+            },
+            "memory": {"percent": 4.0, "cpu_percent": 5.0},
+        },
+    )
+
+    await service.send_system_health_metrics(health_cache)
+
+    service._send_to_api.assert_awaited_once()
+    payload = service._send_to_api.await_args.args[0]
+    assert payload["systemHealth"]["instanceHealthEvents"] == [
+        {
+            "type": "orphaned_transactions",
+            "transactionHash": "0xstuck",
+            "contractAddress": "0xcontract",
+            "status": "COMMITTING",
+            "occurredAt": 1780933606,
+        }
+    ]


### PR DESCRIPTION
## Summary

- Copy the finalization-deadlock fix and stuck-head alert context onto `v0.123-dev`.
- Fix a per-contract scheduling deadlock where an older `PENDING`/`ACTIVATED` head could defer to a younger eligible finalization that `claim_next_finalization` could not legally claim yet.
- Align `/health/consensus` orphaned-transaction reporting with the main `/health` stuck-head detector.
- Add bounded stuck-head transaction details to the cached consensus health payload.
- Forward stuck-head details as `instanceHealthEvents` so health alerts can include affected transaction and contract context.

## Root Cause

`claim_next_transaction` deferred any `PENDING`/`ACTIVATED` candidate when an eligible finalization existed on the same contract. `claim_next_finalization`, correctly, refuses to claim a finalization while an older non-terminal tx exists for that contract. If the finalization was younger than the candidate, both claim paths could reject work: transaction claiming deferred to finalization, and finalization was blocked by the older candidate. The fix makes transaction claiming defer only to older eligible finalizations.

## Validation

- `./.venv/bin/python -m py_compile backend/consensus/worker.py backend/protocol_rpc/health.py backend/services/usage_metrics_service.py tests/db-sqlalchemy/test_finalization_starvation.py tests/db-sqlalchemy/test_health_orphan_detection.py tests/unit/test_usage_metrics_service.py`
- `./.venv/bin/python -m pytest tests/unit/test_usage_metrics_service.py -q` - 2 passed
- `./.venv/bin/python -m pytest tests/db-sqlalchemy/test_finalization_starvation.py tests/db-sqlalchemy/test_health_orphan_detection.py -q` - 34 passed