### PR TITLE
[codex] Fix worker liveness threshold for long Rally txs

### DIFF
--- a/backend/consensus/worker_service.py
+++ b/backend/consensus/worker_service.py
@@ -102,6 +102,52 @@ def get_genvm_failure_count() -> int:
     return _genvm_consecutive_failures
 
 
+def _get_blocked_tx_unhealthy_after_minutes(transaction_timeout_minutes=None) -> int:
+    """Return the liveness threshold for a claimed transaction.
+
+    The worker recovery timeout owns deciding when a transaction is stuck.
+    Liveness must stay above that timeout so Kubernetes does not kill a
+    legitimately long consensus attempt and force a recovery cycle.
+    """
+    if isinstance(transaction_timeout_minutes, (int, str)) and not isinstance(
+        transaction_timeout_minutes, bool
+    ):
+        raw_transaction_timeout = transaction_timeout_minutes
+    else:
+        raw_transaction_timeout = os.getenv("TRANSACTION_TIMEOUT_MINUTES", "30")
+
+    try:
+        transaction_timeout = int(raw_transaction_timeout)
+    except (TypeError, ValueError):
+        transaction_timeout = 30
+    if transaction_timeout <= 0:
+        transaction_timeout = 30
+
+    try:
+        buffer_minutes = int(
+            os.getenv("WORKER_BLOCKED_TX_UNHEALTHY_BUFFER_MINUTES", "5")
+        )
+    except ValueError:
+        buffer_minutes = 5
+    if buffer_minutes <= 0:
+        buffer_minutes = 5
+
+    minimum_threshold = max(14, transaction_timeout + buffer_minutes)
+
+    configured_threshold = os.getenv("WORKER_BLOCKED_TX_UNHEALTHY_AFTER_MINUTES")
+    if configured_threshold is None:
+        return minimum_threshold
+
+    try:
+        configured_threshold_minutes = int(configured_threshold)
+    except ValueError:
+        return minimum_threshold
+    if configured_threshold_minutes <= 0:
+        return minimum_threshold
+
+    return max(configured_threshold_minutes, minimum_threshold)
+
+
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     """Manage the worker lifecycle."""
@@ -432,7 +478,7 @@ def health_check():
     long-running synchronous DB operations in the consensus worker.
     """
     import psutil
-    from datetime import datetime
+    from datetime import datetime, timezone
     from fastapi.responses import JSONResponse
     from urllib.request import urlopen, Request
     from urllib.error import URLError
@@ -556,16 +602,9 @@ def health_check():
     # Check if ANY transaction is blocked for too long
     current_txs = []
     if worker.current_transactions:
-        # Get unhealthy threshold from env
-        try:
-            blocked_tx_unhealthy_after_minutes = int(
-                os.getenv("WORKER_BLOCKED_TX_UNHEALTHY_AFTER_MINUTES", "14")
-            )
-        except ValueError:
-            blocked_tx_unhealthy_after_minutes = 14
-        if blocked_tx_unhealthy_after_minutes <= 0:
-            blocked_tx_unhealthy_after_minutes = 14
-
+        blocked_tx_unhealthy_after_minutes = _get_blocked_tx_unhealthy_after_minutes(
+            getattr(worker, "transaction_timeout_minutes", None)
+        )
         blocked_tx_unhealthy_after_seconds = blocked_tx_unhealthy_after_minutes * 60
 
         for tx_hash, tx_info in worker.current_transactions.items():
@@ -584,7 +623,8 @@ def health_check():
                     if blocked_at.tzinfo is not None:
                         blocked_at = blocked_at.replace(tzinfo=None)
 
-                    elapsed = datetime.utcnow() - blocked_at
+                    now_utc = datetime.now(timezone.utc).replace(tzinfo=None)
+                    elapsed = now_utc - blocked_at
 
                     # Check if blocked for too long - pod is unhealthy
                     if elapsed.total_seconds() > blocked_tx_unhealthy_after_seconds:

--- a/tests/unit/test_worker_health_degradation.py
+++ b/tests/unit/test_worker_health_degradation.py
@@ -2,6 +2,7 @@
 Tests for worker health degradation based on GenVM consecutive failures
 """
 
+from datetime import datetime, timedelta, timezone
 from unittest.mock import patch, MagicMock
 
 # Import the module-level functions and variables
@@ -168,3 +169,85 @@ class TestEnvVarThresholdConfig:
 
             threshold = int(os.environ.get("GENVM_FAILURE_UNHEALTHY_THRESHOLD", "3"))
             assert threshold == 3
