### PR TITLE
[codex] add LLM router provider capability

### DIFF
--- a/backend/node/create_nodes/default_providers/llm-router_policy-auto.json
+++ b/backend/node/create_nodes/default_providers/llm-router_policy-auto.json
@@ -1,0 +1,10 @@
+{
+  "provider": "llm-router",
+  "plugin": "openai-compatible",
+  "model": "policy:auto",
+  "config": {},
+  "plugin_config": {
+    "api_key_env_var": "LLM_ROUTER_API_KEY",
+    "api_url": "https://internal-router.genlayer.com"
+  }
+}

--- a/backend/protocol_rpc/endpoints.py
+++ b/backend/protocol_rpc/endpoints.py
@@ -328,19 +328,28 @@ async def check_provider_is_available(
             url = provider.plugin_config["api_url"]
             plugin = provider.plugin
             key = provider.plugin_config["api_key_env_var"]
-            temperature = provider.config.get("temperature", 1)
-            use_max_completion_tokens = provider.config.get(
-                "use_max_completion_tokens", False
-            )
+            config = provider.config or {}
         else:
             model = provider["model"]
             url = provider["plugin_config"]["api_url"]
             plugin = provider["plugin"]
             key = provider["plugin_config"]["api_key_env_var"]
-            temperature = provider["config"].get("temperature", 1)
-            use_max_completion_tokens = provider["config"].get(
-                "use_max_completion_tokens", False
-            )
+            config = provider["config"] or {}
+        temperature = config.get("temperature", 1)
+        use_max_completion_tokens = config.get("use_max_completion_tokens", False)
+        max_tokens = config.get("max_tokens", 500)
+        known_config_keys = {"temperature", "max_tokens", "use_max_completion_tokens"}
+        extra = {k: v for k, v in config.items() if k not in known_config_keys}
+        prompt = {
+            "system_message": "",
+            "user_message": "respond with two letters 'ok' and nothing else. No quotes, no repetition",
+            "temperature": temperature,
+            "max_tokens": max_tokens,
+            "use_max_completion_tokens": use_max_completion_tokens,
+            "images": [],
+        }
+        if extra:
+            prompt["extra"] = extra
         key = f"${{ENV[{key}]}}"
         timeout_s = float(
             os.environ.get("LLM_PROVIDER_AVAILABILITY_TIMEOUT_SECONDS", "20")
@@ -355,14 +364,7 @@ async def check_provider_is_available(
                         "key": key,
                     }
                 ],
-                prompt={
-                    "system_message": "",
-                    "user_message": "respond with two letters 'ok' and nothing else. No quotes, no repetition",
-                    "temperature": temperature,
-                    "max_tokens": 500,
-                    "use_max_completion_tokens": use_max_completion_tokens,
-                    "images": [],
-                },
+                prompt=prompt,
             ),
             timeout=timeout_s,
         )

