### PR TITLE
[codex] Tolerate dict leader receipts

### DIFF
--- a/backend/database_handler/transactions_processor.py
+++ b/backend/database_handler/transactions_processor.py
@@ -81,6 +81,16 @@ class TransactionsProcessor:
         self.web3 = Web3ConnectionPool.get()
 
     @staticmethod
+    def _select_receipt(receipts, index: int = 0) -> dict | None:
+        if isinstance(receipts, dict):
+            return receipts
+        if isinstance(receipts, list) and 0 <= index < len(receipts):
+            receipt = receipts[index]
+            if isinstance(receipt, dict):
+                return receipt
+        return None
+
+    @staticmethod
     def _parse_transaction_data(
         transaction_data: Transactions,
         *,
@@ -355,12 +365,13 @@ class TransactionsProcessor:
                 len(transaction_data["consensus_history"]["consensus_results"]) - 1
             )
             last_round = transaction_data["consensus_history"]["consensus_results"][-1]
+            leader = self._select_receipt(last_round.get("leader_result"), index=1)
             if (
-                "leader_result" in last_round
-                and last_round["leader_result"] is not None
-                and len(last_round["leader_result"]) > 1
+                leader is not None
+                and leader.get("vote") is not None
+                and isinstance(leader.get("node_config"), dict)
+                and leader["node_config"].get("address") is not None
             ):
-                leader = last_round["leader_result"][1]
                 validator_votes_name.append(leader["vote"].upper())
                 vote_number = int(Vote.from_string(leader["vote"]))
                 validator_votes.append(vote_number)
@@ -459,18 +470,35 @@ class TransactionsProcessor:
             transaction_data["consensus_history"] is not None
             and "consensus_results" in transaction_data["consensus_history"]
         ):
-            transaction_data["activator"] = transaction_data["consensus_history"][
-                "consensus_results"
-            ][0]["leader_result"][0]["node_config"]["address"]
+            first_round = transaction_data["consensus_history"]["consensus_results"][0]
+            leader = self._select_receipt(first_round.get("leader_result"), index=0)
+            if (
+                leader is not None
+                and isinstance(leader.get("node_config"), dict)
+                and leader["node_config"].get("address") is not None
+            ):
+                transaction_data["activator"] = leader["node_config"]["address"]
+            else:
+                transaction_data["activator"] = ""
         else:
             transaction_data["activator"] = ""
 
         if (transaction_data["consensus_data"] is not None) and (
             "leader_receipt" in transaction_data["consensus_data"]
         ):
-            transaction_data["last_leader"] = transaction_data["consensus_data"][
-                "leader_receipt"
-            ][0]["node_config"]["address"]
+            leader_receipt = self._select_receipt(
+                transaction_data["consensus_data"]["leader_receipt"], index=0
+            )
+            if (
+                leader_receipt is not None
+                and isinstance(leader_receipt.get("node_config"), dict)
+                and leader_receipt["node_config"].get("address") is not None
+            ):
+                transaction_data["last_leader"] = leader_receipt["node_config"][
+                    "address"
+                ]
+            else:
+                transaction_data["last_leader"] = ""
         else:
             transaction_data["last_leader"] = ""
         return transaction_data
@@ -496,21 +524,24 @@ class TransactionsProcessor:
         return transaction_data
 
     def _process_execution_hash(self, transaction_data: dict) -> dict:
+        leader_receipt = None
         if (
             transaction_data["consensus_data"] is not None
             and "leader_receipt" in transaction_data["consensus_data"]
-            and len(transaction_data["consensus_data"]["leader_receipt"]) > 1
-            and "node_config" in transaction_data["consensus_data"]["leader_receipt"][1]
+        ):
+            leader_receipt = self._select_receipt(
+                transaction_data["consensus_data"]["leader_receipt"], index=1
+            )
+
+        if (
+            leader_receipt is not None
+            and isinstance(leader_receipt.get("node_config"), dict)
+            and leader_receipt["node_config"].get("address") is not None
+            and leader_receipt.get("vote") is not None
         ):
             transaction_data["tx_execution_hash"] = get_tx_execution_hash(
-                transaction_data["consensus_data"]["leader_receipt"][1]["node_config"][
-                    "address"
-                ],
-                int(
-                    Vote.from_string(
-                        transaction_data["consensus_data"]["leader_receipt"][1]["vote"]
-                    )
-                ),
+                leader_receipt["node_config"]["address"],
+                int(Vote.from_string(leader_receipt["vote"])),
             )
         else:
             transaction_data["tx_execution_hash"] = ""
@@ -527,46 +558,44 @@ class TransactionsProcessor:
             for consensus_round in transaction_data["consensus_history"][
                 "consensus_results"
             ]:
-                if consensus_round["leader_result"] is not None:
+                leader_result = self._select_receipt(
+                    consensus_round.get("leader_result"), index=0
+                )
+                if (
+                    leader_result is not None
+                    and leader_result.get("result") is not None
+                ):
                     eq_output.append(
                         [
                             len(eq_output),  # key
                             [
-                                base64.b64decode(
-                                    consensus_round["leader_result"][0]["result"]
-                                )[
-                                    0
-                                ],  # kind
+                                base64.b64decode(leader_result["result"])[0],  # kind
                                 "\x00",
                             ],
                         ]
                     )  # data
 
         kind = 0
+        leader_receipt = None
         if (
             transaction_data["consensus_data"] is not None
             and "leader_receipt" in transaction_data["consensus_data"]
-            and "result" in transaction_data["consensus_data"]["leader_receipt"]
         ):