+
+
+class TestBlockedTransactionHealthThreshold:
+    """Test health handling for long-running claimed transactions"""
+
+    def setup_method(self):
+        worker_service._genvm_consecutive_failures = 0
+        worker_service._genvm_failure_unhealthy_threshold = 3
+        worker_service._genvm_health_last_check = 0.0
+        worker_service._genvm_health_last_ok = True
+        worker_service._genvm_health_last_error = None
+        worker_service.worker_permanently_failed = False
+
+    def _set_worker_with_blocked_tx(self, blocked_at, transaction_timeout_minutes=30):
+        mock_worker = MagicMock()
+        mock_worker.worker_id = "test-worker-123"
+        mock_worker.running = True
+        mock_worker.transaction_timeout_minutes = transaction_timeout_minutes
+        mock_worker.current_transactions = {"0xabc": {"blocked_at": blocked_at}}
+        mock_worker._active_tasks = set()
+        mock_worker._generic_error_retries = {}
+        mock_worker.max_parallel_txs = 1
+        worker_service.worker = mock_worker
+
+        mock_task = MagicMock()
+        mock_task.done.return_value = False
+        worker_service.worker_task = mock_task
+
+    def test_blocked_tx_threshold_defaults_above_transaction_timeout(self):
+        """Default blocked-tx liveness threshold is tx timeout plus buffer"""
+        with patch.dict("os.environ", {}, clear=True):
+            assert worker_service._get_blocked_tx_unhealthy_after_minutes(30) == 35
+
+    def test_blocked_tx_threshold_clamps_too_low_env_value(self):
+        """Too-low explicit threshold cannot undercut transaction timeout"""
+        with patch.dict(
+            "os.environ", {"WORKER_BLOCKED_TX_UNHEALTHY_AFTER_MINUTES": "14"}
+        ):
+            assert worker_service._get_blocked_tx_unhealthy_after_minutes(30) == 35
+
+    def test_blocked_tx_threshold_respects_higher_env_value(self):
+        """Higher explicit threshold is preserved"""
+        with patch.dict(
+            "os.environ", {"WORKER_BLOCKED_TX_UNHEALTHY_AFTER_MINUTES": "90"}
+        ):
+            assert worker_service._get_blocked_tx_unhealthy_after_minutes(30) == 90
+
+    def test_health_allows_claimed_tx_before_transaction_timeout(self):
+        """A 20-minute claimed tx with a 30-minute timeout remains healthy"""
+        self._set_worker_with_blocked_tx(
+            datetime.now(timezone.utc) - timedelta(minutes=20)
+        )
+
+        with patch.dict(
+            "os.environ", {"WORKER_BLOCKED_TX_UNHEALTHY_AFTER_MINUTES": "14"}
+        ), patch("urllib.request.urlopen") as mock_urlopen:
+            mock_resp = MagicMock()
+            mock_resp.status = 200
+            mock_urlopen.return_value = mock_resp
+
+            response = worker_service.health_check()
+
+        assert isinstance(response, dict)
+        assert response["status"] == "healthy"
+
+    def test_health_fails_for_claimed_tx_after_liveness_threshold(self):
+        """A claimed tx past tx timeout plus buffer still marks pod unhealthy"""
+        self._set_worker_with_blocked_tx(
+            datetime.now(timezone.utc) - timedelta(minutes=36)
+        )
+
+        with patch.dict("os.environ", {}, clear=True), patch(
+            "urllib.request.urlopen"
+        ) as mock_urlopen:
+            mock_resp = MagicMock()
+            mock_resp.status = 200
+            mock_urlopen.return_value = mock_resp
+
+            response = worker_service.health_check()
+
+        assert response.status_code == 500
+        assert "more than 35 minutes" in response.body.decode()


### PR DESCRIPTION
## Summary
- Derive the worker blocked-transaction liveness threshold from the configured transaction timeout plus a buffer
- Clamp too-low `WORKER_BLOCKED_TX_UNHEALTHY_AFTER_MINUTES` values so Kubernetes does not restart workers before Studio recovery owns stuck-tx handling
- Add regression coverage for long-running claimed transactions and stale transaction liveness failures

## Root Cause
Rally transactions can legitimately take longer than 14 minutes when they involve multiple validators, LLM/web calls, and leader rotations. The worker service health endpoint was using a hard-coded 14 minute blocked transaction threshold while Rally workers use a 30 minute transaction timeout. Kubernetes liveness could therefore restart a worker during a valid long-running consensus attempt, leaving the transaction to be recovered later and incrementing `recovery_count`.

## Validation
- `./.venv/bin/python -m pytest tests/unit/test_worker_health_degradation.py` -> 14 passed

## Release Notes
- Fixes false worker liveness restarts for long-running consensus transactions, reducing recovery storm alerts in hosted Rally/Studio deployments.