### PR TITLE
[codex] Fix worker claim release before shutdown deadline

### DIFF
--- a/backend/consensus/worker_service.py
+++ b/backend/consensus/worker_service.py
@@ -148,6 +148,51 @@ def _get_blocked_tx_unhealthy_after_minutes(transaction_timeout_minutes=None) ->
     return max(configured_threshold_minutes, minimum_threshold)
 
 
+def _get_worker_graceful_shutdown_timeout_seconds() -> int:
+    """Return how long shutdown should wait before releasing claimed txs.
+
+    Kubernetes sends SIGKILL when terminationGracePeriodSeconds expires. The
+    worker must release claims before that hard deadline, otherwise scale-down
+    strands in-flight transactions until the 30m stale-claim recovery path bumps
+    recovery_count.
+    """
+    default_termination_grace = 180
+    try:
+        termination_grace = int(
+            os.getenv(
+                "WORKER_TERMINATION_GRACE_SECONDS", str(default_termination_grace)
+            )
+        )
+    except ValueError:
+        termination_grace = default_termination_grace
+    if termination_grace <= 0:
+        termination_grace = default_termination_grace
+
+    try:
+        release_buffer = int(os.getenv("WORKER_SHUTDOWN_RELEASE_BUFFER_SECONDS", "30"))
+    except ValueError:
+        release_buffer = 30
+    if release_buffer <= 0:
+        release_buffer = 30
+
+    default_timeout = max(1, termination_grace - release_buffer)
+
+    configured_timeout = os.getenv("WORKER_GRACEFUL_SHUTDOWN_TIMEOUT_SECONDS")
+    if configured_timeout is None:
+        return default_timeout
+
+    try:
+        timeout = int(configured_timeout)
+    except ValueError:
+        return default_timeout
+    if timeout <= 0:
+        return default_timeout
+
+    # Preserve a release buffer even when the configured value is too close to
+    # Kubernetes' hard kill deadline.
+    return min(timeout, default_timeout)
+
+
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     """Manage the worker lifecycle."""
@@ -369,11 +414,10 @@ async def lifespan(app: FastAPI):
                 f"Waiting for {tx_count} transactions / {task_count} tasks to complete before shutdown..."
             )
 
