### PR TITLE
fix: surface stuck finalization health context

### DIFF
--- a/backend/protocol_rpc/health.py
+++ b/backend/protocol_rpc/health.py
@@ -337,6 +337,9 @@ async def _run_health_checks() -> None:
             "stuck_finalization_count": consensus_health.get(
                 "stuck_finalization_count", 0
             ),
+            "stuck_finalization_transactions": consensus_health.get(
+                "stuck_finalization_transactions", []
+            ),
             "recovery_storm_count": consensus_health.get("recovery_storm_count", 0),
             "max_recovery_count": consensus_health.get("max_recovery_count", 0),
             "max_recovery_exhausted_count": consensus_health.get(
@@ -659,6 +662,9 @@ async def _check_consensus_health() -> Dict[str, Any]:
         os.environ.get("HEALTH_MAX_RECOVERY_EXHAUSTED_EVENT_LIMIT", "10")
     )
     STUCK_HEAD_EVENT_LIMIT = int(os.environ.get("HEALTH_STUCK_HEAD_EVENT_LIMIT", "10"))
+    STUCK_FINALIZATION_EVENT_LIMIT = int(
+        os.environ.get("HEALTH_STUCK_FINALIZATION_EVENT_LIMIT", "10")
+    )
 
     try:
         if not _rpc_router_ref:
@@ -772,27 +778,82 @@ async def _check_consensus_health() -> Dict[str, Any]:
                 #      reached UNDETERMINED without ever stamping the
                 #      timestamp — invisible to claim_next_finalization
                 #      forever)
-                stuck_fin_row = conn.execute(
+                stuck_fin_rows = conn.execute(
                     text(
                         f"""
-                        SELECT COUNT(*) AS n
-                        FROM transactions
-                        WHERE status IN ({FINALIZATION_ELIGIBLE_STATUSES_SQL})
-                          AND (
-                              (timestamp_awaiting_finalization IS NOT NULL
-                               AND EXTRACT(EPOCH FROM NOW())::bigint
-                                   - timestamp_awaiting_finalization
-                                   > :stuck_seconds)
-                              OR
-                              (timestamp_awaiting_finalization IS NULL
-                               AND created_at
-                                   < NOW() - make_interval(secs => :stuck_seconds))
-                          )
+                        WITH stuck_finalizations AS (
+                            SELECT
+                                hash AS tx_hash,
+                                to_address,
+                                status,
+                                created_at,
+                                timestamp_awaiting_finalization,
+                                blocked_at,
+                                worker_id,
+                                CASE
+                                    WHEN timestamp_awaiting_finalization IS NOT NULL
+                                    THEN EXTRACT(EPOCH FROM NOW())::bigint
+                                        - timestamp_awaiting_finalization
+                                    ELSE EXTRACT(EPOCH FROM NOW() - created_at)::bigint
+                                END AS waiting_seconds
+                            FROM transactions
+                            WHERE status IN ({FINALIZATION_ELIGIBLE_STATUSES_SQL})
+                              AND (
+                                  (timestamp_awaiting_finalization IS NOT NULL
+                                   AND EXTRACT(EPOCH FROM NOW())::bigint
+                                       - timestamp_awaiting_finalization
+                                       > :stuck_seconds)
+                                  OR
+                                  (timestamp_awaiting_finalization IS NULL
+                                   AND created_at
+                                       < NOW() - make_interval(secs => :stuck_seconds))
+                              )
+                        )
+                        SELECT
+                            COUNT(*) OVER() AS total_count,
+                            tx_hash,
+                            to_address,
+                            status,
+                            EXTRACT(EPOCH FROM created_at)::bigint
+                                AS created_at_epoch,
+                            timestamp_awaiting_finalization,
+                            EXTRACT(EPOCH FROM blocked_at)::bigint
+                                AS blocked_at_epoch,
+                            worker_id,
+                            waiting_seconds
+                        FROM stuck_finalizations
+                        ORDER BY
+                            COALESCE(
+                                timestamp_awaiting_finalization,
+                                EXTRACT(EPOCH FROM created_at)::bigint
+                            ) ASC,
+                            tx_hash ASC
+                        LIMIT :event_limit
                         """
                     ),
-                    {"stuck_seconds": STUCK_FINALIZATION_AFTER_SECONDS},
-                ).fetchone()
-                stuck_finalization_count = stuck_fin_row.n if stuck_fin_row else 0
+                    {
+                        "stuck_seconds": STUCK_FINALIZATION_AFTER_SECONDS,
+                        "event_limit": STUCK_FINALIZATION_EVENT_LIMIT,
+                    },
+                ).fetchall()
+                stuck_finalization_count = (
+                    stuck_fin_rows[0].total_count if stuck_fin_rows else 0
+                )
+                stuck_finalization_transactions = [
+                    {
+                        "hash": row.tx_hash,
+                        "contract_address": row.to_address,
+                        "status": row.status,
+                        "created_at": row.created_at_epoch,
+                        "timestamp_awaiting_finalization": (
+                            row.timestamp_awaiting_finalization
+                        ),
+                        "blocked_at": row.blocked_at_epoch,
+                        "worker_id": row.worker_id,
+                        "waiting_seconds": row.waiting_seconds,
+                    }
+                    for row in stuck_fin_rows
+                ]
 
                 # Recovery storm: a non-terminal transaction that has already
                 # been reset several times is a high-confidence poison-tx
