### PR TITLE
fix(rpc): gen_getTransactionStatus returns the legacy string again

### DIFF
--- a/backend/protocol_rpc/endpoints.py
+++ b/backend/protocol_rpc/endpoints.py
@@ -1571,6 +1571,20 @@ def get_studio_transaction_by_hash(
 
 def get_transaction_status(
     transactions_processor: TransactionsProcessor, transaction_hash: str
+) -> str:
+    status = transactions_processor.get_transaction_status(transaction_hash)
+    if status is None:
+        raise NotFoundError(
+            message=f"Transaction {transaction_hash} not found",
+            data={"hash": transaction_hash},
+        )
+    # Compatibility contract for deployed apps (Rally): this legacy RPC returns
+    # the status string only. Extensions belong in gen_getTransactionStatusDetails.
+    return status["status"]
+
+
+def get_transaction_status_details(
+    transactions_processor: TransactionsProcessor, transaction_hash: str
 ) -> dict:
     status = transactions_processor.get_transaction_status(transaction_hash)
     if status is None:

--- a/backend/protocol_rpc/rpc_methods.py
+++ b/backend/protocol_rpc/rpc_methods.py
@@ -500,8 +500,19 @@ def get_studio_transaction_by_hash(
 def get_transaction_status(
     transaction_hash: str,
     transactions_processor: TransactionsProcessor = Depends(get_transactions_processor),
-) -> dict:
+) -> str:
     return impl.get_transaction_status(
+        transactions_processor=transactions_processor,
+        transaction_hash=transaction_hash,
+    )
+
+
+@rpc.method("gen_getTransactionStatusDetails", log_policy=LogPolicy.debug())
+def get_transaction_status_details(
+    transaction_hash: str,
+    transactions_processor: TransactionsProcessor = Depends(get_transactions_processor),
+) -> dict:
+    return impl.get_transaction_status_details(
         transactions_processor=transactions_processor,
         transaction_hash=transaction_hash,
     )

--- a/tests/unit/test_studio_fees.py
+++ b/tests/unit/test_studio_fees.py
@@ -16,11 +16,12 @@ from backend.domain.types import TransactionType
 from backend.errors.errors import InvalidTransactionError
 from backend.database_handler.accounts_manager import _infer_final_round
 from backend.database_handler.transactions_processor import TransactionsProcessor
-from backend.protocol_rpc.exceptions import JSONRPCError
+from backend.protocol_rpc.exceptions import JSONRPCError, NotFoundError
 from backend.protocol_rpc.endpoints import (
     _current_fee_round,
     _handle_appeal_or_top_up_and_submit,
     _handle_top_up_fees,
+    get_transaction_status_details,
     get_transaction_status,
     _stage_simulated_call_value,
     _simulation_fee_accounting,
@@ -6364,15 +6365,34 @@ def _processor_transaction(*, accounting=None, execution_result=None):
     )
 
 
-def test_transaction_status_rpc_shape_includes_canonical_status_code():
+def test_transaction_status_rpc_returns_legacy_status_string():
     class _Processor:
         def get_transaction_status(self, transaction_hash):
             return TransactionsProcessor._status_payload("ACCEPTED")
 
-    assert get_transaction_status(_Processor(), "0x1234") == {
+    assert get_transaction_status(_Processor(), "0x1234") == "ACCEPTED"
+
+
+def test_transaction_status_details_rpc_shape_includes_canonical_status_code():
+    class _Processor:
+        def get_transaction_status(self, transaction_hash):
+            return TransactionsProcessor._status_payload("ACCEPTED")
+
+    assert get_transaction_status_details(_Processor(), "0x1234") == {
         "status": "ACCEPTED",
         "statusCode": 5,
     }
+
+
+def test_transaction_status_details_rpc_raises_not_found():
+    class _Processor:
+        def get_transaction_status(self, transaction_hash):
+            return None
+
+    with pytest.raises(NotFoundError) as exc_info:
+        get_transaction_status_details(_Processor(), "0xmissing")
+
+    assert exc_info.value.data == {"hash": "0xmissing"}
 
 
 def test_transaction_payload_maps_execution_result_name():


### PR DESCRIPTION
ad77f6b7 changed `gen_getTransactionStatus` from a plain status string to `{status, statusCode}`. That's a breaking RPC change for deployed apps — Rally raw-calls it on every transaction poll and crashes on the dict (audit: `gen_getTransactionStatus` feeds `parseStatusString().toUpperCase()` in Rally's transactionService and the poll endpoint).

Principle (Edgars): hosted-studio upgrades must not require synced app deploys, and jsonrpc replicas roll sequentially — response shapes on existing methods are compatibility contracts.

- `gen_getTransactionStatus` → legacy plain string again, with a contract comment
- `gen_getTransactionStatusDetails` (new, additive) → the `{status, statusCode}` dict
- No in-tree consumer used the dict (e2e/genlayer-js matches are comments/ABI entries)
- Unit tests updated + Details coverage; full test_studio_fees suite green locally

With this merged, the Rally compat audit verdict flips to **rolls out clean** (zero migrations v0.121.7→v0.123-dev; statuses unchanged on the wire; everything else additive). Remaining staging gate: verify deployed IC runner hashes resolve on the genvm-main runtime.