--- a/backend/protocol_rpc/rpc_methods.py
+++ b/backend/protocol_rpc/rpc_methods.py
@@ -169,6 +169,7 @@ async def update_validator(
     stake: int | None = None,
     provider: str | None = None,
     model: str | None = None,
+    config: dict | None = None,
     plugin: str | None = None,
     plugin_config: dict | None = None,
     session: Session = Depends(get_db_session),
@@ -181,6 +182,7 @@ async def update_validator(
         stake=stake,
         provider=provider,
         model=model,
+        config=config,
         plugin=plugin,
         plugin_config=plugin_config,
     )

--- a/tests/unit/test_llm_provider_availability.py
+++ b/tests/unit/test_llm_provider_availability.py
@@ -51,6 +51,16 @@ class SlowGenVMManager:
         return [{"response": "ok"}]
 
 
+class CapturingGenVMManager:
+    def __init__(self):
+        self.logger = MagicMock()
+        self.prompt = None
+
+    async def try_llms(self, providers, prompt):
+        self.prompt = prompt
+        return [{"response": "ok"}]
+
+
 @pytest.mark.asyncio
 async def test_get_providers_and_models_marks_failed_checks_unavailable():
     providers = await endpoints.get_providers_and_models(
@@ -83,3 +93,41 @@ async def test_provider_availability_timeout_returns_unavailable(monkeypatch):
 
     assert available is False
     manager.logger.error.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_provider_availability_forwards_extra_config():
+    manager = CapturingGenVMManager()
+    policy_ir = [
+        "policy",
+        ["and", ["meets_req"], ["not", ["is", "disabled"]]],
+        ["zero"],
+        ["argmax"],
+        ["id"],
+        ["always", {"action": "next_candidate"}],
+    ]
+
+    available = await endpoints.check_provider_is_available(
+        manager,
+        {
+            "provider": "llm-router",
+            "model": "policy:auto",
+            "config": {
+                "temperature": 0.5,
+                "max_tokens": 250,
+                "use_max_completion_tokens": True,
+                "policy_ir": policy_ir,
+            },
+            "plugin": "openai-compatible",
+            "plugin_config": {
+                "api_key_env_var": "LLM_ROUTER_API_KEY",
+                "api_url": "https://internal-router.genlayer.com",
+            },
+        },
+    )
+
+    assert available is True
+    assert manager.prompt["temperature"] == 0.5
+    assert manager.prompt["max_tokens"] == 250
+    assert manager.prompt["use_max_completion_tokens"] is True
+    assert manager.prompt["extra"] == {"policy_ir": policy_ir}

--- a/tests/unit/test_rpc_methods.py
+++ b/tests/unit/test_rpc_methods.py
@@ -1,0 +1,44 @@
+from unittest.mock import AsyncMock
+
+import pytest
+
+from backend.protocol_rpc import rpc_methods
+
+
+@pytest.mark.asyncio
+async def test_update_validator_forwards_config_argument(monkeypatch):
+    session = object()
+    validators_manager = object()
+    update_validator = AsyncMock(return_value={"address": "0xabc"})
+    monkeypatch.setattr(rpc_methods.impl, "update_validator", update_validator)
+
+    config = {"max_tokens": 500, "temperature": 0.75}
+    plugin_config = {
+        "api_key_env_var": "OPENROUTERAPIKEY",
+        "api_url": "https://openrouter.ai/api",
+    }
+
+    result = await rpc_methods.update_validator(
+        "0xabc",
+        11,
+        "openrouter",
+        "@preset/rally-testnet-gpt-5-1",
+        config,
+        "openai-compatible",
+        plugin_config,
+        session=session,
+        validators_manager=validators_manager,
+    )
+
+    assert result == {"address": "0xabc"}
+    update_validator.assert_awaited_once_with(
+        session=session,
+        validators_manager=validators_manager,
+        validator_address="0xabc",
+        stake=11,
+        provider="openrouter",
+        model="@preset/rally-testnet-gpt-5-1",
+        config=config,
+        plugin="openai-compatible",
+        plugin_config=plugin_config,
+    )


### PR DESCRIPTION
## Summary

Adds the inert Studio-side capability needed for workload-controlled LLM router rollout:

- registers `llm-router/policy:auto` as a default OpenAI-compatible provider
- keeps the default provider config empty so no demo/custom policy is hardcoded in Studio
- forwards unknown provider config fields, such as `policy_ir`, through availability checks under `prompt.extra`
- preserves provider `config` through the JSON-RPC `sim_updateValidator` wrapper so validator updates do not misposition config as `plugin`
- adds focused unit coverage for provider-config forwarding

## Scope

This intentionally does not include workload config, API-key wiring, `.env` changes, validator switches, pruning/state-retention changes, or any router policy rollout. Environments only use this capability when their workload config references `llm-router/policy:auto`.

## Validation

Local focused validation:

```bash
/Users/edgars/Dev/genlayer-studio/.venv/bin/python -m pytest tests/unit/test_llm_provider_availability.py tests/unit/test_providers.py tests/unit/test_rpc_methods.py tests/unit/test_simulator_sessions.py
```

Result: `21 passed, 1 warning`.

## Release Gate

Do not merge until full CI and E2E have passed for this PR.