@@ -1050,6 +1111,9 @@ async def _check_consensus_health() -> Dict[str, Any]:
                     "total_orphaned_transactions": stuck_head_contracts,
                     "stuck_head_transactions": stuck_head_transactions,
                     "stuck_finalization_count": stuck_finalization_count,
+                    "stuck_finalization_transactions": (
+                        stuck_finalization_transactions
+                    ),
                     "recovery_storm_count": recovery_storm_count,
                     "max_recovery_count": max_recovery_count,
                     "max_recovery_exhausted_count": max_recovery_exhausted_count,

--- a/tests/db-sqlalchemy/test_health_orphan_detection.py
+++ b/tests/db-sqlalchemy/test_health_orphan_detection.py
@@ -614,6 +614,18 @@ async def test_stuck_finalization_with_stale_timestamp_is_flagged(engine: Engine
     assert (
         result["stuck_finalization_count"] == 1
     ), f"Stale timestamp_awaiting_finalization must be flagged. Got: {result}"
+    assert result["stuck_finalization_transactions"] == [
+        {
+            "hash": "0x" + "f1" * 32,
+            "contract_address": "0x" + "f1" * 20,
+            "status": "ACCEPTED",
+            "created_at": pytest.approx(int(now.timestamp()), abs=1),
+            "timestamp_awaiting_finalization": stale_ts,
+            "blocked_at": None,
+            "worker_id": None,
+            "waiting_seconds": pytest.approx(24 * 3600, abs=5),
+        }
+    ]
 
 
 @pytest.mark.asyncio
@@ -645,6 +657,18 @@ async def test_stuck_finalization_with_null_timestamp_is_flagged(engine: Engine)
         "NULL timestamp + old row must be flagged so a regression of the "
         f"insufficient-balance SEND bug is caught. Got: {result}"
     )
+    assert result["stuck_finalization_transactions"] == [
+        {
+            "hash": "0x" + "f2" * 32,
+            "contract_address": "0x" + "f2" * 20,
+            "status": "UNDETERMINED",
+            "created_at": pytest.approx(int(now.timestamp()), abs=1),
+            "timestamp_awaiting_finalization": None,
+            "blocked_at": None,
+            "worker_id": None,
+            "waiting_seconds": pytest.approx(2 * 3600, abs=5),
+        }
+    ]
 
 
 @pytest.mark.asyncio
@@ -676,6 +700,7 @@ async def test_recent_finalization_eligible_row_is_not_flagged(engine: Engine):
     assert (
         result["stuck_finalization_count"] == 0
     ), f"Fresh finalization-eligible row must not be flagged. Got: {result}"
