### PR TITLE
docs: add branching guide

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -2,9 +2,14 @@
 
 `branch-policy.yml` keeps the release-train model explicit:
 
-- feature PRs go to the active `*-dev` integration branch
-- promotion PRs into a release branch must come from the matching `*-dev`
+- independently releasable work may target a stable branch directly
+- multi-feature or cross-repo train work goes to the active `*-dev` integration
+  branch
+- promotion PRs into a release branch normally come from the matching `*-dev`
   branch, for example `v0.123-dev` into `v0.123`
-- `main`, `master`, `v0.122`, `release-from-main.yml`, and
+- `main` is treated as the static/default GitHub branch, not a release surface
+- `master`, stale release branches, `release-from-main.yml`, and
   `release.config.js` are treated as invalid release surfaces
 - releases must go through version tags validated by `release-from-tag.yml`
+
+See `docs/BRANCHING.md` for the contributor-facing branch model.

--- a/README.md
+++ b/README.md
@@ -6,6 +6,11 @@
 
 This Studio is an interactive sandbox designed for developers to explore the potential of the [GenLayer Protocol](https://genlayer.com/). It replicates the GenLayer network's execution environment and consensus algorithm, but offers a controlled and local environment to test different ideas and behaviors.
 
+## Branching
+
+See [docs/BRANCHING.md](docs/BRANCHING.md) for the release-train model used by
+this repo.
+
 ## Prerequisites
 Before installing the GenLayer CLI, ensure you have the following prerequisites installed:
 

--- a/docs/BRANCHING.md
+++ b/docs/BRANCHING.md
@@ -1,0 +1,58 @@
+# Branching and Release Trains
+
+This repo follows the GenLayer release-train model.
+
+## Current Train
+
+- Current stable branch: `v0.121`
+- Active integration branch: `v0.123-dev`
+- Next stable target: `v0.123`
+- `main`: default/static branch alias for the active integration branch
+
+## Stable Branches
+
+Stable branches are long-lived release lines. For semver-zero packages, each
+minor line is treated as the release line, for example `v0.121` or `v0.123`.
+
+PRs may target a stable branch directly when the merged result should be
+releasable immediately. This is appropriate for bug fixes, small non-breaking
+features, isolated release fixes, or a breaking change that is intentionally
+shipping as the next version by itself.
+
+Stable branches must remain releasable. PRs into stable branches are expected to
+pass the required cross-repo `E2E Tests` gate before merge.
+
+## Integration Branches
+
+Integration branches are optional. Use one when multiple changes need to
+accumulate before release, especially for cross-repo work, dependent features,
+breaking changes that must ship together, or a train that needs advisory E2E
+while still expected to be red.
+
+Integration branches are named after the target stable branch plus `-dev`, for
+example `v0.123-dev`. Feature PRs for that train target the integration branch.
+
+PRs into integration branches may run `E2E Tests` as advisory checks. They are
+not the release gate.
+
+## Promotion and Release
+
+When an integration train is ready, open a promotion PR from the integration
+branch to the matching stable branch, for example `v0.123-dev` to `v0.123`.
+
+That promotion PR is the release-readiness gate and must pass required
+cross-repo `E2E Tests`. The actual release is cut from the stable branch using a
+version tag after the stable branch is ready.
+
+## `main`
+
+`main` exists for GitHub UX and tools that require a stable default branch. It is
+not a release branch and it is not the integration target.
+
+This repo keeps `main` forwarded to the active integration branch using
+automation. PRs opened against `main` are automatically retargeted to the branch
+listed in `support/ci/ACTIVE_DEV_BRANCH`.
+
+When changing the active integration branch, update
+`support/ci/ACTIVE_DEV_BRANCH`, the repo docs, and the corresponding
+`genlayer-e2e` release-train matrix in the same change set.


### PR DESCRIPTION
## Summary

- add docs/BRANCHING.md describing stable branches, optional integration branches, promotion PRs, E2E gates, releases, and main behavior
- link the guide from README
- update CI notes so main is described as a static/default branch, not a release surface

## Testing

- Docs-only change; commit hooks passed.