-            kind = base64.b64decode(
-                transaction_data["consensus_data"]["leader_receipt"][0]["result"]
-            )[0]
+            leader_receipt = self._select_receipt(
+                transaction_data["consensus_data"]["leader_receipt"], index=0
+            )
+        if leader_receipt is not None and leader_receipt.get("result") is not None:
+            kind = base64.b64decode(leader_receipt["result"])[0]
+
         pending_transactions = []
         messages = []
-        if (
-            transaction_data["consensus_data"] is not None
-            and "leader_receipt" in transaction_data["consensus_data"]
-            and transaction_data["consensus_data"]["leader_receipt"] is not None
-            and "pending_transactions"
-            in transaction_data["consensus_data"]["leader_receipt"][0]
-            and transaction_data["consensus_data"]["leader_receipt"][0][
-                "pending_transactions"
-            ]
-            is not None
-        ):
-            for message in transaction_data["consensus_data"]["leader_receipt"][0][
-                "pending_transactions"
-            ]:
+        pending_messages = (
+            leader_receipt.get("pending_transactions")
+            if leader_receipt is not None
+            else None
+        )
+        if pending_messages is not None:
+            for message in pending_messages:
                 pending_transactions.append(
                     [
                         message.get("address", ""),  # Account

--- a/tests/unit/test_transactions_processor_improvements.py
+++ b/tests/unit/test_transactions_processor_improvements.py
@@ -2,7 +2,7 @@
 
 from unittest.mock import Mock, patch
 from backend.database_handler.transactions_processor import TransactionsProcessor
-from backend.database_handler.models import Transactions
+from backend.database_handler.models import TransactionStatus, Transactions
 from sqlalchemy.orm import Session
 
 
@@ -40,6 +40,93 @@ class TestArchivedContractSnapshotHydration:
 
         assert transaction_data["contract_snapshot"] == {"state": "hot"}
         assert archive.calls == []
+
+
+class TestLeaderReceiptCompatibility:
+    def setup_method(self):
+        self.processor = TransactionsProcessor(Mock())
+
+    def test_processor_helpers_accept_dict_shaped_leader_receipts(self):
+        address = "0xaAaAaAaaAaAaAaaAaAAAAAAAAaaaAaAaAaaAaaAa"
+        receipt = {
+            "vote": "agree",
+            "result": "AG9r",
+            "node_config": {"address": address},
+            "pending_transactions": [
+                {
+                    "address": "0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB",
+                    "calldata": "0x1234",
+                    "value": 3,
+                    "on": "accepted",
+                    "code": "",
+                    "salt_nonce": 0,
+                }
+            ],
+        }
+        transaction_data = {
+            "hash": "0xabc",
+            "from_address": address,
+            "to_address": address,
+            "data": {},
+            "value": 0,
+            "type": 1,
+            "status": TransactionStatus.FINALIZED.value,
+            "result": {},
+            "consensus_data": {"leader_receipt": receipt},
+            "gaslimit": 0,
+            "nonce": 7,
+            "created_at": "2026-06-24T12:00:00+00:00",
+            "leader_only": True,
+            "execution_mode": "LEADER_ONLY",
+            "origin_address": None,
+            "triggered_by": None,
+            "triggered_on": None,
+            "triggered_transactions": [],
+            "appealed": False,
+            "timestamp_awaiting_finalization": None,
+            "appeal_failed": False,
+            "appeal_undetermined": False,
+            "consensus_history": {
+                "consensus_results": [
+                    {
+                        "leader_result": receipt,
+                        "validator_results": [],
+                    }
+                ]
+            },
+            "timestamp_appeal": None,
+            "appeal_processing_time": None,
+            "config_rotation_rounds": 3,
+            "num_of_initial_validators": 1,
+            "last_vote_timestamp": None,
+            "rotation_count": 0,
+            "appeal_leader_timeout": False,
+            "leader_timeout_validators": [],
+            "appeal_validators_timeout": [],
+            "sim_config": None,
+            "value_credited": False,
+        }
+
+        transaction_data = self.processor._prepare_basic_transaction_data(
+            transaction_data
+        )
+        transaction_data = self.processor._process_execution_hash(transaction_data)
+        transaction_data = self.processor._process_messages(transaction_data)
+        transaction_data = self.processor._process_round_data(transaction_data)
+
+        assert transaction_data["activator"] == address
+        assert transaction_data["last_leader"] == address
+        assert transaction_data["tx_execution_hash"].startswith("0x")
+        assert transaction_data["messages"] == [
+            {
+                "messageType": "0",
+                "recipient": "0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB",
+                "value": 3,
+                "data": "0x1234",
+                "onAcceptance": True,
+            }
+        ]
+        assert transaction_data["last_round"]["validator_votes_name"] == ["AGREE"]
 
 
 class TestGetTransactionCount:


### PR DESCRIPTION
## Summary
- tolerate dict-shaped legacy leader_result / leader_receipt entries in transaction formatting
- keep list-shaped receipt behavior unchanged for current rows
- add regression coverage for dict-shaped receipt formatting

## Why
A controlled one-record prod prune exposed that eth_getTransactionByHash can fail on older finalized rows before archive hydration when consensus_history.leader_result is stored as a dict instead of a list. The archive object and direct archive reader worked; this keeps public transaction formatting compatible with legacy rows before continuing pruning rollout.

## Tests
- /Users/edgars/Dev/genlayer-studio/.venv/bin/python -m pytest tests/unit/test_transactions_processor_improvements.py tests/unit/test_terminal_snapshot_pruner.py
- /Users/edgars/Dev/genlayer-studio/.venv/bin/python -m black --check backend/database_handler/transactions_processor.py tests/unit/test_transactions_processor_improvements.py