+    assert result["stuck_finalization_transactions"] == []
 
 
 @pytest.mark.asyncio

--- a/tests/db-sqlalchemy/test_health_orphan_detection.py
+++ b/tests/db-sqlalchemy/test_health_orphan_detection.py
@@ -594,6 +594,7 @@ async def test_stuck_finalization_with_stale_timestamp_is_flagged(engine: Engine
     Session_ = sessionmaker(bind=engine, expire_on_commit=False)
     now = datetime.now(timezone.utc)
     stale_ts = int(time.time()) - 24 * 3600  # 1 day ago
+    created_at = now - timedelta(days=1)
 
     with Session_() as s:
         _insert_tx(
@@ -602,7 +603,7 @@ async def test_stuck_finalization_with_stale_timestamp_is_flagged(engine: Engine
             to_address="0x" + "f1" * 20,
             status="ACCEPTED",
             nonce=0,
-            created_at=now - timedelta(days=1),
+            created_at=created_at,
             timestamp_awaiting_finalization=stale_ts,
         )
         s.commit()
@@ -619,7 +620,7 @@ async def test_stuck_finalization_with_stale_timestamp_is_flagged(engine: Engine
             "hash": "0x" + "f1" * 32,
             "contract_address": "0x" + "f1" * 20,
             "status": "ACCEPTED",
-            "created_at": pytest.approx(int(now.timestamp()), abs=1),
+            "created_at": pytest.approx(int(created_at.timestamp()), abs=1),
             "timestamp_awaiting_finalization": stale_ts,
             "blocked_at": None,
             "worker_id": None,
@@ -636,6 +637,7 @@ async def test_stuck_finalization_with_null_timestamp_is_flagged(engine: Engine)
     to claim_next_finalization)."""
     Session_ = sessionmaker(bind=engine, expire_on_commit=False)
     now = datetime.now(timezone.utc)
+    created_at = now - timedelta(hours=2)
 
     with Session_() as s:
         _insert_tx(
@@ -644,7 +646,7 @@ async def test_stuck_finalization_with_null_timestamp_is_flagged(engine: Engine)
             to_address="0x" + "f2" * 20,
             status="UNDETERMINED",
             nonce=0,
-            created_at=now - timedelta(hours=2),
+            created_at=created_at,
             timestamp_awaiting_finalization=None,
         )
         s.commit()
@@ -662,7 +664,7 @@ async def test_stuck_finalization_with_null_timestamp_is_flagged(engine: Engine)
             "hash": "0x" + "f2" * 32,
             "contract_address": "0x" + "f2" * 20,
             "status": "UNDETERMINED",
-            "created_at": pytest.approx(int(now.timestamp()), abs=1),
+            "created_at": pytest.approx(int(created_at.timestamp()), abs=1),
             "timestamp_awaiting_finalization": None,
             "blocked_at": None,
             "worker_id": None,


### PR DESCRIPTION
## Summary
- include a bounded stuck_finalization_transactions sample in consensus health output
- propagate that sample through the top-level /health consensus service payload
- cover stale and missing timestamp finalization rows in the existing DB health tests

This is an observability fix for the 2026-06-09 Rally Testnet stuck_finalizations alert. It does not claim to fix the finalizer backlog root cause; it makes the next alert actionable by including the stuck tx hash, contract, status, waiting age, blocked_at, and worker_id.

## Tests
- /Users/edgars/Dev/genlayer-studio/.venv/bin/python -m py_compile backend/protocol_rpc/health.py tests/db-sqlalchemy/test_health_orphan_detection.py
- /Users/edgars/Dev/genlayer-studio/.venv/bin/python -m black --check backend/protocol_rpc/health.py tests/db-sqlalchemy/test_health_orphan_detection.py
- /Users/edgars/Dev/genlayer-studio/.venv/bin/python -m pytest tests/db-sqlalchemy/test_health_orphan_detection.py -k stuck_finalization *(blocked: POSTGRES_URL is not set in this local environment)*