-            # Get graceful shutdown timeout from env (default: 180 seconds)
-            # This gives the transactions time to finish before we force-stop
-            graceful_timeout = int(
-                os.environ.get("WORKER_GRACEFUL_SHUTDOWN_TIMEOUT_SECONDS", "180")
-            )
+            # Release claims before Kubernetes' SIGKILL deadline. This gives
+            # in-flight work time to complete, but still leaves a buffer for
+            # cleanup/requeue if the pod is being scaled down.
+            graceful_timeout = _get_worker_graceful_shutdown_timeout_seconds()
             start_time = time.time()
 
             while (worker.current_transactions or worker._active_tasks) and (

--- a/tests/unit/test_worker_health_degradation.py
+++ b/tests/unit/test_worker_health_degradation.py
@@ -171,6 +171,76 @@ class TestEnvVarThresholdConfig:
             assert threshold == 3
 
 
+class TestGracefulShutdownTimeoutConfig:
+    """Test worker shutdown timeout leaves time to release claimed transactions"""
+
+    def test_shutdown_timeout_defaults_to_termination_grace_minus_buffer(self):
+        """Default timeout preserves a release buffer before Kubernetes SIGKILL"""
+        with patch.dict("os.environ", {}, clear=True):
+            assert worker_service._get_worker_graceful_shutdown_timeout_seconds() == 150
+
+    def test_shutdown_timeout_clamps_configured_value_to_release_buffer(self):
+        """Configured timeout cannot consume the whole termination grace window"""
+        with patch.dict(
+            "os.environ",
+            {
+                "WORKER_TERMINATION_GRACE_SECONDS": "180",
+                "WORKER_SHUTDOWN_RELEASE_BUFFER_SECONDS": "30",
+                "WORKER_GRACEFUL_SHUTDOWN_TIMEOUT_SECONDS": "180",
+            },
+            clear=True,
+        ):
+            assert worker_service._get_worker_graceful_shutdown_timeout_seconds() == 150
+
+    def test_shutdown_timeout_respects_lower_configured_value(self):
+        """Lower configured timeout is preserved"""
+        with patch.dict(
+            "os.environ",
+            {
+                "WORKER_TERMINATION_GRACE_SECONDS": "180",
+                "WORKER_SHUTDOWN_RELEASE_BUFFER_SECONDS": "30",
+                "WORKER_GRACEFUL_SHUTDOWN_TIMEOUT_SECONDS": "90",
+            },
+            clear=True,
+        ):
+            assert worker_service._get_worker_graceful_shutdown_timeout_seconds() == 90
+
+    def test_shutdown_timeout_uses_custom_termination_grace(self):
+        """Custom termination grace still keeps the default release buffer"""
+        with patch.dict(
+            "os.environ",
+            {"WORKER_TERMINATION_GRACE_SECONDS": "300"},
+            clear=True,
+        ):
+            assert worker_service._get_worker_graceful_shutdown_timeout_seconds() == 270
+
+    def test_shutdown_timeout_handles_invalid_env_values(self):
+        """Invalid env values fall back to the safe default"""
+        with patch.dict(
+            "os.environ",
+            {
+                "WORKER_TERMINATION_GRACE_SECONDS": "bad",
+                "WORKER_SHUTDOWN_RELEASE_BUFFER_SECONDS": "bad",
+                "WORKER_GRACEFUL_SHUTDOWN_TIMEOUT_SECONDS": "bad",
+            },
+            clear=True,
+        ):
+            assert worker_service._get_worker_graceful_shutdown_timeout_seconds() == 150
+
+    def test_shutdown_timeout_handles_non_positive_env_values(self):
+        """Non-positive env values fall back to the safe default"""
+        with patch.dict(
+            "os.environ",
+            {
+                "WORKER_TERMINATION_GRACE_SECONDS": "0",
+                "WORKER_SHUTDOWN_RELEASE_BUFFER_SECONDS": "-1",
+                "WORKER_GRACEFUL_SHUTDOWN_TIMEOUT_SECONDS": "0",
+            },
+            clear=True,
+        ):
+            assert worker_service._get_worker_graceful_shutdown_timeout_seconds() == 150
+
+
 class TestBlockedTransactionHealthThreshold:
     """Test health handling for long-running claimed transactions"""
 


### PR DESCRIPTION
## Summary

Fixes worker shutdown timing so claimed transactions are released before Kubernetes reaches its hard termination deadline.

## Root cause

The worker cleanup path waited up to `WORKER_GRACEFUL_SHUTDOWN_TIMEOUT_SECONDS`, defaulting to 180 seconds, before releasing `current_transactions`. Rally worker pods also use a 180 second `terminationGracePeriodSeconds`, so during HPA scale-down the process could be SIGKILLed before cleanup released claimed transactions. Those stranded claims then sit until the stale-claim recovery path runs, incrementing `recovery_count` and triggering recovery-storm alerts.

## Changes

- Add `_get_worker_graceful_shutdown_timeout_seconds()` to derive a safe shutdown wait from the termination grace period minus a release buffer.
- Default to 150 seconds for the current 180 second termination grace, preserving 30 seconds for release/requeue cleanup before SIGKILL.
- Clamp explicit `WORKER_GRACEFUL_SHUTDOWN_TIMEOUT_SECONDS` values so they cannot consume the whole termination window.
- Cover default, clamped, custom grace, lower explicit, and invalid-env cases in unit tests.

## Validation

- `/Users/edgars/Dev/genlayer-studio/.venv/bin/python -m pytest tests/unit/test_worker_health_degradation.py` -> 19 passed
- `/Users/edgars/Dev/genlayer-studio/.venv/bin/python -m py_compile backend/consensus/worker_service.py tests/unit/test_worker_health_degradation.py`

## Operational note

This does not replace a deployment-side `preStop` hook, but it hardens the current app behavior for the live 180 second termination grace window.