### PR TITLE
fix(ci): default GENVM_TAG for standalone PR builds

### DIFF
--- a/.github/workflows/backend_integration_tests_pr.yml
+++ b/.github/workflows/backend_integration_tests_pr.yml
@@ -43,6 +43,16 @@ jobs:
       - name: Copy .env file
         run: cp .env.example .env
 
+      - name: Set GenVM tag for CI builds
+        env:
+          GENVM_TAG_DEFAULT: ${{ vars.GENVM_TAG || 'v0.3.0-rc4' }}
+        run: |
+          # docker-compose.yml hard-requires GENVM_TAG (963f9359); .env.example ships it
+          # empty. Default from the GENVM_TAG repo variable so the release train can pin it.
+          sed -i "s|^GENVM_TAG=.*|GENVM_TAG=\"$GENVM_TAG_DEFAULT\"|" .env
+          echo "GENVM_TAG=$GENVM_TAG_DEFAULT" >> "$GITHUB_ENV"
+          grep "^GENVM_TAG=" .env
+
       # TODO: we should also add also heuristai and anthropic keys to the e2e tests and test all providers
 
       - name: Configure LLM provider

--- a/.github/workflows/backend_integration_tests_pr.yml
+++ b/.github/workflows/backend_integration_tests_pr.yml
@@ -45,10 +45,15 @@ jobs:
 
       - name: Set GenVM tag for CI builds
         env:
-          GENVM_TAG_DEFAULT: ${{ vars.GENVM_TAG || 'v0.3.0-rc4' }}
+          GENVM_TAG_DEFAULT: ${{ vars.GENVM_TAG || 'v0.3.0-rc3' }}
         run: |
           # docker-compose.yml hard-requires GENVM_TAG (963f9359); .env.example ships it
           # empty. Default from the GENVM_TAG repo variable so the release train can pin it.
+          # Pinned to v0.3.0-rc3: the v0.6 fee host protocol (MessageFeeAllocationNode with
+          # message_type/parent_index + flat MessageFeeParams) matches rc3; rc4 switched to
+          # the tagged Internal/External MessageAllocationNode schema and rejects our
+          # /genvm/run payload with 500 "unknown variant `execution_budget_per_round`",
+          # which stalls every deploy in PROPOSING until LEADER_TIMEOUT.
           sed -i "s|^GENVM_TAG=.*|GENVM_TAG=\"$GENVM_TAG_DEFAULT\"|" .env
           echo "GENVM_TAG=$GENVM_TAG_DEFAULT" >> "$GITHUB_ENV"
           grep "^GENVM_TAG=" .env

--- a/.github/workflows/load-test-oha.yml
+++ b/.github/workflows/load-test-oha.yml
@@ -65,10 +65,15 @@ jobs:
 
       - name: Set GenVM tag for CI builds
         env:
-          GENVM_TAG_DEFAULT: ${{ vars.GENVM_TAG || 'v0.3.0-rc4' }}
+          GENVM_TAG_DEFAULT: ${{ vars.GENVM_TAG || 'v0.3.0-rc3' }}
         run: |
           # docker-compose.yml hard-requires GENVM_TAG (963f9359); .env.example ships it
           # empty. Default from the GENVM_TAG repo variable so the release train can pin it.
+          # Pinned to v0.3.0-rc3: the v0.6 fee host protocol (MessageFeeAllocationNode with
+          # message_type/parent_index + flat MessageFeeParams) matches rc3; rc4 switched to
+          # the tagged Internal/External MessageAllocationNode schema and rejects our
+          # /genvm/run payload with 500 "unknown variant `execution_budget_per_round`",
+          # which stalls every deploy in PROPOSING until LEADER_TIMEOUT.
           sed -i "s|^GENVM_TAG=.*|GENVM_TAG=\"$GENVM_TAG_DEFAULT\"|" .env
           echo "GENVM_TAG=$GENVM_TAG_DEFAULT" >> "$GITHUB_ENV"
           grep "^GENVM_TAG=" .env

--- a/.github/workflows/load-test-oha.yml
+++ b/.github/workflows/load-test-oha.yml
@@ -63,6 +63,16 @@ jobs:
       - name: Copy .env file
         run: cp .env.example .env
 
+      - name: Set GenVM tag for CI builds
+        env:
+          GENVM_TAG_DEFAULT: ${{ vars.GENVM_TAG || 'v0.3.0-rc4' }}
+        run: |
+          # docker-compose.yml hard-requires GENVM_TAG (963f9359); .env.example ships it
+          # empty. Default from the GENVM_TAG repo variable so the release train can pin it.
+          sed -i "s|^GENVM_TAG=.*|GENVM_TAG=\"$GENVM_TAG_DEFAULT\"|" .env
+          echo "GENVM_TAG=$GENVM_TAG_DEFAULT" >> "$GITHUB_ENV"
+          grep "^GENVM_TAG=" .env
+
       - name: Changing URL for rpc server to localhost
         run: sed -i "s/'jsonrpc'/'localhost'/g" .env
 


### PR DESCRIPTION
Since 963f9359 docker-compose hard-requires `GENVM_TAG`, but PR workflows never set it (`.env.example` ships it empty) — any run reaching the buildx-bake step fails with `GENVM_TAG is required`. First surfaced on #1672 (Load Tests + integration tests), latent for every PR that misses the image cache.

Fix: a step after `cp .env.example .env` in `load-test-oha.yml` and `backend_integration_tests_pr.yml` sets `GENVM_TAG` from the `GENVM_TAG` repo **variable** (release-train pinnable), falling back to `v0.3.0-rc4` (current GenVM release). Written to both `.env` and `$GITHUB_ENV` so bake and compose interpolation agree.

After merge: re-run CI on #1672.