### PR TITLE
fix: reuse existing GCS snapshot archives

### DIFF
--- a/backend/database_handler/terminal_snapshot_pruner.py
+++ b/backend/database_handler/terminal_snapshot_pruner.py
@@ -283,6 +283,12 @@ def _verify_archive_result_body(archive_result: ArchiveResult, body: bytes) -> N
     )
 
 
+def _is_precondition_failed(exc: Exception) -> bool:
+    if exc.__class__.__name__ == "PreconditionFailed":
+        return True
+    return getattr(exc, "code", None) == 412
+
+
 class FileSnapshotArchiveWriter:
     backend = "file"
 
@@ -395,9 +401,7 @@ class GCSSnapshotArchiveWriter:
         blob.metadata = metadata
         if self.storage_class:
             blob.storage_class = self.storage_class
-        blob.upload_from_string(body, content_type="application/json")
-
-        return ArchiveResult(
+        archive_result = ArchiveResult(
             backend=self.backend,
             bucket=self.bucket,
             key=key,
@@ -409,6 +413,43 @@ class GCSSnapshotArchiveWriter:
             compressed_sha256=compressed_sha256,
             metadata=metadata,
         )
+        try:
+            blob.upload_from_string(
+                body,
+                content_type="application/json",
+                if_generation_match=0,
+            )
+        except Exception as exc:
+            if not _is_precondition_failed(exc):
+                raise
+            self._verify_existing_object(bucket, key, archive_result, metadata)
+
+        return archive_result
+
+    def _verify_existing_object(
+        self,
+        bucket,
+        key: str,
+        archive_result: ArchiveResult,
+        expected_metadata: dict[str, str],
+    ) -> None:
+        existing_blob = bucket.get_blob(key)
+        if existing_blob is None:
+            raise RuntimeError(
+                f"GCS archive object already exists but could not be read: {key}"
+            )
+
+        body = existing_blob.download_as_bytes(raw_download=True)
+        _verify_archive_result_body(archive_result, body)
+
+        actual_metadata = existing_blob.metadata or {}
+        for metadata_key, expected_value in expected_metadata.items():
+            actual_value = actual_metadata.get(metadata_key)
+            if actual_value != expected_value:
+                raise RuntimeError(
+                    "Existing GCS archive metadata mismatch for "
+                    f"{archive_result.key}: {metadata_key}"
+                )
 
     def verify(self, archive_result: ArchiveResult) -> None:
         if not archive_result.bucket:

--- a/tests/unit/test_terminal_snapshot_pruner.py
+++ b/tests/unit/test_terminal_snapshot_pruner.py
@@ -27,6 +27,10 @@ from backend.database_handler.terminal_snapshot_pruner import (
 )
 
 
+class PreconditionFailed(Exception):
+    code = 412
+
+
 class FakeS3Client:
     def __init__(self):
         self.calls = []
@@ -57,8 +61,12 @@ class FakeGCSBlob:
         self.uploads = []
         self.download_calls = []
 
-    def upload_from_string(self, data, content_type):
-        self.uploads.append({"data": data, "content_type": content_type})
+    def upload_from_string(self, data, content_type, **kwargs):
+        if kwargs.get("if_generation_match") == 0 and hasattr(self, "data"):
+            raise PreconditionFailed("object already exists")
+        self.uploads.append(
+            {"data": data, "content_type": content_type, "kwargs": kwargs}
+        )
         self.data = data
 
     def download_as_bytes(self, raw_download=False):
@@ -75,6 +83,9 @@ class FakeGCSBucket:
 
     def blob(self, key):
         return self.blobs.setdefault(key, FakeGCSBlob(key))
+
+    def get_blob(self, key):
+        return self.blobs.get(key)
 
 
 class FakeGCSClient:
@@ -536,9 +547,65 @@ def test_gcs_archive_writer_uploads_compressed_snapshot_with_metadata():
     assert blob.metadata["tx-hash"] == "0xABCDEF"
     assert blob.metadata["snapshot-sha256"] == hashlib.sha256(b'{"x":1}').hexdigest()
     assert blob.uploads[0]["content_type"] == "application/json"
+    assert blob.uploads[0]["kwargs"] == {"if_generation_match": 0}
     assert gzip.decompress(blob.uploads[0]["data"]) == b'{"x":1}'
     writer.verify(result)
     assert blob.download_calls == [True]
+
+
+def test_gcs_archive_writer_reuses_matching_existing_object():
+    client = FakeGCSClient()
+    writer = GCSSnapshotArchiveWriter(
+        bucket="archive-bucket",
+        prefix="studio/rally",
+        client=client,
+    )
+    candidate = SnapshotCandidate(
+        tx_hash="0xABCDEF",
+        status="FINALIZED",
+        created_at=datetime(2026, 6, 1, tzinfo=timezone.utc),
+        snapshot_bytes=7,
+        snapshot_json='{"x":1}',
+    )
+
+    first_result = writer.archive(candidate)
+    second_result = writer.archive(candidate)
+
+    blob = client.buckets["archive-bucket"].blobs[first_result.key]
+    assert second_result == first_result
+    assert len(blob.uploads) == 1
+    assert blob.download_calls == [True]
+
+
+def test_gcs_archive_writer_rejects_mismatched_existing_object():
+    client = FakeGCSClient()
+    writer = GCSSnapshotArchiveWriter(
+        bucket="archive-bucket",
+        prefix="studio/rally",
+        client=client,
+    )
+    first_candidate = SnapshotCandidate(
+        tx_hash="0xABCDEF",
+        status="FINALIZED",
+        created_at=datetime(2026, 6, 1, tzinfo=timezone.utc),
+        snapshot_bytes=7,
+        snapshot_json='{"x":1}',
+    )
+    second_candidate = SnapshotCandidate(
+        tx_hash="0xABCDEF",
+        status="FINALIZED",
+        created_at=datetime(2026, 6, 1, tzinfo=timezone.utc),
+        snapshot_bytes=7,
+        snapshot_json='{"x":2}',
+    )
+
+    result = writer.archive(first_candidate)
+    blob = client.buckets["archive-bucket"].blobs[result.key]
+
+    with pytest.raises(RuntimeError, match="checksum mismatch"):
+        writer.archive(second_candidate)
+
+    assert len(blob.uploads) == 1
 
 
 def test_archive_writers_require_bucket_for_verification():


### PR DESCRIPTION
## Summary
- make GCS snapshot archive upload create-only with generation precondition
- when the object already exists, raw-download and verify compressed/raw checksums plus metadata before proceeding
- fail closed if an existing object does not match the current transaction snapshot

## Why
Production one-record validation found deterministic orphan objects from the earlier pre-hotfix failed attempt. Retrying tried to overwrite the object, and GCS requires storage.objects.delete for overwrite. This keeps the workload identity scoped to create/read and makes archive writes idempotent after an upload-before-DB-commit failure.

## Validation
- /Users/edgars/Dev/genlayer-studio/.venv/bin/python -m pytest tests/unit/test_terminal_snapshot_pruner.py
- commit hooks: autoflake + black passed