### PR TITLE
feat: report configured LLM token metrics

### DIFF
--- a/backend/node/base.py
+++ b/backend/node/base.py
@@ -713,6 +713,7 @@ class Node:
 
             if fallback_validator:
                 enhanced_node_config["secondary_model"] = {
+                    "address": fallback_validator.address,
                     "provider": fallback_validator.llmprovider.provider,
                     "model": fallback_validator.llmprovider.model,
                     "plugin": fallback_validator.llmprovider.plugin,

--- a/backend/node/genvm/base.py
+++ b/backend/node/genvm/base.py
@@ -236,6 +236,23 @@ class ExecutionResult:
     execution_stats: dict | None = None
 
 
+def _extract_llm_token_metrics(
+    metrics: dict[str, typing.Any] | None,
+) -> dict[str, typing.Any] | None:
+    if not isinstance(metrics, dict):
+        return None
+
+    llm_metrics = metrics.get("llm")
+    if not isinstance(llm_metrics, dict):
+        return None
+
+    token_metrics = llm_metrics.get("tokens")
+    if not isinstance(token_metrics, dict) or not token_metrics:
+        return None
+
+    return token_metrics
+
+
 class Host(genvmhost.IHost):
     """
     Handles all genvm host methods and accumulates results
@@ -384,6 +401,11 @@ class Host(genvmhost.IHost):
         # Extract eq_outputs from result_nondet_results
         eq_outputs = {i: data for i, data in enumerate(res.result_nondet_results)}
 
+        execution_stats = dict(ctx.stats)
+        llm_token_metrics = _extract_llm_token_metrics(res.metrics)
+        if llm_token_metrics is not None:
+            execution_stats["llm"] = {"tokens": llm_token_metrics}
+
         return ExecutionResult(
             eq_outputs=eq_outputs,
             pending_transactions=pending_transactions,
@@ -394,7 +416,7 @@ class Host(genvmhost.IHost):
             state=state,
             processing_time=0,
             nondet_disagree=self._nondet_disagreement,
-            execution_stats=ctx.stats,
+            execution_stats=execution_stats,
         )
 
     async def loop_enter(self, cancellation) -> socket.socket:

--- a/backend/node/genvm/origin/base_host.py
+++ b/backend/node/genvm/origin/base_host.py
@@ -364,6 +364,7 @@ class RunHostAndProgramRes:
     stdout: str
     stderr: str
     genvm_log: list[dict[str, typing.Any]]
+    metrics: dict[str, typing.Any] | None
 
     execution_time: float
 
@@ -825,6 +826,7 @@ async def run_genvm(
             stdout=status["stdout"],
             stderr=status["stderr"],
             genvm_log=status.get("genvm_log") or [],
+            metrics=status.get("metrics") if isinstance(status, dict) else None,
             execution_hash=execution_hash,
             result_kind=result_kind,
             result_data=result_data,

--- a/backend/services/usage_metrics_service.py
+++ b/backend/services/usage_metrics_service.py
@@ -1,8 +1,8 @@
 # backend/services/usage_metrics_service.py
 
-import os
 import asyncio
-from typing import Optional
+import os
+from typing import Any, Optional
 from datetime import datetime
 import aiohttp
 from loguru import logger
@@ -292,46 +292,140 @@ class UsageMetricsService:
         # Process leader receipts
         if consensus_data.leader_receipt:
             for receipt in consensus_data.leader_receipt:
-                llm_call = self._extract_llm_call_from_receipt(receipt)
-                if llm_call:
-                    llm_calls.append(llm_call)
+                llm_calls.extend(self._extract_llm_calls_from_receipt(receipt))
 
         # Process validator receipts
         if consensus_data.validators:
             for receipt in consensus_data.validators:
-                llm_call = self._extract_llm_call_from_receipt(receipt)
-                if llm_call:
-                    llm_calls.append(llm_call)
+                llm_calls.extend(self._extract_llm_calls_from_receipt(receipt))
 
         return llm_calls
 
-    def _extract_llm_call_from_receipt(self, receipt) -> Optional[dict]:
-        """Extract LLM info from a single receipt."""
+    def _extract_llm_calls_from_receipt(self, receipt) -> list[dict]:
+        """Extract one or more LLM call summaries from a single receipt."""
         if receipt is None:
-            return None
+            return []
 
-        node_config = getattr(receipt, "node_config", None)
+        node_config = self._receipt_field(receipt, "node_config")
         if node_config is None or not isinstance(node_config, dict):
-            return None
+            return []
 
         primary_model = node_config.get("primary_model", {})
         if not primary_model:
+            return []
+
+        token_metrics = self._extract_llm_token_metrics(receipt)
+        if token_metrics:
+            configured_by_key = self._configured_models_by_token_key(node_config)
+            calls = []
+            for token_key, tokens in token_metrics.items():
+                configured_model = configured_by_key.get(token_key)
+                if configured_model is None:
+                    configured_model = self._configured_model_from_token_key(
+                        primary_model, token_key
+                    )
+                call = self._build_llm_call(configured_model, tokens)
+                if call:
+                    calls.append(call)
+
+            if calls:
+                return calls
+
+        call = self._build_llm_call(primary_model)
+        return [call] if call else []
+
+    def _extract_llm_call_from_receipt(self, receipt) -> Optional[dict]:
+        """Extract the first LLM call from a receipt for legacy callers."""
+        calls = self._extract_llm_calls_from_receipt(receipt)
+        return calls[0] if calls else None
+
+    def _build_llm_call(
+        self, model_config: dict | None, tokens: dict | None = None
+    ) -> Optional[dict]:
+        if not model_config:
             return None
 
-        provider = primary_model.get("provider", "unknown")
-        model = primary_model.get("model", "unknown")
+        provider = model_config.get("provider", "unknown")
+        model = model_config.get("model", "unknown")
 
         # Skip if both are unknown (no meaningful data)
         if provider == "unknown" and model == "unknown":
             return None
 
+        tokens = tokens if isinstance(tokens, dict) else {}
+
         return {
             "provider": provider,
             "model": model,
-            "inputTokens": 0,  # Not tracked yet
-            "outputTokens": 0,  # Not tracked yet
+            "inputTokens": self._safe_int(tokens.get("input")),
+            "outputTokens": self._safe_int(tokens.get("output")),
             "costUsd": 0,  # Not tracked yet
         }
+
+    def _configured_models_by_token_key(self, node_config: dict) -> dict[str, dict]:
+        configured = {}
+
+        primary_model = node_config.get("primary_model")
+        primary_key = self._token_metric_key(
+            node_config.get("address"),
+            primary_model.get("model") if isinstance(primary_model, dict) else None,
+        )
+        if primary_key and isinstance(primary_model, dict):
+            configured[primary_key] = primary_model
+
+        secondary_model = node_config.get("secondary_model")
+        secondary_key = self._token_metric_key(
+            (
+                secondary_model.get("address")
+                if isinstance(secondary_model, dict)
+                else None
+            ),
+            secondary_model.get("model") if isinstance(secondary_model, dict) else None,
+        )
+        if secondary_key and isinstance(secondary_model, dict):
+            configured[secondary_key] = secondary_model
+
+        return configured
+
+    def _configured_model_from_token_key(
+        self, primary_model: dict, token_key: str
+    ) -> dict:
+        _, _, token_model = token_key.partition("/")
+        if not token_model:
+            token_model = primary_model.get("model", "unknown")
+
+        return {
+            "provider": primary_model.get("provider", "unknown"),
+            "model": token_model,
+        }
+
+    def _extract_llm_token_metrics(self, receipt) -> dict:
+        execution_stats = self._receipt_field(receipt, "execution_stats")
+        if not isinstance(execution_stats, dict):
+            return {}
+
+        llm_stats = execution_stats.get("llm")
+        if not isinstance(llm_stats, dict):
+            return {}
+
+        token_metrics = llm_stats.get("tokens")
+        return token_metrics if isinstance(token_metrics, dict) else {}
+
+    def _receipt_field(self, receipt, field: str) -> Any:
+        if isinstance(receipt, dict):
+            return receipt.get(field)
+        return getattr(receipt, field, None)
+
+    def _token_metric_key(self, address: Any, model: Any) -> str | None:
+        if not address or not model:
+            return None
+        return f"node-{address}/{model}"
+
+    def _safe_int(self, value: Any) -> int:
+        try:
+            return int(value)
+        except (TypeError, ValueError):
+            return 0
 
     def _format_created_at(self, created_at) -> str:
         """Format created_at to ISO8601 string."""

--- a/tests/unit/test_usage_metrics_service.py
+++ b/tests/unit/test_usage_metrics_service.py
@@ -3,7 +3,16 @@ from unittest.mock import AsyncMock
 
 import pytest
 
+from backend.node.genvm import base as genvm_base
+from backend.node.genvm.origin import public_abi
 from backend.services.usage_metrics_service import UsageMetricsService
+
+
+def _receipt(node_config, execution_stats=None):
+    return SimpleNamespace(
+        node_config=node_config,
+        execution_stats=execution_stats,
+    )
 
 
 @pytest.mark.asyncio
@@ -48,5 +57,248 @@ async def test_system_health_metrics_include_max_recovery_events():
             "contractAddress": "0xcontract",
             "recoveryCount": 3,
             "occurredAt": 1779938084,
+        }
+    ]
+
+
+def test_extract_llm_token_metrics_keeps_only_llm_tokens():
+    metrics = {
+        "llm": {
+            "tokens": {
+                "node-0xprimary/policy:dev-openai": {
+                    "input": 12,
+                    "output": 5,
+                    "total": 17,
+                }
+            },
+            "scripting": {"requests": 1},
+        },
+        "web": {"requests": 3},
+    }
+
+    assert genvm_base._extract_llm_token_metrics(metrics) == {
+        "node-0xprimary/policy:dev-openai": {
+            "input": 12,
+            "output": 5,
+            "total": 17,
+        }
+    }
+
+
+def test_provide_result_preserves_llm_token_metrics():
+    host = object.__new__(genvm_base.Host)
+    host._nondet_disagreement = None
+
+    res = SimpleNamespace(
+        result_kind=public_abi.ResultCode.RETURN,
+        result_data={"ok": True},
+        result_storage_changes=[],
+        result_emissions=[],
+        result_nondet_results=[],
+        stdout="",
+        stderr="",
+        genvm_log=[],
+        metrics={
+            "llm": {
+                "tokens": {
+                    "node-0xprimary/policy:dev-openai": {
+                        "input": 12,
+                        "output": 5,
+                        "total": 17,
+                    }
+                }
+            }
+        },
+        vm_error_description=None,
+    )
+
+    result = host.provide_result(res, SimpleNamespace(), genvm_base.Context())
+
+    assert result.execution_stats == {
+        "llm": {
+            "tokens": {
+                "node-0xprimary/policy:dev-openai": {
+                    "input": 12,
+                    "output": 5,
+                    "total": 17,
+                }
+            }
+        }
+    }
+
+
+def test_extract_llm_calls_uses_primary_token_metrics():
+    service = UsageMetricsService()
+    receipt = _receipt(
+        {
+            "address": "0xprimary",
+            "primary_model": {
+                "provider": "llm-router",
+                "model": "policy:dev-openai",
+            },
+            "secondary_model": None,
+        },
+        {
+            "llm": {
+                "tokens": {
+                    "node-0xprimary/policy:dev-openai": {
+                        "input": 12,
+                        "output": 5,
+                        "total": 17,
+                    }
+                }
+            }
+        },
+    )
+
+    assert service._extract_llm_calls_from_receipt(receipt) == [
+        {
+            "provider": "llm-router",
+            "model": "policy:dev-openai",
+            "inputTokens": 12,
+            "outputTokens": 5,
+            "costUsd": 0,
+        }
+    ]
+
+
+def test_extract_llm_calls_skips_receipts_without_model_config():
+    service = UsageMetricsService()
+
+    assert service._extract_llm_calls_from_receipt(None) == []
+    assert service._extract_llm_calls_from_receipt(_receipt(None)) == []
+    assert service._extract_llm_calls_from_receipt(_receipt({})) == []
+    assert service._build_llm_call(None) is None
+    assert service._build_llm_call({"provider": "unknown", "model": "unknown"}) is None
+
+
+def test_extract_llm_call_legacy_and_defensive_paths():
+    service = UsageMetricsService()
+    dict_receipt = {
+        "node_config": {
+            "address": "0xprimary",
+            "primary_model": {
+                "provider": "llm-router",
+                "model": "policy:dev-openai",
+            },
+        },
+        "execution_stats": {"llm": "invalid"},
+    }
+
+    assert service._extract_llm_call_from_receipt(dict_receipt) == {
+        "provider": "llm-router",
+        "model": "policy:dev-openai",
+        "inputTokens": 0,
+        "outputTokens": 0,
+        "costUsd": 0,
+    }
+    assert service._extract_llm_call_from_receipt(None) is None
+    assert service._configured_model_from_token_key(
+        {"provider": "llm-router", "model": "policy:dev-openai"},
+        "malformed-token-key",
+    ) == {
+        "provider": "llm-router",
+        "model": "policy:dev-openai",
+    }
+
+
+def test_extract_llm_calls_uses_fallback_token_metrics():
+    service = UsageMetricsService()
+    receipt = _receipt(
+        {
+            "address": "0xprimary",
+            "primary_model": {
+                "provider": "llm-router",
+                "model": "policy:dev-openai",
+            },
+            "secondary_model": {
+                "address": "0xfallback",
+                "provider": "openrouter",
+                "model": "anthropic/claude-sonnet-4.5",
+            },
+        },
+        {
+            "llm": {
+                "tokens": {
+                    "node-0xfallback/anthropic/claude-sonnet-4.5": {
+                        "input": 9,
+                        "output": 4,
+                        "total": 13,
+                    }
+                }
+            }
+        },
+    )
+
+    assert service._extract_llm_calls_from_receipt(receipt) == [
+        {
+            "provider": "openrouter",
+            "model": "anthropic/claude-sonnet-4.5",
+            "inputTokens": 9,
+            "outputTokens": 4,
+            "costUsd": 0,
+        }
+    ]
+
+
+def test_extract_llm_calls_falls_back_to_primary_provider_for_unknown_token_key():
+    service = UsageMetricsService()
+    receipt = _receipt(
+        {
+            "address": "0xprimary",
+            "primary_model": {
+                "provider": "llm-router",
+                "model": "policy:dev-openai",
+            },
+            "secondary_model": None,
+        },
+        {
+            "llm": {
+                "tokens": {
+                    "node-0xother/policy:unexpected": {
+                        "input": "7",
+                        "output": "bad-value",
+                        "total": 7,
+                    }
+                }
+            }
+        },
+    )
+
+    assert service._extract_llm_calls_from_receipt(receipt) == [
+        {
+            "provider": "llm-router",
+            "model": "policy:unexpected",
+            "inputTokens": 7,
+            "outputTokens": 0,
+            "costUsd": 0,
+        }
+    ]
+
+
+def test_extract_llm_calls_falls_back_to_primary_without_token_metrics():
+    service = UsageMetricsService()
+    receipt = _receipt(
+        {
+            "address": "0xprimary",
+            "primary_model": {
+                "provider": "llm-router",
+                "model": "policy:dev-openai",
+            },
+            "secondary_model": {
+                "address": "0xfallback",
+                "provider": "openrouter",
+                "model": "anthropic/claude-sonnet-4.5",
+            },
+        }
+    )
+
+    assert service._extract_llm_calls_from_receipt(receipt) == [
+        {
+            "provider": "llm-router",
+            "model": "policy:dev-openai",
+            "inputTokens": 0,
+            "outputTokens": 0,
+            "costUsd": 0,
         }
     ]


### PR DESCRIPTION
## Summary
- preserve GenVM LLM token metrics in Studio execution stats
- report token-backed configured primary/fallback LLM calls to usage metrics
- keep existing primary-model fallback behavior when token metrics are absent

## Tests
- /Users/edgars/Dev/genlayer-studio/.venv/bin/python -m pytest tests/unit/test_usage_metrics_service.py tests/unit/test_node_state_proxy_metrics.py tests/unit/test_fallback_validator_model_host_data.py tests/unit/test_leader_llm_recovery.py
- git diff --check