### PR TITLE
fix: read raw GCS snapshot archives

### DIFF
--- a/backend/database_handler/models.py
+++ b/backend/database_handler/models.py
@@ -181,6 +181,57 @@ class Transactions(Base):
     )
 
 
+class TransactionSnapshotArchive(Base):
+    __tablename__ = "transaction_snapshot_archives"
+    __table_args__ = (
+        CheckConstraint(
+            "backend IN ('file', 'gcs', 's3')",
+            name="transaction_snapshot_archives_backend_check",
+        ),
+        CheckConstraint(
+            "archive_status IN ('archived', 'pruned')",
+            name="transaction_snapshot_archives_status_check",
+        ),
+    )
+
+    tx_hash: Mapped[str] = mapped_column(
+        String(66),
+        ForeignKey("transactions.hash", ondelete="CASCADE"),
+        primary_key=True,
+    )
+    backend: Mapped[str] = mapped_column(String(20), nullable=False)
+    object_key: Mapped[str] = mapped_column(String(1024), nullable=False)
+    uri: Mapped[str] = mapped_column(String(2048), nullable=False)
+    snapshot_sha256: Mapped[str] = mapped_column(String(64), nullable=False)
+    compressed_sha256: Mapped[str] = mapped_column(String(64), nullable=False)
+    snapshot_bytes: Mapped[int] = mapped_column(BigInteger, nullable=False)
+    compressed_bytes: Mapped[int] = mapped_column(BigInteger, nullable=False)
+    bucket: Mapped[Optional[str]] = mapped_column(String(255), default=None)
+    format: Mapped[str] = mapped_column(
+        String(64),
+        nullable=False,
+        server_default="full-json-gzip-v1",
+        default="full-json-gzip-v1",
+    )
+    archive_status: Mapped[str] = mapped_column(
+        String(20),
+        nullable=False,
+        server_default="archived",
+        default="archived",
+    )
+    archived_at: Mapped[datetime.datetime] = mapped_column(
+        DateTime(True),
+        server_default=func.current_timestamp(),
+        init=False,
+    )
+    pruned_at: Mapped[Optional[datetime.datetime]] = mapped_column(
+        DateTime(True), nullable=True, default=None
+    )
+    object_metadata: Mapped[Optional[dict]] = mapped_column(
+        JSONB, nullable=True, default=None
+    )
+
+
 class Validators(Base):
     __tablename__ = "validators"
     __table_args__ = (

--- a/backend/database_handler/terminal_snapshot_pruner.py
+++ b/backend/database_handler/terminal_snapshot_pruner.py
@@ -416,7 +416,7 @@ class GCSSnapshotArchiveWriter:
         body = (
             self.client.bucket(archive_result.bucket)
             .blob(archive_result.key)
-            .download_as_bytes()
+            .download_as_bytes(raw_download=True)
         )
         _verify_archive_result_body(archive_result, body)
 
@@ -651,7 +651,9 @@ class SnapshotArchiveReader:
         if not bucket:
             raise RuntimeError("GCS archive row is missing bucket")
         return (
-            self.gcs_client.bucket(bucket).blob(row["object_key"]).download_as_bytes()
+            self.gcs_client.bucket(bucket)
+            .blob(row["object_key"])
+            .download_as_bytes(raw_download=True)
         )
 
     def _download_s3(self, row: dict[str, Any]) -> bytes:

--- a/tests/unit/test_terminal_snapshot_pruner.py
+++ b/tests/unit/test_terminal_snapshot_pruner.py
@@ -55,12 +55,16 @@ class FakeGCSBlob:
         self.metadata = None
         self.storage_class = None
         self.uploads = []
+        self.download_calls = []
 
     def upload_from_string(self, data, content_type):
         self.uploads.append({"data": data, "content_type": content_type})
         self.data = data
 
-    def download_as_bytes(self):
+    def download_as_bytes(self, raw_download=False):
+        self.download_calls.append(raw_download)
+        if self.content_encoding == "gzip" and not raw_download:
+            return gzip.decompress(self.data)
         return self.data
 
 
@@ -353,6 +357,8 @@ def test_archive_reader_loads_cloud_backends():
     assert SnapshotArchiveReader(gcs_client=gcs_client).load_snapshot(
         gcs_session, candidate.tx_hash
     ) == {"x": 1}
+    gcs_blob = gcs_client.buckets["archive-bucket"].blobs[gcs_result.key]
+    assert gcs_blob.download_calls == [True]
 
 
 def test_archive_reader_file_download_fallbacks(tmp_path):
@@ -532,6 +538,7 @@ def test_gcs_archive_writer_uploads_compressed_snapshot_with_metadata():
     assert blob.uploads[0]["content_type"] == "application/json"
     assert gzip.decompress(blob.uploads[0]["data"]) == b'{"x":1}'
     writer.verify(result)
+    assert blob.download_calls == [True]
 
 
 def test_archive_writers_require_bucket_for_verification():


### PR DESCRIPTION
## Summary
- fix GCS snapshot archive verification/read-through to download raw object bytes when objects have Content-Encoding: gzip
- update the GCS fake to mimic GCS transcoding unless raw_download=True is requested
- assert writer verification and archive reader use raw GCS downloads

## Production rollout finding
During the prod one-record rollout check, both Studio and Rally failed before DB commit with an archive checksum mismatch during GCS verification. Hot snapshots remained present and no archive rows were committed. This PR addresses the GCS-specific download behavior; S3 staging was unaffected.

## Tests
- /Users/edgars/Dev/genlayer-studio/.venv/bin/python -m pytest tests/unit/test_terminal_snapshot_pruner.py