### PR TITLE
[codex] record wallet connection analytics

### DIFF
--- a/backend/database_handler/migration/versions/8c2f0f0c9f1a_wallet_connection_analytics.py
+++ b/backend/database_handler/migration/versions/8c2f0f0c9f1a_wallet_connection_analytics.py
@@ -1,0 +1,57 @@
+"""wallet connection analytics
+
+Revision ID: 8c2f0f0c9f1a
+Revises: a7b8c9d0e1f2
+Create Date: 2026-06-17 00:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "8c2f0f0c9f1a"
+down_revision: Union[str, None] = "a7b8c9d0e1f2"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "wallet_connection_analytics",
+        sa.Column("wallet_address", sa.String(length=42), nullable=False),
+        sa.Column(
+            "connect_count",
+            sa.Integer(),
+            server_default="1",
+            nullable=False,
+        ),
+        sa.Column("first_observed_ip", sa.String(length=45), nullable=True),
+        sa.Column("last_observed_ip", sa.String(length=45), nullable=True),
+        sa.Column("first_user_agent", sa.String(length=512), nullable=True),
+        sa.Column("last_user_agent", sa.String(length=512), nullable=True),
+        sa.Column("first_origin", sa.String(length=512), nullable=True),
+        sa.Column("last_origin", sa.String(length=512), nullable=True),
+        sa.Column(
+            "first_connected_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("CURRENT_TIMESTAMP"),
+            nullable=False,
+        ),
+        sa.Column(
+            "last_connected_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("CURRENT_TIMESTAMP"),
+            nullable=False,
+        ),
+        sa.PrimaryKeyConstraint(
+            "wallet_address", name="wallet_connection_analytics_pkey"
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("wallet_connection_analytics")

--- a/backend/database_handler/models.py
+++ b/backend/database_handler/models.py
@@ -293,3 +293,39 @@ class ApiKey(Base):
     last_used_at: Mapped[Optional[datetime.datetime]] = mapped_column(
         DateTime(True), nullable=True, init=False
     )
+
+
+class WalletConnectionAnalytics(Base):
+    __tablename__ = "wallet_connection_analytics"
+    __table_args__ = (
+        PrimaryKeyConstraint("wallet_address", name="wallet_connection_analytics_pkey"),
+    )
+
+    wallet_address: Mapped[str] = mapped_column(String(42), primary_key=True)
+    connect_count: Mapped[int] = mapped_column(
+        Integer, nullable=False, server_default="1", default=1
+    )
+    first_observed_ip: Mapped[Optional[str]] = mapped_column(
+        String(45), nullable=True, default=None
+    )
+    last_observed_ip: Mapped[Optional[str]] = mapped_column(
+        String(45), nullable=True, default=None
+    )
+    first_user_agent: Mapped[Optional[str]] = mapped_column(
+        String(512), nullable=True, default=None
+    )
+    last_user_agent: Mapped[Optional[str]] = mapped_column(
+        String(512), nullable=True, default=None
+    )
+    first_origin: Mapped[Optional[str]] = mapped_column(
+        String(512), nullable=True, default=None
+    )
+    last_origin: Mapped[Optional[str]] = mapped_column(
+        String(512), nullable=True, default=None
+    )
+    first_connected_at: Mapped[datetime.datetime] = mapped_column(
+        DateTime(True), server_default=func.current_timestamp(), init=False
+    )
+    last_connected_at: Mapped[datetime.datetime] = mapped_column(
+        DateTime(True), server_default=func.current_timestamp(), init=False
+    )

--- a/backend/protocol_rpc/analytics_router.py
+++ b/backend/protocol_rpc/analytics_router.py
@@ -1,0 +1,53 @@
+"""Analytics-only HTTP endpoints."""
+
+from typing import Annotated
+
+from fastapi import APIRouter, Depends, HTTPException, Request, status
+from pydantic import BaseModel
+from sqlalchemy.orm import Session
+
+from backend.protocol_rpc.client_ip import ClientIPResolver
+from backend.protocol_rpc.dependencies import get_db_session
+from backend.services.wallet_connection_analytics_service import (
+    WalletConnectionMetadata,
+    record_wallet_connection,
+)
+
+analytics_router = APIRouter(prefix="/api/analytics", tags=["analytics"])
+_client_ip_resolver = ClientIPResolver()
+
+
+class WalletConnectionRequest(BaseModel):
+    wallet_address: str
+
+
+class WalletConnectionResponse(BaseModel):
+    wallet_address: str
+    recorded: bool
+
+
+@analytics_router.post(
+    "/wallet-connections",
+    response_model=WalletConnectionResponse,
+    status_code=status.HTTP_200_OK,
+)
+def record_wallet_connection_endpoint(
+    payload: WalletConnectionRequest,
+    request: Request,
+    session: Annotated[Session, Depends(get_db_session)],
+):
+    metadata = WalletConnectionMetadata(
+        observed_ip=_client_ip_resolver.client_ip(request),
+        user_agent=request.headers.get("User-Agent"),
+        origin=request.headers.get("Origin"),
+    )
+    try:
+        record = record_wallet_connection(
+            session=session,
+            wallet_address=payload.wallet_address,
+            metadata=metadata,
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+
+    return WalletConnectionResponse(wallet_address=record.wallet_address, recorded=True)

--- a/backend/protocol_rpc/client_ip.py
+++ b/backend/protocol_rpc/client_ip.py
@@ -1,0 +1,101 @@
+"""Helpers for deriving a client IP from trusted proxy headers."""
+
+from __future__ import annotations
+
+import logging
+import os
+from ipaddress import ip_address, ip_network
+from typing import Optional
+
+from starlette.requests import Request
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_TRUSTED_PROXY_CIDRS = (
+    "127.0.0.0/8",
+    "10.0.0.0/8",  # NOSONAR - RFC1918 private proxy range.
+    "172.16.0.0/12",  # NOSONAR - RFC1918 private proxy range.
+    "192.168.0.0/16",  # NOSONAR - RFC1918 private proxy range.
+    "::1/128",
+    "fc00::/7",
+)
+
+
+def load_trusted_proxy_networks(env_var: str = "RATE_LIMIT_TRUSTED_PROXIES"):
+    raw = os.environ.get(env_var, ",".join(DEFAULT_TRUSTED_PROXY_CIDRS))
+    networks = []
+    for value in raw.split(","):
+        value = value.strip()
+        if not value:
+            continue
+        try:
+            networks.append(ip_network(value, strict=False))
+        except ValueError:
+            logger.warning("Ignoring invalid %s entry", env_var)
+    return tuple(networks)
+
+
+class ClientIPResolver:
+    def __init__(self, trusted_proxy_networks=None):
+        self._trusted_proxy_networks = (
+            trusted_proxy_networks
+            if trusted_proxy_networks is not None
+            else load_trusted_proxy_networks()
+        )
+
+    def client_ip(self, request: Request) -> str:
+        peer_host = request.client.host if request.client else "unknown"
+        if not self._is_trusted_proxy(peer_host):
+            return peer_host
+
+        forwarded_for = request.headers.get("X-Forwarded-For")
+        if forwarded_for:
+            forwarded_ip = self._forwarded_client_ip(forwarded_for)
+            if forwarded_ip is not None:
+                return forwarded_ip
+
+        real_ip = self._valid_ip_header(request.headers.get("X-Real-IP"))
+        if real_ip:
+            return real_ip
+
+        return peer_host
+
+    def _forwarded_client_ip(self, forwarded_for: str) -> Optional[str]:
+        parsed = self._parse_forwarded_for(forwarded_for)
+        for value, parsed_ip in reversed(parsed):
+            if not self._is_trusted_ip(parsed_ip):
+                return value
+        if parsed:
+            return parsed[0][0]
+        return None
+
+    def _parse_forwarded_for(self, forwarded_for: str) -> list[tuple[str, object]]:
+        parsed = []
+        for value in forwarded_for.split(","):
+            value = value.strip()
+            if not value:
+                continue
+            try:
+                parsed.append((value, ip_address(value)))
+            except ValueError:
+                continue
+        return parsed
+
+    def _valid_ip_header(self, value: Optional[str]) -> Optional[str]:
+        if not value:
+            return None
+        value = value.strip()
+        try:
+            ip_address(value)
+        except ValueError:
+            return None
+        return value
+
+    def _is_trusted_proxy(self, host: str) -> bool:
+        try:
+            return self._is_trusted_ip(ip_address(host))
+        except ValueError:
+            return False
+
+    def _is_trusted_ip(self, parsed_ip) -> bool:
+        return any(parsed_ip in network for network in self._trusted_proxy_networks)

--- a/backend/protocol_rpc/fastapi_server.py
+++ b/backend/protocol_rpc/fastapi_server.py
@@ -14,6 +14,7 @@ from starlette.requests import ClientDisconnect
 load_dotenv()
 
 from backend.protocol_rpc.app_lifespan import RPCAppSettings, rpc_app_lifespan
+from backend.protocol_rpc.analytics_router import analytics_router
 from backend.protocol_rpc.dependencies import (
     get_rpc_router_optional,
     websocket_broadcast,
@@ -78,6 +79,9 @@ app.include_router(health_router)
 
 # Include explorer API endpoints
 app.include_router(explorer_router)
+
+# Include analytics-only endpoints
+app.include_router(analytics_router)
 
 
 # JSON-RPC endpoint (supports single and batch requests)

--- a/backend/protocol_rpc/rate_limit_middleware.py
+++ b/backend/protocol_rpc/rate_limit_middleware.py
@@ -3,44 +3,17 @@
 from __future__ import annotations
 
 import logging
-import os
-from ipaddress import ip_address, ip_network
 from typing import Optional
 
 from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.requests import Request
 from starlette.responses import JSONResponse, Response
 
+from backend.protocol_rpc.client_ip import ClientIPResolver
 from backend.protocol_rpc.exceptions import RateLimitExceeded
 from backend.protocol_rpc.rate_limiter import RateLimiterService
 
 logger = logging.getLogger(__name__)
-
-DEFAULT_TRUSTED_PROXY_CIDRS = (
-    "127.0.0.0/8",
-    "10.0.0.0/8",  # NOSONAR - RFC1918 private proxy range.
-    "172.16.0.0/12",  # NOSONAR - RFC1918 private proxy range.
-    "192.168.0.0/16",  # NOSONAR - RFC1918 private proxy range.
-    "::1/128",
-    "fc00::/7",
-)
-
-
-def _load_trusted_proxy_networks():
-    raw = os.environ.get(
-        "RATE_LIMIT_TRUSTED_PROXIES",
-        ",".join(DEFAULT_TRUSTED_PROXY_CIDRS),
-    )
-    networks = []
-    for value in raw.split(","):
-        value = value.strip()
-        if not value:
-            continue
-        try:
-            networks.append(ip_network(value, strict=False))
-        except ValueError:
-            logger.warning("Ignoring invalid RATE_LIMIT_TRUSTED_PROXIES entry")
-    return tuple(networks)
 
 
 class RateLimitMiddleware(BaseHTTPMiddleware):
@@ -48,7 +21,7 @@ class RateLimitMiddleware(BaseHTTPMiddleware):
 
     def __init__(self, app, dispatch=None):
         super().__init__(app, dispatch=dispatch)
-        self._trusted_proxy_networks = _load_trusted_proxy_networks()
+        self._client_ip_resolver = ClientIPResolver()
 
     async def dispatch(self, request: Request, call_next) -> Response:
         # Only rate-limit the JSON-RPC endpoint
@@ -62,7 +35,7 @@ class RateLimitMiddleware(BaseHTTPMiddleware):
             return await call_next(request)
 
         api_key = request.headers.get("X-API-Key")
-        client_ip = self._client_ip(request)
+        client_ip = self._client_ip_resolver.client_ip(request)
 
         try:
             await rate_limiter.check_rate_limit(api_key, client_ip)
@@ -86,60 +59,3 @@ class RateLimitMiddleware(BaseHTTPMiddleware):
             )
 
         return await call_next(request)
-
-    def _client_ip(self, request: Request) -> str:
-        peer_host = request.client.host if request.client else "unknown"
-        if not self._is_trusted_proxy(peer_host):
-            return peer_host
-
-        forwarded_for = request.headers.get("X-Forwarded-For")
-        if forwarded_for:
-            forwarded_ip = self._forwarded_client_ip(forwarded_for)
-            if forwarded_ip is not None:
-                return forwarded_ip
-
-        real_ip = self._valid_ip_header(request.headers.get("X-Real-IP"))
-        if real_ip:
-            return real_ip
-
-        return peer_host
-
-    def _forwarded_client_ip(self, forwarded_for: str) -> Optional[str]:
-        parsed = self._parse_forwarded_for(forwarded_for)
-        for value, parsed_ip in reversed(parsed):
-            if not self._is_trusted_ip(parsed_ip):
-                return value
-        if parsed:
-            return parsed[0][0]
-        return None
-
-    def _parse_forwarded_for(self, forwarded_for: str) -> list[tuple[str, object]]:
-        parsed = []
-        for value in forwarded_for.split(","):
-            value = value.strip()
-            if not value:
-                continue
-            try:
-                parsed.append((value, ip_address(value)))
-            except ValueError:
-                continue
-        return parsed
-
-    def _valid_ip_header(self, value: Optional[str]) -> Optional[str]:
-        if not value:
-            return None
-        value = value.strip()
-        try:
-            ip_address(value)
-        except ValueError:
-            return None
-        return value
-
-    def _is_trusted_proxy(self, host: str) -> bool:
-        try:
-            return self._is_trusted_ip(ip_address(host))
-        except ValueError:
-            return False
-
-    def _is_trusted_ip(self, parsed_ip) -> bool:
-        return any(parsed_ip in network for network in self._trusted_proxy_networks)

--- a/backend/services/wallet_connection_analytics_service.py
+++ b/backend/services/wallet_connection_analytics_service.py
@@ -1,0 +1,135 @@
+"""Analytics-only wallet connection recording."""
+
+from __future__ import annotations
+
+import datetime
+import re
+from dataclasses import dataclass
+from typing import Optional
+
+from sqlalchemy.dialects.postgresql import insert
+from sqlalchemy.orm import Session
+
+from backend.database_handler.models import WalletConnectionAnalytics
+
+WALLET_ADDRESS_RE = re.compile(r"^0x[0-9a-fA-F]{40}$")
+
+
+@dataclass(frozen=True)
+class WalletConnectionMetadata:
+    observed_ip: Optional[str] = None
+    user_agent: Optional[str] = None
+    origin: Optional[str] = None
+
+
+def normalize_wallet_address(wallet_address: str) -> str:
+    value = wallet_address.strip()
+    if not WALLET_ADDRESS_RE.fullmatch(value):
+        raise ValueError("wallet_address must be a 0x-prefixed 20-byte hex address")
+    return value.lower()
+
+
+def record_wallet_connection(
+    session: Session,
+    wallet_address: str,
+    metadata: WalletConnectionMetadata,
+    connected_at: Optional[datetime.datetime] = None,
+) -> WalletConnectionAnalytics:
+    normalized_address = normalize_wallet_address(wallet_address)
+    connected_at = connected_at or datetime.datetime.now(datetime.UTC)
+    observed_ip = _truncate(metadata.observed_ip, 45)
+    user_agent = _truncate(metadata.user_agent, 512)
+    origin = _truncate(metadata.origin, 512)
+
+    if session.bind is not None and session.bind.dialect.name == "postgresql":
+        return _record_wallet_connection_postgres(
+            session,
+            normalized_address,
+            observed_ip,
+            user_agent,
+            origin,
+            connected_at,
+        )
+
+    return _record_wallet_connection_generic(
+        session,
+        normalized_address,
+        observed_ip,
+        user_agent,
+        origin,
+        connected_at,
+    )
+
+
+def _record_wallet_connection_postgres(
+    session: Session,
+    wallet_address: str,
+    observed_ip: Optional[str],
+    user_agent: Optional[str],
+    origin: Optional[str],
+    connected_at: datetime.datetime,
+) -> WalletConnectionAnalytics:
+    stmt = insert(WalletConnectionAnalytics).values(
+        wallet_address=wallet_address,
+        connect_count=1,
+        first_observed_ip=observed_ip,
+        last_observed_ip=observed_ip,
+        first_user_agent=user_agent,
+        last_user_agent=user_agent,
+        first_origin=origin,
+        last_origin=origin,
+        first_connected_at=connected_at,
+        last_connected_at=connected_at,
+    )
+    stmt = stmt.on_conflict_do_update(
+        index_elements=[WalletConnectionAnalytics.wallet_address],
+        set_={
+            "connect_count": WalletConnectionAnalytics.connect_count + 1,
+            "last_observed_ip": observed_ip,
+            "last_user_agent": user_agent,
+            "last_origin": origin,
+            "last_connected_at": connected_at,
+        },
+    ).returning(WalletConnectionAnalytics)
+    return session.execute(stmt).scalar_one()
+
+
+def _record_wallet_connection_generic(
+    session: Session,
+    wallet_address: str,
+    observed_ip: Optional[str],
+    user_agent: Optional[str],
+    origin: Optional[str],
+    connected_at: datetime.datetime,
+) -> WalletConnectionAnalytics:
+    existing = session.get(WalletConnectionAnalytics, wallet_address)
+    if existing is not None:
+        existing.connect_count += 1
+        existing.last_observed_ip = observed_ip
+        existing.last_user_agent = user_agent
+        existing.last_origin = origin
+        existing.last_connected_at = connected_at
+        session.flush()
+        return existing
+
+    record = WalletConnectionAnalytics(
+        wallet_address=wallet_address,
+        connect_count=1,
+        first_observed_ip=observed_ip,
+        last_observed_ip=observed_ip,
+        first_user_agent=user_agent,
+        last_user_agent=user_agent,
+        first_origin=origin,
+        last_origin=origin,
+    )
+    record.first_connected_at = connected_at
+    record.last_connected_at = connected_at
+    session.add(record)
+    session.flush()
+    return record
+
+
+def _truncate(value: Optional[str], max_length: int) -> Optional[str]:
+    if value is None:
+        return None
+    return value[:max_length]

--- a/frontend/src/hooks/useWalletSync.ts
+++ b/frontend/src/hooks/useWalletSync.ts
@@ -1,16 +1,30 @@
 import { watch } from 'vue';
 import { useWallet } from './useWallet';
 import { useAccountsStore } from '@/stores';
+import { recordWalletConnection } from '@/services/walletAnalytics';
+import type { Address } from '@/types';
 
 export function useWalletSync() {
   const wallet = useWallet();
   const accountsStore = useAccountsStore();
   let initialized = false;
+  let lastRecordedAddress: string | null = null;
+
+  const recordAnalytics = (address: Address) => {
+    const normalizedAddress = address.toLowerCase();
+    if (lastRecordedAddress === normalizedAddress) return;
+
+    lastRecordedAddress = normalizedAddress;
+    void recordWalletConnection(address).catch((error) => {
+      console.debug('Wallet connection analytics failed', error);
+    });
+  };
 
   watch(
     [() => wallet.isConnected.value, () => wallet.address.value],
     ([isConnected, address], [wasConnected]) => {
       if (isConnected && address) {
+        recordAnalytics(address);
         if (!initialized) {
           // Auto-reconnect on page load: add/update wallet but don't switch to it
           initialized = true;
@@ -20,6 +34,7 @@ export function useWalletSync() {
           accountsStore.connectExternalWallet(address);
         }
       } else if (wasConnected && !isConnected) {
+        lastRecordedAddress = null;
         accountsStore.disconnectExternalWallet();
       }
     },

--- a/frontend/src/services/walletAnalytics.ts
+++ b/frontend/src/services/walletAnalytics.ts
@@ -1,0 +1,27 @@
+import { getApiKeyHeaders } from '@/utils/apiKey';
+import { getRuntimeConfig } from '@/utils/runtimeConfig';
+import type { Address } from '@/types';
+
+const DEFAULT_RPC_URL = 'http://127.0.0.1:4000/api';
+
+export async function recordWalletConnection(
+  walletAddress: Address,
+): Promise<void> {
+  const response = await fetch(walletConnectionAnalyticsUrl(), {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      ...getApiKeyHeaders(),
+    },
+    body: JSON.stringify({ wallet_address: walletAddress }),
+  });
+
+  if (!response.ok) {
+    throw new Error(`Wallet analytics request failed: ${response.status}`);
+  }
+}
+
+function walletConnectionAnalyticsUrl(): string {
+  const rpcUrl = getRuntimeConfig('VITE_JSON_RPC_SERVER_URL', DEFAULT_RPC_URL);
+  return `${rpcUrl.replace(/\/$/, '')}/analytics/wallet-connections`;
+}

--- a/frontend/test/unit/hooks/useWalletSync.test.ts
+++ b/frontend/test/unit/hooks/useWalletSync.test.ts
@@ -1,0 +1,112 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { effectScope, nextTick, ref } from 'vue';
+import type { Address } from '@/types';
+
+const walletState = {
+  isConnected: ref(false),
+  address: ref<Address | null>(null),
+};
+
+const accountsStore = {
+  connectExternalWallet: vi.fn(),
+  disconnectExternalWallet: vi.fn(),
+  updateExternalWalletAddress: vi.fn(),
+};
+
+const recordWalletConnection = vi.fn(() => Promise.resolve());
+
+vi.mock('@/stores', () => ({
+  useAccountsStore: () => accountsStore,
+}));
+
+vi.mock('@/hooks/useWallet', () => ({
+  useWallet: () => walletState,
+}));
+
+vi.mock('@/services/walletAnalytics', () => ({
+  recordWalletConnection,
+}));
+
+describe('useWalletSync', () => {
+  let scope: ReturnType<typeof effectScope>;
+
+  beforeEach(() => {
+    scope = effectScope();
+    walletState.isConnected.value = false;
+    walletState.address.value = null;
+    accountsStore.connectExternalWallet.mockClear();
+    accountsStore.disconnectExternalWallet.mockClear();
+    accountsStore.updateExternalWalletAddress.mockClear();
+    recordWalletConnection.mockClear();
+  });
+
+  afterEach(() => {
+    scope.stop();
+  });
+
+  async function startWalletSync() {
+    const { useWalletSync } = await import('@/hooks/useWalletSync');
+    scope.run(() => useWalletSync());
+  }
+
+  it('records analytics when a wallet is connected', async () => {
+    await startWalletSync();
+
+    walletState.address.value = '0x1111111111111111111111111111111111111111';
+    walletState.isConnected.value = true;
+    await nextTick();
+
+    expect(recordWalletConnection).toHaveBeenCalledWith(
+      '0x1111111111111111111111111111111111111111',
+    );
+    expect(accountsStore.connectExternalWallet).toHaveBeenCalledWith(
+      '0x1111111111111111111111111111111111111111',
+      false,
+    );
+  });
+
+  it('records analytics when the connected wallet address changes', async () => {
+    await startWalletSync();
+
+    walletState.address.value = '0x1111111111111111111111111111111111111111';
+    walletState.isConnected.value = true;
+    await nextTick();
+
+    walletState.address.value = '0x2222222222222222222222222222222222222222';
+    await nextTick();
+
+    expect(recordWalletConnection).toHaveBeenCalledTimes(2);
+    expect(recordWalletConnection).toHaveBeenLastCalledWith(
+      '0x2222222222222222222222222222222222222222',
+    );
+  });
+
+  it('does not record duplicate analytics for the same connected address', async () => {
+    await startWalletSync();
+
+    walletState.address.value = '0x1111111111111111111111111111111111111111';
+    walletState.isConnected.value = true;
+    await nextTick();
+
+    walletState.address.value = '0x1111111111111111111111111111111111111111';
+    await nextTick();
+
+    expect(recordWalletConnection).toHaveBeenCalledTimes(1);
+  });
+
+  it('records again when the same wallet reconnects after disconnecting', async () => {
+    await startWalletSync();
+
+    walletState.address.value = '0x1111111111111111111111111111111111111111';
+    walletState.isConnected.value = true;
+    await nextTick();
+
+    walletState.isConnected.value = false;
+    await nextTick();
+
+    walletState.isConnected.value = true;
+    await nextTick();
+
+    expect(recordWalletConnection).toHaveBeenCalledTimes(2);
+  });
+});

--- a/frontend/test/unit/services/walletAnalytics.test.ts
+++ b/frontend/test/unit/services/walletAnalytics.test.ts
@@ -1,0 +1,42 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { recordWalletConnection } from '@/services/walletAnalytics';
+
+describe('wallet analytics service', () => {
+  beforeEach(() => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(() => Promise.resolve(new Response('{}', { status: 200 }))),
+    );
+    localStorage.clear();
+    vi.unstubAllEnvs();
+  });
+
+  it('posts wallet address to the analytics endpoint derived from RPC URL', async () => {
+    vi.stubEnv('VITE_JSON_RPC_SERVER_URL', 'https://studio.example.com/api');
+
+    await recordWalletConnection('0x1111111111111111111111111111111111111111');
+
+    expect(fetch).toHaveBeenCalledWith(
+      'https://studio.example.com/api/analytics/wallet-connections',
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({
+          wallet_address: '0x1111111111111111111111111111111111111111',
+        }),
+      }),
+    );
+  });
+
+  it('sends the configured API key when present', async () => {
+    localStorage.setItem('settingsStore.apiKey', 'glk_test');
+
+    await recordWalletConnection('0x1111111111111111111111111111111111111111');
+
+    expect(fetch).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({
+        headers: expect.objectContaining({ 'X-API-Key': 'glk_test' }),
+      }),
+    );
+  });
+});

--- a/tests/unit/test_wallet_analytics_router.py
+++ b/tests/unit/test_wallet_analytics_router.py
@@ -1,17 +1,20 @@
-from collections.abc import Generator
+from types import SimpleNamespace
 
-from fastapi import FastAPI
-from fastapi.testclient import TestClient
+import pytest
+from fastapi import HTTPException
 from sqlalchemy import create_engine
-from sqlalchemy.orm import Session, sessionmaker
+from sqlalchemy.orm import sessionmaker
 from sqlalchemy.pool import StaticPool
+from starlette.datastructures import Headers
 
 from backend.database_handler.models import WalletConnectionAnalytics
-from backend.protocol_rpc.analytics_router import analytics_router
-from backend.protocol_rpc.dependencies import get_db_session
+from backend.protocol_rpc.analytics_router import (
+    WalletConnectionRequest,
+    record_wallet_connection_endpoint,
+)
 
 
-def test_wallet_connection_endpoint_records_server_observed_metadata():
+def _make_sqlite_session():
     engine = create_engine(
         "sqlite://",
         connect_args={"check_same_thread": False},
@@ -19,43 +22,46 @@ def test_wallet_connection_endpoint_records_server_observed_metadata():
     )
     WalletConnectionAnalytics.__table__.create(engine)
     maker = sessionmaker(bind=engine, expire_on_commit=False)
+    session = maker()
+    return engine, session
 
-    app = FastAPI()
 
-    def override_session() -> Generator[Session, None, None]:
-        session = maker()
-        try:
-            yield session
-            session.commit()
-        finally:
-            session.close()
-
-    app.dependency_overrides[get_db_session] = override_session
-    app.include_router(analytics_router)
-
-    client = TestClient(app)
-    response = client.post(
-        "/api/analytics/wallet-connections",
-        json={"wallet_address": "0xAABBcc0000000000000000000000000000000000"},
-        headers={
-            "Origin": "https://studio.example.com",
-            "User-Agent": "UnitTest/1.0",
-        },
+def _make_request(headers: dict[str, str] | None = None, client_host="127.0.0.1"):
+    return SimpleNamespace(
+        headers=Headers(headers or {}),
+        client=SimpleNamespace(host=client_host),
     )
 
-    assert response.status_code == 200
-    assert response.json() == {
-        "wallet_address": "0xaabbcc0000000000000000000000000000000000",
-        "recorded": True,
-    }
 
-    session = maker()
+def test_wallet_connection_endpoint_records_server_observed_metadata():
+    engine, session = _make_sqlite_session()
+
     try:
+        response = record_wallet_connection_endpoint(
+            WalletConnectionRequest(
+                wallet_address="0xAABBcc0000000000000000000000000000000000"
+            ),
+            _make_request(
+                headers={
+                    "Origin": "https://studio.example.com",
+                    "User-Agent": "UnitTest/1.0",
+                    "X-Forwarded-For": "198.51.100.7",
+                }
+            ),
+            session,
+        )
+        session.commit()
+
+        assert response.wallet_address == "0xaabbcc0000000000000000000000000000000000"
+        assert response.recorded is True
+
         record = session.get(
             WalletConnectionAnalytics,
             "0xaabbcc0000000000000000000000000000000000",
         )
         assert record is not None
+        assert record.first_observed_ip == "198.51.100.7"
+        assert record.last_observed_ip == "198.51.100.7"
         assert record.first_origin == "https://studio.example.com"
         assert record.last_origin == "https://studio.example.com"
         assert record.first_user_agent == "UnitTest/1.0"
@@ -66,33 +72,18 @@ def test_wallet_connection_endpoint_records_server_observed_metadata():
 
 
 def test_wallet_connection_endpoint_rejects_invalid_wallet_address():
-    engine = create_engine(
-        "sqlite://",
-        connect_args={"check_same_thread": False},
-        poolclass=StaticPool,
-    )
-    WalletConnectionAnalytics.__table__.create(engine)
-    maker = sessionmaker(bind=engine)
+    engine, session = _make_sqlite_session()
 
-    app = FastAPI()
+    try:
+        with pytest.raises(HTTPException) as exc_info:
+            record_wallet_connection_endpoint(
+                WalletConnectionRequest(wallet_address="0x123"),
+                _make_request(),
+                session,
+            )
 
-    def override_session() -> Generator[Session, None, None]:
-        session = maker()
-        try:
-            yield session
-            session.commit()
-        finally:
-            session.close()
-
-    app.dependency_overrides[get_db_session] = override_session
-    app.include_router(analytics_router)
-
-    client = TestClient(app)
-    response = client.post(
-        "/api/analytics/wallet-connections",
-        json={"wallet_address": "0x123"},
-    )
-
-    assert response.status_code == 422
-    assert "wallet_address" in response.json()["detail"]
-    engine.dispose()
+        assert exc_info.value.status_code == 422
+        assert "wallet_address" in exc_info.value.detail
+    finally:
+        session.close()
+        engine.dispose()

--- a/tests/unit/test_wallet_analytics_router.py
+++ b/tests/unit/test_wallet_analytics_router.py
@@ -1,0 +1,98 @@
+from collections.abc import Generator
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session, sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from backend.database_handler.models import WalletConnectionAnalytics
+from backend.protocol_rpc.analytics_router import analytics_router
+from backend.protocol_rpc.dependencies import get_db_session
+
+
+def test_wallet_connection_endpoint_records_server_observed_metadata():
+    engine = create_engine(
+        "sqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    WalletConnectionAnalytics.__table__.create(engine)
+    maker = sessionmaker(bind=engine, expire_on_commit=False)
+
+    app = FastAPI()
+
+    def override_session() -> Generator[Session, None, None]:
+        session = maker()
+        try:
+            yield session
+            session.commit()
+        finally:
+            session.close()
+
+    app.dependency_overrides[get_db_session] = override_session
+    app.include_router(analytics_router)
+
+    client = TestClient(app)
+    response = client.post(
+        "/api/analytics/wallet-connections",
+        json={"wallet_address": "0xAABBcc0000000000000000000000000000000000"},
+        headers={
+            "Origin": "https://studio.example.com",
+            "User-Agent": "UnitTest/1.0",
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "wallet_address": "0xaabbcc0000000000000000000000000000000000",
+        "recorded": True,
+    }
+
+    session = maker()
+    try:
+        record = session.get(
+            WalletConnectionAnalytics,
+            "0xaabbcc0000000000000000000000000000000000",
+        )
+        assert record is not None
+        assert record.first_origin == "https://studio.example.com"
+        assert record.last_origin == "https://studio.example.com"
+        assert record.first_user_agent == "UnitTest/1.0"
+        assert record.last_user_agent == "UnitTest/1.0"
+    finally:
+        session.close()
+        engine.dispose()
+
+
+def test_wallet_connection_endpoint_rejects_invalid_wallet_address():
+    engine = create_engine(
+        "sqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    WalletConnectionAnalytics.__table__.create(engine)
+    maker = sessionmaker(bind=engine)
+
+    app = FastAPI()
+
+    def override_session() -> Generator[Session, None, None]:
+        session = maker()
+        try:
+            yield session
+            session.commit()
+        finally:
+            session.close()
+
+    app.dependency_overrides[get_db_session] = override_session
+    app.include_router(analytics_router)
+
+    client = TestClient(app)
+    response = client.post(
+        "/api/analytics/wallet-connections",
+        json={"wallet_address": "0x123"},
+    )
+
+    assert response.status_code == 422
+    assert "wallet_address" in response.json()["detail"]
+    engine.dispose()

--- a/tests/unit/test_wallet_connection_analytics_service.py
+++ b/tests/unit/test_wallet_connection_analytics_service.py
@@ -1,0 +1,125 @@
+import datetime
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from backend.database_handler.models import WalletConnectionAnalytics
+from backend.services.wallet_connection_analytics_service import (
+    WalletConnectionMetadata,
+    normalize_wallet_address,
+    record_wallet_connection,
+)
+
+
+def _same_timestamp(left: datetime.datetime, right: datetime.datetime) -> bool:
+    return left.replace(tzinfo=None) == right.replace(tzinfo=None)
+
+
+@pytest.fixture
+def session():
+    engine = create_engine("sqlite:///:memory:")
+    WalletConnectionAnalytics.__table__.create(engine)
+    maker = sessionmaker(bind=engine, expire_on_commit=False)
+    session = maker()
+    yield session
+    session.close()
+    engine.dispose()
+
+
+def test_normalize_wallet_address_lowercases_valid_address():
+    assert (
+        normalize_wallet_address("0xAABBcc0000000000000000000000000000000000")
+        == "0xaabbcc0000000000000000000000000000000000"
+    )
+
+
+@pytest.mark.parametrize(
+    "wallet_address",
+    [
+        "0x123",
+        "1234567890123456789012345678901234567890",
+        "0xzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz",
+    ],
+)
+def test_normalize_wallet_address_rejects_invalid_values(wallet_address):
+    with pytest.raises(ValueError):
+        normalize_wallet_address(wallet_address)
+
+
+def test_record_wallet_connection_inserts_analytics_metadata(session):
+    now = datetime.datetime(2026, 6, 17, 12, 0, tzinfo=datetime.UTC)
+
+    record = record_wallet_connection(
+        session,
+        "0xAABBcc0000000000000000000000000000000000",
+        WalletConnectionMetadata(
+            observed_ip="198.51.100.7",
+            user_agent="Mozilla/5.0",
+            origin="https://studio.example.com",
+        ),
+        connected_at=now,
+    )
+
+    assert record.wallet_address == "0xaabbcc0000000000000000000000000000000000"
+    assert record.connect_count == 1
+    assert record.first_observed_ip == "198.51.100.7"
+    assert record.last_observed_ip == "198.51.100.7"
+    assert record.first_user_agent == "Mozilla/5.0"
+    assert record.last_user_agent == "Mozilla/5.0"
+    assert record.first_origin == "https://studio.example.com"
+    assert record.last_origin == "https://studio.example.com"
+    assert _same_timestamp(record.first_connected_at, now)
+    assert _same_timestamp(record.last_connected_at, now)
+
+
+def test_record_wallet_connection_updates_last_metadata_only(session):
+    first = datetime.datetime(2026, 6, 17, 12, 0, tzinfo=datetime.UTC)
+    second = datetime.datetime(2026, 6, 17, 13, 0, tzinfo=datetime.UTC)
+
+    record_wallet_connection(
+        session,
+        "0xAABBcc0000000000000000000000000000000000",
+        WalletConnectionMetadata(
+            observed_ip="198.51.100.7",
+            user_agent="First UA",
+            origin="https://first.example.com",
+        ),
+        connected_at=first,
+    )
+    record = record_wallet_connection(
+        session,
+        "0xaabbcc0000000000000000000000000000000000",
+        WalletConnectionMetadata(
+            observed_ip="203.0.113.9",
+            user_agent="Second UA",
+            origin="https://second.example.com",
+        ),
+        connected_at=second,
+    )
+
+    assert record.connect_count == 2
+    assert record.first_observed_ip == "198.51.100.7"
+    assert record.last_observed_ip == "203.0.113.9"
+    assert record.first_user_agent == "First UA"
+    assert record.last_user_agent == "Second UA"
+    assert record.first_origin == "https://first.example.com"
+    assert record.last_origin == "https://second.example.com"
+    assert _same_timestamp(record.first_connected_at, first)
+    assert _same_timestamp(record.last_connected_at, second)
+
+
+def test_record_wallet_connection_truncates_request_metadata(session):
+    record = record_wallet_connection(
+        session,
+        "0xAABBcc0000000000000000000000000000000000",
+        WalletConnectionMetadata(
+            observed_ip="1" * 60,
+            user_agent="u" * 600,
+            origin="o" * 600,
+        ),
+    )
+
+    assert len(record.first_observed_ip) == 45
+    assert len(record.first_user_agent) == 512
+    assert len(record.first_origin) == 512


### PR DESCRIPTION
## Summary

Adds analytics-only wallet connection recording for Studio, keyed by normalized wallet address instead of user accounts.

- Adds a `wallet_connection_analytics` table with first/last connection timestamps, connect count, server-observed IP, user agent, and origin metadata.
- Adds `/api/analytics/wallet-connections` as a focused FastAPI endpoint that derives IP from trusted proxy handling and does not trust client-supplied IP.
- Calls the endpoint from the frontend wallet sync path after connect/account changes without blocking wallet UX.
- Extracts the existing trusted-proxy client IP resolver so rate limiting and analytics use the same behavior.

## Privacy / Product Notes

This is analytics-only. The stored wallet address and request metadata are not authentication or identity proof, and wallet addresses can be spoofed by client-side calls. Metadata is limited to IP, user agent, and Origin headers with bounded lengths; no request body beyond the wallet address is collected.

## Validation

- `/Users/edgars/Dev/genlayer-studio/.venv/bin/python -m pytest tests/unit/test_wallet_connection_analytics_service.py tests/unit/test_wallet_analytics_router.py tests/unit/test_rate_limit_middleware.py`
- `npm run test -- --run test/unit/hooks/useWalletSync.test.ts test/unit/services/walletAnalytics.test.ts`
- `/Users/edgars/Dev/genlayer-studio/.venv/bin/python -m black --check backend/protocol_rpc/client_ip.py backend/protocol_rpc/rate_limit_middleware.py backend/protocol_rpc/analytics_router.py backend/services/wallet_connection_analytics_service.py backend/database_handler/models.py tests/unit/test_wallet_connection_analytics_service.py tests/unit/test_wallet_analytics_router.py`
- `/Users/edgars/Dev/genlayer-studio/frontend/node_modules/.bin/prettier --check src/hooks/useWalletSync.ts src/services/walletAnalytics.ts test/unit/hooks/useWalletSync.test.ts test/unit/services/walletAnalytics.test.ts`