### PR TITLE
[codex] Split snapshot pruning pipeline

### DIFF
--- a/backend/database_handler/migration/versions/d0e1f2a3b4c5_add_snapshot_archive_verification.py
+++ b/backend/database_handler/migration/versions/d0e1f2a3b4c5_add_snapshot_archive_verification.py
@@ -1,0 +1,48 @@
+"""add snapshot archive verification marker
+
+Revision ID: d0e1f2a3b4c5
+Revises: c9d0e1f2a3b4
+Create Date: 2026-06-24 15:55:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision: str = "d0e1f2a3b4c5"
+down_revision: Union[str, None] = "c9d0e1f2a3b4"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:  # pragma: no cover
+    op.add_column(
+        "transaction_snapshot_archives",
+        sa.Column("verified_at", sa.DateTime(timezone=True), nullable=True),
+    )
+    op.create_index(
+        "idx_transaction_snapshot_archives_verify_queue",
+        "transaction_snapshot_archives",
+        ["archive_status", "verified_at", "archived_at"],
+    )
+    op.create_index(
+        "idx_transaction_snapshot_archives_prune_queue",
+        "transaction_snapshot_archives",
+        ["archive_status", "verified_at"],
+    )
+
+
+def downgrade() -> None:  # pragma: no cover
+    op.drop_index(
+        "idx_transaction_snapshot_archives_prune_queue",
+        table_name="transaction_snapshot_archives",
+    )
+    op.drop_index(
+        "idx_transaction_snapshot_archives_verify_queue",
+        table_name="transaction_snapshot_archives",
+    )
+    op.drop_column("transaction_snapshot_archives", "verified_at")

--- a/backend/database_handler/models.py
+++ b/backend/database_handler/models.py
@@ -227,6 +227,9 @@ class TransactionSnapshotArchive(Base):
     pruned_at: Mapped[Optional[datetime.datetime]] = mapped_column(
         DateTime(True), nullable=True, default=None
     )
+    verified_at: Mapped[Optional[datetime.datetime]] = mapped_column(
+        DateTime(True), nullable=True, default=None
+    )
     object_metadata: Mapped[Optional[dict]] = mapped_column(
         JSONB, nullable=True, default=None
     )

--- a/backend/database_handler/prune_terminal_snapshots.py
+++ b/backend/database_handler/prune_terminal_snapshots.py
@@ -46,6 +46,7 @@ def _empty_totals() -> dict:
         "batches": 0,
         "candidates": 0,
         "archived": 0,
+        "verified": 0,
         "pruned": 0,
         "logical_bytes": 0,
         "compressed_bytes": 0,
@@ -56,6 +57,7 @@ def _add_batch_result(totals: dict, result) -> None:
     totals["batches"] += 1
     totals["candidates"] += result.candidates
     totals["archived"] += result.archived
+    totals["verified"] += result.verified
     totals["pruned"] += result.pruned
     totals["logical_bytes"] += result.logical_bytes
     totals["compressed_bytes"] += result.compressed_bytes
@@ -63,19 +65,22 @@ def _add_batch_result(totals: dict, result) -> None:
 
 def _log_batch_result(
     *,
+    phase: str,
     batch_number: int,
     worker_id: int,
     result,
     elapsed_seconds: float,
 ) -> None:
     logger.info(
-        "Batch %s complete: worker=%s candidates=%s archived=%s pruned=%s "
-        "logical_bytes=%s compressed_bytes=%s dry_run=%s elapsed=%.2fs "
-        "logical_rate=%s compressed_rate=%s",
+        "Batch %s complete: phase=%s worker=%s candidates=%s archived=%s "
+        "verified=%s pruned=%s logical_bytes=%s compressed_bytes=%s "
+        "dry_run=%s elapsed=%.2fs logical_rate=%s compressed_rate=%s",
         batch_number,
+        phase,
         worker_id,
         result.candidates,
         result.archived,
+        result.verified,
         result.pruned,
         result.logical_bytes,
         result.compressed_bytes,
@@ -95,6 +100,8 @@ def _run_pruner_worker(
     sleep_seconds: float,
     totals: dict,
     totals_lock: threading.Lock,
+    phase: str,
+    verify_inline: bool,
 ) -> None:
     pruner = TerminalSnapshotPruner(session_factory, config)
 
@@ -104,12 +111,21 @@ def _run_pruner_worker(
             return
 
         batch_started_at = time.monotonic()
-        result = pruner.prune_once()
+        if phase == "archive":
+            result = pruner.archive_once(verify_inline=verify_inline)
+        elif phase == "verify":
+            result = pruner.verify_archives_once()
+        elif phase == "prune":
+            result = pruner.prune_verified_once()
+        else:
+            result = pruner.prune_once()
         batch_elapsed = time.monotonic() - batch_started_at
         if result.candidates == 0:
             logger.info(
-                "Worker %s found no eligible terminal contract snapshots",
+                "Worker %s found no eligible terminal contract snapshots "
+                "for phase %s",
                 worker_id,
+                phase,
             )
             return
 
@@ -117,6 +133,7 @@ def _run_pruner_worker(
             _add_batch_result(totals, result)
 
         _log_batch_result(
+            phase=phase,
             batch_number=batch_number,
             worker_id=worker_id,
             result=result,
@@ -152,6 +169,26 @@ def build_parser() -> argparse.ArgumentParser:
             "Archive terminal transaction contract snapshots and prune them from "
             "the hot transactions table."
         )
+    )
+    parser.add_argument(
+        "--phase",
+        choices=("full", "archive", "verify", "prune"),
+        default="full",
+        help=(
+            "Pipeline phase to run. full preserves the original archive, verify, "
+            "and prune behavior in one pass. archive writes archive rows without "
+            "pruning. verify reads archived objects back and marks them verified. "
+            "prune removes hot snapshots only for verified archive rows."
+        ),
+    )
+    parser.add_argument(
+        "--inline-verify",
+        action="store_true",
+        help=(
+            "When --phase archive is used, read each object back immediately and "
+            "mark it verified. Off by default so archive and verification can be "
+            "scaled independently."
+        ),
     )
     parser.add_argument(
         "--batch-size",
@@ -211,7 +248,12 @@ def main() -> int:
             else config.retention_hours
         ),
     )
-    config.validate_for_run()
+    if args.phase == "archive":
+        config.validate_for_archive()
+    elif args.phase == "verify":
+        config.validate_for_verify()
+    elif args.phase == "full":
+        config.validate_for_run()
 
     engine = create_engine(
         get_database_url(),
@@ -230,8 +272,10 @@ def main() -> int:
 
     logger.info(
         "Starting terminal snapshot pruning "
-        "(batch_size=%s retention_hours=%s archive_enabled=%s "
-        "archive_backend=%s dry_run=%s workers=%s max_batches=%s)",
+        "(phase=%s batch_size=%s retention_hours=%s archive_enabled=%s "
+        "archive_backend=%s dry_run=%s workers=%s max_batches=%s "
+        "inline_verify=%s)",
+        args.phase,
         config.batch_size,
         config.retention_hours,
         config.archive_enabled,
@@ -239,6 +283,7 @@ def main() -> int:
         config.dry_run,
         args.workers,
         args.max_batches,
+        args.inline_verify,
     )
 
     started_at = time.monotonic()
@@ -253,6 +298,8 @@ def main() -> int:
                 sleep_seconds=args.sleep_seconds,
                 totals=totals,
                 totals_lock=totals_lock,
+                phase=args.phase,
+                verify_inline=args.inline_verify,
             )
             for worker_id in range(1, args.workers + 1)
         ]

--- a/backend/database_handler/terminal_snapshot_pruner.py
+++ b/backend/database_handler/terminal_snapshot_pruner.py
@@ -132,19 +132,7 @@ class TerminalSnapshotPrunerConfig:
             or None,
         )
 
-    def validate_for_run(self) -> None:
-        if self.dry_run:
-            return
-        if not self.archive_enabled:
-            if self.allow_lossy_prune:
-                return
-            raise RuntimeError(
-                "Refusing to prune terminal contract snapshots without archiving. "
-                "Set STUDIO_CONTRACT_SNAPSHOT_PRUNER_ARCHIVE_ENABLED=true, or set "
-                "STUDIO_CONTRACT_SNAPSHOT_PRUNER_ALLOW_LOSSY_PRUNE=true to make "
-                "the data-loss mode explicit."
-            )
-
+    def _validate_archive_backend(self) -> None:
         backend = self.archive_backend.lower()
         if backend not in {"file", "gcs", "s3"}:
             raise RuntimeError(
@@ -166,6 +154,35 @@ class TerminalSnapshotPrunerConfig:
                 "STUDIO_CONTRACT_SNAPSHOT_PRUNER_S3_BUCKET is required when "
                 "STUDIO_CONTRACT_SNAPSHOT_PRUNER_ARCHIVE_BACKEND=s3"
             )
+
+    def validate_for_archive(self) -> None:
+        if self.dry_run:
+            return
+        if not self.archive_enabled:
+            raise RuntimeError(
+                "Archive phase requires "
+                "STUDIO_CONTRACT_SNAPSHOT_PRUNER_ARCHIVE_ENABLED=true"
+            )
+        self._validate_archive_backend()
+
+    def validate_for_verify(self) -> None:
+        if self.dry_run:
+            return
+        self._validate_archive_backend()
+
+    def validate_for_run(self) -> None:
+        if self.dry_run:
+            return
+        if not self.archive_enabled:
+            if self.allow_lossy_prune:
+                return
+            raise RuntimeError(
+                "Refusing to prune terminal contract snapshots without archiving. "
+                "Set STUDIO_CONTRACT_SNAPSHOT_PRUNER_ARCHIVE_ENABLED=true, or set "
+                "STUDIO_CONTRACT_SNAPSHOT_PRUNER_ALLOW_LOSSY_PRUNE=true to make "
+                "the data-loss mode explicit."
+            )
+        self._validate_archive_backend()
 
 
 @dataclass(frozen=True)
@@ -192,9 +209,38 @@ class ArchiveResult:
 
 
 @dataclass(frozen=True)
+class SnapshotArchiveRecord:
+    tx_hash: str
+    backend: str
+    bucket: str | None
+    object_key: str
+    uri: str
+    format: str
+    snapshot_sha256: str
+    compressed_sha256: str
+    snapshot_bytes: int
+    compressed_bytes: int
+
+    def to_archive_result(self) -> ArchiveResult:
+        return ArchiveResult(
+            backend=self.backend,
+            bucket=self.bucket,
+            key=self.object_key,
+            uri=self.uri,
+            format=self.format,
+            uncompressed_bytes=self.snapshot_bytes,
+            compressed_bytes=self.compressed_bytes,
+            uncompressed_sha256=self.snapshot_sha256,
+            compressed_sha256=self.compressed_sha256,
+            metadata={"tx-hash": self.tx_hash},
+        )
+
+
+@dataclass(frozen=True)
 class PruneBatchResult:
     candidates: int = 0
     archived: int = 0
+    verified: int = 0
     pruned: int = 0
     logical_bytes: int = 0
     compressed_bytes: int = 0
@@ -646,7 +692,10 @@ class SnapshotArchiveReader:
                         compressed_bytes
                     FROM transaction_snapshot_archives
                     WHERE tx_hash = :hash
-                      AND archive_status IN ('archived', 'pruned')
+                      AND (
+                          archive_status = 'pruned'
+                          OR verified_at IS NOT NULL
+                      )
                     ORDER BY archived_at DESC
                     LIMIT 1
                     """
@@ -764,11 +813,165 @@ class TerminalSnapshotPruner:
             for row in rows
         ]
 
+    def _fetch_archive_candidates(self, session: Session) -> list[SnapshotCandidate]:
+        rows = (
+            session.execute(
+                text(
+                    """
+                    SELECT
+                        hash,
+                        status::text AS status,
+                        created_at,
+                        pg_column_size(contract_snapshot) AS snapshot_bytes,
+                        contract_snapshot::text AS snapshot_json
+                    FROM transactions
+                    WHERE contract_snapshot IS NOT NULL
+                      AND status IN ('FINALIZED', 'CANCELED')
+                      AND created_at < :cutoff
+                      AND NOT EXISTS (
+                          SELECT 1
+                          FROM transaction_snapshot_archives archives
+                          WHERE archives.tx_hash = transactions.hash
+                            AND archives.archive_status IN ('archived', 'pruned')
+                      )
+                    ORDER BY created_at ASC, hash ASC
+                    LIMIT :batch_size
+                    FOR UPDATE SKIP LOCKED
+                    """
+                ),
+                {
+                    "cutoff": self._cutoff(),
+                    "batch_size": self.config.batch_size,
+                },
+            )
+            .mappings()
+            .all()
+        )
+
+        return [
+            SnapshotCandidate(
+                tx_hash=row["hash"],
+                status=row["status"],
+                created_at=row["created_at"],
+                snapshot_bytes=int(row["snapshot_bytes"] or 0),
+                snapshot_json=row["snapshot_json"],
+            )
+            for row in rows
+        ]
+
+    def _fetch_unverified_archives(
+        self, session: Session
+    ) -> list[SnapshotArchiveRecord]:
+        rows = (
+            session.execute(
+                text(
+                    """
+                    SELECT
+                        tx_hash,
+                        backend,
+                        bucket,
+                        object_key,
+                        uri,
+                        format,
+                        snapshot_sha256,
+                        compressed_sha256,
+                        snapshot_bytes,
+                        compressed_bytes
+                    FROM transaction_snapshot_archives
+                    WHERE archive_status = 'archived'
+                      AND verified_at IS NULL
+                    ORDER BY archived_at ASC, tx_hash ASC
+                    LIMIT :batch_size
+                    FOR UPDATE SKIP LOCKED
+                    """
+                ),
+                {"batch_size": self.config.batch_size},
+            )
+            .mappings()
+            .all()
+        )
+
+        return [
+            SnapshotArchiveRecord(
+                tx_hash=row["tx_hash"],
+                backend=row["backend"],
+                bucket=row["bucket"],
+                object_key=row["object_key"],
+                uri=row["uri"],
+                format=row["format"],
+                snapshot_sha256=row["snapshot_sha256"],
+                compressed_sha256=row["compressed_sha256"],
+                snapshot_bytes=int(row["snapshot_bytes"] or 0),
+                compressed_bytes=int(row["compressed_bytes"] or 0),
+            )
+            for row in rows
+        ]
+
+    def _fetch_verified_prune_candidates(
+        self, session: Session
+    ) -> list[SnapshotArchiveRecord]:
+        rows = (
+            session.execute(
+                text(
+                    """
+                    SELECT
+                        archives.tx_hash,
+                        archives.backend,
+                        archives.bucket,
+                        archives.object_key,
+                        archives.uri,
+                        archives.format,
+                        archives.snapshot_sha256,
+                        archives.compressed_sha256,
+                        pg_column_size(transactions.contract_snapshot)
+                            AS snapshot_bytes,
+                        archives.compressed_bytes
+                    FROM transaction_snapshot_archives archives
+                    JOIN transactions ON transactions.hash = archives.tx_hash
+                    WHERE archives.archive_status = 'archived'
+                      AND archives.verified_at IS NOT NULL
+                      AND transactions.contract_snapshot IS NOT NULL
+                      AND transactions.status IN ('FINALIZED', 'CANCELED')
+                      AND transactions.created_at < :cutoff
+                    ORDER BY archives.verified_at ASC,
+                             transactions.created_at ASC,
+                             archives.tx_hash ASC
+                    LIMIT :batch_size
+                    FOR UPDATE OF archives, transactions SKIP LOCKED
+                    """
+                ),
+                {
+                    "cutoff": self._cutoff(),
+                    "batch_size": self.config.batch_size,
+                },
+            )
+            .mappings()
+            .all()
+        )
+
+        return [
+            SnapshotArchiveRecord(
+                tx_hash=row["tx_hash"],
+                backend=row["backend"],
+                bucket=row["bucket"],
+                object_key=row["object_key"],
+                uri=row["uri"],
+                format=row["format"],
+                snapshot_sha256=row["snapshot_sha256"],
+                compressed_sha256=row["compressed_sha256"],
+                snapshot_bytes=int(row["snapshot_bytes"] or 0),
+                compressed_bytes=int(row["compressed_bytes"] or 0),
+            )
+            for row in rows
+        ]
+
     def _record_archive(
         self,
         session: Session,
         candidate: SnapshotCandidate,
         archive_result: ArchiveResult,
+        *,
+        verified: bool = False,
     ) -> None:
         session.execute(
             text(
@@ -786,6 +989,7 @@ class TerminalSnapshotPruner:
                     compressed_bytes,
                     archive_status,
                     archived_at,
+                    verified_at,
                     object_metadata
                 )
                 VALUES (
@@ -801,6 +1005,7 @@ class TerminalSnapshotPruner:
                     :compressed_bytes,
                     'archived',
                     CURRENT_TIMESTAMP,
+                    CASE WHEN :verified THEN CURRENT_TIMESTAMP ELSE NULL END,
                     CAST(:object_metadata AS jsonb)
                 )
                 ON CONFLICT (tx_hash) DO UPDATE SET
@@ -815,6 +1020,7 @@ class TerminalSnapshotPruner:
                     compressed_bytes = EXCLUDED.compressed_bytes,
                     archive_status = 'archived',
                     archived_at = CURRENT_TIMESTAMP,
+                    verified_at = EXCLUDED.verified_at,
                     pruned_at = NULL,
                     object_metadata = EXCLUDED.object_metadata
                 """
@@ -830,8 +1036,22 @@ class TerminalSnapshotPruner:
                 "compressed_sha256": archive_result.compressed_sha256,
                 "snapshot_bytes": archive_result.uncompressed_bytes,
                 "compressed_bytes": archive_result.compressed_bytes,
+                "verified": verified,
                 "object_metadata": json.dumps(archive_result.metadata),
             },
+        )
+
+    def _mark_archive_verified(self, session: Session, tx_hash: str) -> None:
+        session.execute(
+            text(
+                """
+                UPDATE transaction_snapshot_archives
+                SET verified_at = CURRENT_TIMESTAMP
+                WHERE tx_hash = :hash
+                  AND archive_status = 'archived'
+                """
+            ),
+            {"hash": tx_hash},
         )
 
     def _mark_archive_pruned(self, session: Session, tx_hash: str) -> None:
@@ -847,10 +1067,155 @@ class TerminalSnapshotPruner:
             {"hash": tx_hash},
         )
 
+    def archive_once(self, *, verify_inline: bool = False) -> PruneBatchResult:
+        self.config.validate_for_archive()
+        session = self.get_session()
+        archived = 0
+        verified = 0
+        logical_bytes = 0
+        compressed_bytes = 0
+        try:
+            candidates = self._fetch_archive_candidates(session)
+            if not candidates:
+                session.rollback()
+                return PruneBatchResult(dry_run=self.config.dry_run)
+
+            logical_bytes = sum(candidate.snapshot_bytes for candidate in candidates)
+            if self.config.dry_run:
+                session.rollback()
+                return PruneBatchResult(
+                    candidates=len(candidates),
+                    logical_bytes=logical_bytes,
+                    dry_run=True,
+                )
+
+            writer = self._archive_writer()
+            for candidate in candidates:
+                archive_result = writer.archive(candidate)
+                if verify_inline:
+                    writer.verify(archive_result)
+                    verified += 1
+                self._record_archive(
+                    session,
+                    candidate,
+                    archive_result,
+                    verified=verify_inline,
+                )
+                archived += 1
+                compressed_bytes += archive_result.compressed_bytes
+
+            session.commit()
+            return PruneBatchResult(
+                candidates=len(candidates),
+                archived=archived,
+                verified=verified,
+                logical_bytes=logical_bytes,
+                compressed_bytes=compressed_bytes,
+                dry_run=False,
+            )
+        except Exception:
+            session.rollback()
+            raise
+        finally:
+            session.close()
+
+    def verify_archives_once(self) -> PruneBatchResult:
+        self.config.validate_for_verify()
+        session = self.get_session()
+        try:
+            archives = self._fetch_unverified_archives(session)
+            if not archives:
+                session.rollback()
+                return PruneBatchResult(dry_run=self.config.dry_run)
+
+            logical_bytes = sum(archive.snapshot_bytes for archive in archives)
+            compressed_bytes = sum(archive.compressed_bytes for archive in archives)
+            if self.config.dry_run:
+                session.rollback()
+                return PruneBatchResult(
+                    candidates=len(archives),
+                    logical_bytes=logical_bytes,
+                    compressed_bytes=compressed_bytes,
+                    dry_run=True,
+                )
+
+            writer = self._archive_writer()
+            verified = 0
+            for archive in archives:
+                writer.verify(archive.to_archive_result())
+                self._mark_archive_verified(session, archive.tx_hash)
+                verified += 1
+
+            session.commit()
+            return PruneBatchResult(
+                candidates=len(archives),
+                verified=verified,
+                logical_bytes=logical_bytes,
+                compressed_bytes=compressed_bytes,
+                dry_run=False,
+            )
+        except Exception:
+            session.rollback()
+            raise
+        finally:
+            session.close()
+
+    def prune_verified_once(self) -> PruneBatchResult:
+        session = self.get_session()
+        pruned = 0
+        try:
+            archives = self._fetch_verified_prune_candidates(session)
+            if not archives:
+                session.rollback()
+                return PruneBatchResult(dry_run=self.config.dry_run)
+
+            logical_bytes = sum(archive.snapshot_bytes for archive in archives)
+            compressed_bytes = sum(archive.compressed_bytes for archive in archives)
+            if self.config.dry_run:
+                session.rollback()
+                return PruneBatchResult(
+                    candidates=len(archives),
+                    logical_bytes=logical_bytes,
+                    compressed_bytes=compressed_bytes,
+                    dry_run=True,
+                )
+
+            for archive in archives:
+                result = session.execute(
+                    text(
+                        """
+                        UPDATE transactions
+                        SET contract_snapshot = NULL
+                        WHERE hash = :hash
+                          AND contract_snapshot IS NOT NULL
+                        """
+                    ),
+                    {"hash": archive.tx_hash},
+                )
+                rowcount = result.rowcount or 0
+                pruned += rowcount
+                if rowcount:
+                    self._mark_archive_pruned(session, archive.tx_hash)
+
+            session.commit()
+            return PruneBatchResult(
+                candidates=len(archives),
+                pruned=pruned,
+                logical_bytes=logical_bytes,
+                compressed_bytes=compressed_bytes,
+                dry_run=False,
+            )
+        except Exception:
+            session.rollback()
+            raise
+        finally:
+            session.close()
+
     def prune_once(self) -> PruneBatchResult:
         self.config.validate_for_run()
         session = self.get_session()
         archived = 0
+        verified = 0
         pruned = 0
         logical_bytes = 0
         compressed_bytes = 0
@@ -878,7 +1243,13 @@ class TerminalSnapshotPruner:
                     archive_result = writer.archive(candidate)
                     if self.config.verify_archive:
                         writer.verify(archive_result)
-                    self._record_archive(session, candidate, archive_result)
+                        verified += 1
+                    self._record_archive(
+                        session,
+                        candidate,
+                        archive_result,
+                        verified=self.config.verify_archive,
+                    )
                     archived += 1
                     compressed_bytes += archive_result.compressed_bytes
 
@@ -902,6 +1273,7 @@ class TerminalSnapshotPruner:
             return PruneBatchResult(
                 candidates=len(candidates),
                 archived=archived,
+                verified=verified,
                 pruned=pruned,
                 logical_bytes=logical_bytes,
                 compressed_bytes=compressed_bytes,
@@ -943,10 +1315,12 @@ async def run_terminal_snapshot_pruner_loop(
             if result.candidates:
                 logger.info(
                     "Terminal contract snapshot pruning batch complete: "
-                    "candidates=%s archived=%s pruned=%s logical_bytes=%s "
-                    "compressed_bytes=%s dry_run=%s elapsed=%.2fs",
+                    "candidates=%s archived=%s verified=%s pruned=%s "
+                    "logical_bytes=%s compressed_bytes=%s dry_run=%s "
+                    "elapsed=%.2fs",
                     result.candidates,
                     result.archived,
+                    result.verified,
                     result.pruned,
                     result.logical_bytes,
                     result.compressed_bytes,

--- a/docs/terminal-contract-snapshot-pruning.md
+++ b/docs/terminal-contract-snapshot-pruning.md
@@ -23,8 +23,14 @@ All backends use the same deterministic gzip JSON object format:
 
 An archive index row is written to `transaction_snapshot_archives` with the
 backend, object URI, uncompressed/compressed byte counts, and SHA-256 checksums.
-The pruner only sets `transactions.contract_snapshot = NULL` after the archive
-write and index row succeed.
+The fastest production drain should run as a three-phase pipeline:
+
+1. Archive snapshots and write archive index rows.
+2. Verify archived objects by reading them back and setting `verified_at`.
+3. Prune only hot snapshots whose archive row has been verified.
+
+The legacy/default `full` CLI phase still performs archive, read-back
+verification, and pruning in one pass for small/manual runs.
 
 ## Runtime Auto-Pruner
 
@@ -69,14 +75,15 @@ STUDIO_CONTRACT_SNAPSHOT_PRUNER_VERIFY_ARCHIVE=true
 STUDIO_CONTRACT_SNAPSHOT_ARCHIVE_RETRIEVAL_ENABLED=true
 ```
 
-Each batch:
+The default `full` phase performs all work in one batch:
 
 1. Locks a small set of `FINALIZED` or `CANCELED` rows with
    `contract_snapshot IS NOT NULL`.
 2. Writes each snapshot to the configured backend as deterministic gzip JSON.
 3. Reads the archived object back and verifies the compressed checksum, gzip
    payload, and raw JSON checksum.
-4. Stores object location and checksums in `transaction_snapshot_archives`.
+4. Stores object location, checksums, and `verified_at` in
+   `transaction_snapshot_archives`.
 5. Sets `transactions.contract_snapshot = NULL` only after the archive write,
    read-back verification, and index row succeed.
 
@@ -88,10 +95,49 @@ mode and is rejected unless
 
 ## One-Time Historical Drain
 
-Use the same implementation for one-time cleanup:
+For large one-time cleanup, prefer the split pipeline. Keep the background
+pruner disabled while these commands run.
+
+Archive phase, no deletion:
 
 ```bash
 python -m backend.database_handler.prune_terminal_snapshots \
+  --phase archive \
+  --batch-size 25 \
+  --retention-hours 24 \
+  --workers 4 \
+  --max-batches 100 \
+  --sleep-seconds 0
+```
+
+Verify phase, no deletion:
+
+```bash
+python -m backend.database_handler.prune_terminal_snapshots \
+  --phase verify \
+  --batch-size 25 \
+  --workers 4 \
+  --max-batches 100 \
+  --sleep-seconds 0
+```
+
+Prune phase, deletes only verified archive rows:
+
+```bash
+python -m backend.database_handler.prune_terminal_snapshots \
+  --phase prune \
+  --batch-size 100 \
+  --retention-hours 24 \
+  --workers 4 \
+  --max-batches 100 \
+  --sleep-seconds 0
+```
+
+Use the legacy all-in-one phase for tiny/manual checks:
+
+```bash
+python -m backend.database_handler.prune_terminal_snapshots \
+  --phase full \
   --batch-size 5 \
   --retention-hours 24
 ```
@@ -110,6 +156,7 @@ Use `--workers` for bounded parallel one-time drains:
 
 ```bash
 python -m backend.database_handler.prune_terminal_snapshots \
+  --phase archive \
   --batch-size 5 \
   --retention-hours 24 \
   --workers 4 \
@@ -117,10 +164,9 @@ python -m backend.database_handler.prune_terminal_snapshots \
   --sleep-seconds 0
 ```
 
-Each worker uses its own database session and the shared candidate query uses
-`FOR UPDATE SKIP LOCKED`, so workers claim different rows. The CLI caps its
-database connection pool to the worker count. Keep the background pruner disabled
-while running a one-time parallel drain.
+Each worker uses its own database session and the shared queue queries use
+`FOR UPDATE SKIP LOCKED`, so workers claim different rows/archive rows. The CLI
+caps its database connection pool to the worker count.
 
 ## Read-Through Retrieval
 
@@ -392,6 +438,7 @@ Start with lossless archive verification enabled. Do not set
 
    ```bash
    python -m backend.database_handler.prune_terminal_snapshots \
+     --phase archive \
      --dry-run \
      --batch-size 5 \
      --retention-hours 24 \
@@ -404,6 +451,7 @@ Start with lossless archive verification enabled. Do not set
 
    ```bash
    python -m backend.database_handler.prune_terminal_snapshots \
+     --phase full \
      --batch-size 1 \
      --retention-hours 24 \
      --max-batches 1 \
@@ -414,13 +462,41 @@ Start with lossless archive verification enabled. Do not set
 5. Verify the pruned transaction end to end:
    archive row, object metadata, checksum, hot row null, and direct read
    hydration.
-6. Run a small measured batch ladder while watching DB CPU/IO, object-store
+6. For the real historical drain, switch to the split pipeline:
+
+   ```bash
+   python -m backend.database_handler.prune_terminal_snapshots \
+     --phase archive \
+     --batch-size 25 \
+     --retention-hours 24 \
+     --max-batches 100 \
+     --workers 4 \
+     --sleep-seconds 0
+
+   python -m backend.database_handler.prune_terminal_snapshots \
+     --phase verify \
+     --batch-size 25 \
+     --max-batches 100 \
+     --workers 4 \
+     --sleep-seconds 0
+
+   python -m backend.database_handler.prune_terminal_snapshots \
+     --phase prune \
+     --batch-size 100 \
+     --retention-hours 24 \
+     --max-batches 100 \
+     --workers 4 \
+     --sleep-seconds 0
+   ```
+
+7. Run a small measured batch ladder while watching DB CPU/IO, object-store
    errors, RPC latency, and application logs:
-   `workers=1`, then `workers=2`, then `workers=4`.
-7. Continue the one-time drain only at the highest worker count that remains
-   healthy. The Rally probe suggests starting with `workers=4` as the likely
-   practical ceiling unless live metrics prove otherwise.
-8. After the historical drain, enable the background pruner only if steady-state
+   `workers=1`, then `workers=2`, then `workers=4`. Use dedicated one-off
+   Kubernetes Jobs for large drains instead of execing inside serving RPC pods.
+8. Continue the one-time drain only at the highest worker/job count that remains
+   healthy. Keep verification and pruning behind the archive phase; do not prune
+   rows whose archive row lacks `verified_at`.
+9. After the historical drain, enable the background pruner only if steady-state
    pruning is desired. Use a conservative retention window and batch size first,
    for example `retention_hours=24`, `batch_size=5`, `interval_seconds=300`.
 

--- a/tests/db-sqlalchemy/test_terminal_snapshot_archive_pruning.py
+++ b/tests/db-sqlalchemy/test_terminal_snapshot_archive_pruning.py
@@ -78,7 +78,7 @@ def test_pruner_archives_verifies_prunes_and_read_through_hydrates_snapshot(
                 text(
                     """
                     SELECT backend, uri, archive_status, snapshot_sha256,
-                           compressed_sha256
+                           compressed_sha256, verified_at
                     FROM transaction_snapshot_archives
                     WHERE tx_hash = :hash
                     """
@@ -95,6 +95,136 @@ def test_pruner_archives_verifies_prunes_and_read_through_hydrates_snapshot(
         assert archive_row["uri"].startswith("file://")
         assert archive_row["snapshot_sha256"]
         assert archive_row["compressed_sha256"]
+        assert archive_row["verified_at"] is not None
+
+        tp = TransactionsProcessor(
+            read_session,
+            snapshot_archive=SnapshotArchiveReader(file_dir=tmp_path),
+        )
+        tx = tp.get_transaction_by_hash(tx_hash)
+
+        assert tx["contract_snapshot"] == snapshot
+    finally:
+        read_session.close()
+
+
+def test_archive_verify_prune_phases_preserve_read_through(engine, tmp_path):
+    SessionLocal = sessionmaker(bind=engine, expire_on_commit=False)
+    tx_hash = f"0x{uuid.uuid4().hex}{uuid.uuid4().hex}"
+    snapshot = {
+        "state": {
+            "accepted": {"counter": 2},
+            "finalized": {"counter": 2},
+        },
+    }
+
+    setup_session = SessionLocal()
+    try:
+        tp = TransactionsProcessor(setup_session)
+        tp.insert_transaction(
+            from_address="0x9F0e84243496AcFB3Cd99D02eA59673c05901501",
+            to_address="0xAcec3A6d871C25F591aBd4fC24054e524BBbF794",
+            data={"key": "value"},
+            value=1.0,
+            type=1,
+            nonce=0,
+            leader_only=True,
+            config_rotation_rounds=3,
+            transaction_hash=tx_hash,
+        )
+        tp.set_transaction_contract_snapshot(tx_hash, snapshot)
+        setup_session.execute(
+            text(
+                """
+                UPDATE transactions
+                SET status = 'FINALIZED'::transaction_status,
+                    created_at = CURRENT_TIMESTAMP - INTERVAL '2 days'
+                WHERE hash = :hash
+                """
+            ),
+            {"hash": tx_hash},
+        )
+        setup_session.commit()
+    finally:
+        setup_session.close()
+
+    config = TerminalSnapshotPrunerConfig(
+        enabled=True,
+        archive_backend="file",
+        file_dir=str(tmp_path),
+        retention_hours=24,
+        batch_size=10,
+    )
+    pruner = TerminalSnapshotPruner(SessionLocal, config)
+
+    archive_result = pruner.archive_once()
+    assert archive_result.candidates == 1
+    assert archive_result.archived == 1
+    assert archive_result.verified == 0
+    assert archive_result.pruned == 0
+
+    inspect_session = SessionLocal()
+    try:
+        row = (
+            inspect_session.execute(
+                text(
+                    """
+                    SELECT transactions.contract_snapshot IS NOT NULL AS hot_present,
+                           archives.archive_status,
+                           archives.verified_at,
+                           archives.pruned_at
+                    FROM transactions
+                    JOIN transaction_snapshot_archives archives
+                      ON archives.tx_hash = transactions.hash
+                    WHERE transactions.hash = :hash
+                    """
+                ),
+                {"hash": tx_hash},
+            )
+            .mappings()
+            .one()
+        )
+        assert row["hot_present"] is True
+        assert row["archive_status"] == "archived"
+        assert row["verified_at"] is None
+        assert row["pruned_at"] is None
+    finally:
+        inspect_session.close()
+
+    verify_result = pruner.verify_archives_once()
+    assert verify_result.candidates == 1
+    assert verify_result.verified == 1
+    assert verify_result.pruned == 0
+
+    prune_result = pruner.prune_verified_once()
+    assert prune_result.candidates == 1
+    assert prune_result.pruned == 1
+
+    read_session = SessionLocal()
+    try:
+        row = (
+            read_session.execute(
+                text(
+                    """
+                    SELECT transactions.contract_snapshot IS NULL AS hot_null,
+                           archives.archive_status,
+                           archives.verified_at,
+                           archives.pruned_at
+                    FROM transactions
+                    JOIN transaction_snapshot_archives archives
+                      ON archives.tx_hash = transactions.hash
+                    WHERE transactions.hash = :hash
+                    """
+                ),
+                {"hash": tx_hash},
+            )
+            .mappings()
+            .one()
+        )
+        assert row["hot_null"] is True
+        assert row["archive_status"] == "pruned"
+        assert row["verified_at"] is not None
+        assert row["pruned_at"] is not None
 
         tp = TransactionsProcessor(
             read_session,

--- a/tests/unit/test_terminal_snapshot_pruner.py
+++ b/tests/unit/test_terminal_snapshot_pruner.py
@@ -126,6 +126,7 @@ class FakeSession:
         self.rows = rows
         self.archive_rows = archive_rows or []
         self.archive_inserts = []
+        self.verified_archive_hashes = []
         self.pruned_archive_hashes = []
         self.updated_hashes = []
         self.fail_on_archive_insert = fail_on_archive_insert
@@ -136,6 +137,8 @@ class FakeSession:
 
     def execute(self, statement, params=None):
         sql = str(statement)
+        if "FROM transactions" in sql and "JOIN transactions" not in sql:
+            return FakeMappingsResult(self.rows)
         if "FROM transaction_snapshot_archives" in sql:
             return FakeMappingsResult(self.archive_rows)
         if "INSERT INTO transaction_snapshot_archives" in sql:
@@ -144,7 +147,10 @@ class FakeSession:
             self.archive_inserts.append(params)
             return FakeUpdateResult()
         if "UPDATE transaction_snapshot_archives" in sql:
-            self.pruned_archive_hashes.append(params["hash"])
+            if "archive_status = 'pruned'" in sql:
+                self.pruned_archive_hashes.append(params["hash"])
+            else:
+                self.verified_archive_hashes.append(params["hash"])
             return FakeUpdateResult()
         if "SELECT" in sql:
             return FakeMappingsResult(self.rows)
@@ -686,6 +692,116 @@ def test_pruner_archives_before_pruning_and_commits():
     assert result.compressed_bytes == 84
 
 
+def test_archive_phase_records_archive_without_pruning_or_verifying():
+    session = FakeSession([_candidate_row("0x1"), _candidate_row("0x2")])
+    writer = RecordingArchiveWriter()
+    pruner = TerminalSnapshotPruner(
+        lambda: session,
+        TerminalSnapshotPrunerConfig(enabled=True, s3_bucket="archive-bucket"),
+        archive_writer=writer,
+    )
+
+    result = pruner.archive_once()
+
+    assert writer.archived == ["0x1", "0x2"]
+    assert writer.verified == []
+    assert [row["tx_hash"] for row in session.archive_inserts] == ["0x1", "0x2"]
+    assert [row["verified"] for row in session.archive_inserts] == [False, False]
+    assert session.updated_hashes == []
+    assert session.pruned_archive_hashes == []
+    assert session.committed is True
+    assert result.archived == 2
+    assert result.verified == 0
+    assert result.pruned == 0
+
+
+def test_archive_phase_can_inline_verify():
+    session = FakeSession([_candidate_row("0x1")])
+    writer = RecordingArchiveWriter()
+    pruner = TerminalSnapshotPruner(
+        lambda: session,
+        TerminalSnapshotPrunerConfig(enabled=True, s3_bucket="archive-bucket"),
+        archive_writer=writer,
+    )
+
+    result = pruner.archive_once(verify_inline=True)
+
+    assert writer.archived == ["0x1"]
+    assert writer.verified == ["studio/v1/0x1.json.gz"]
+    assert [row["verified"] for row in session.archive_inserts] == [True]
+    assert session.updated_hashes == []
+    assert result.archived == 1
+    assert result.verified == 1
+    assert result.pruned == 0
+
+
+def test_verify_phase_marks_archives_without_pruning():
+    writer = RecordingArchiveWriter()
+    archive_result = writer.archive(
+        SnapshotCandidate(
+            tx_hash="0x1",
+            status="FINALIZED",
+            created_at=datetime(2026, 6, 1, tzinfo=timezone.utc),
+            snapshot_bytes=7,
+            snapshot_json='{"x":1}',
+        )
+    )
+    session = FakeSession([], archive_rows=[_archive_row(archive_result)])
+    writer.archived = []
+    pruner = TerminalSnapshotPruner(
+        lambda: session,
+        TerminalSnapshotPrunerConfig(enabled=True, s3_bucket="archive-bucket"),
+        archive_writer=writer,
+    )
+
+    result = pruner.verify_archives_once()
+
+    assert writer.archived == []
+    assert writer.verified == ["studio/v1/0x1.json.gz"]
+    assert session.verified_archive_hashes == ["0x1"]
+    assert session.updated_hashes == []
+    assert session.pruned_archive_hashes == []
+    assert session.committed is True
+    assert result.verified == 1
+    assert result.pruned == 0
+
+
+def test_prune_verified_phase_only_deletes_preverified_archives():
+    session = FakeSession(
+        [],
+        archive_rows=[
+            {
+                "tx_hash": "0x1",
+                "backend": "file",
+                "bucket": None,
+                "object_key": "studio/v1/0x1.json.gz",
+                "uri": "file:///tmp/0x1.json.gz",
+                "format": ARCHIVE_FORMAT,
+                "snapshot_sha256": "0" * 64,
+                "compressed_sha256": "1" * 64,
+                "snapshot_bytes": 123,
+                "compressed_bytes": 45,
+            }
+        ],
+    )
+    pruner = TerminalSnapshotPruner(
+        lambda: session,
+        TerminalSnapshotPrunerConfig(enabled=True, s3_bucket="archive-bucket"),
+    )
+
+    result = pruner.prune_verified_once()
+
+    assert session.updated_hashes == ["0x1"]
+    assert session.pruned_archive_hashes == ["0x1"]
+    assert session.archive_inserts == []
+    assert session.committed is True
+    assert result.archived == 0
+    assert result.verified == 0
+    assert result.pruned == 1
+    assert result.logical_bytes == 123
+    assert result.compressed_bytes == 45
+
+
 def test_pruner_rolls_back_and_does_not_prune_when_archive_fails():
     session = FakeSession([_candidate_row("0x1")])
     pruner = TerminalSnapshotPruner(
@@ -1140,6 +1256,143 @@ def test_prune_cli_main_runs_until_empty_and_applies_cli_overrides(monkeypatch):
     assert pruner.config.batch_size == 7
     assert pruner.config.retention_hours == 12
     assert sleep_calls == [0.5]
+
+
+def test_prune_cli_main_runs_archive_phase_without_inline_verify(monkeypatch):
+    created_pruners = []
+    engine = object()
+
+    class FakePruner:
+        def __init__(self, session_factory, config):
+            self.session_factory = session_factory
+            self.config = config
+            self.archive_calls = []
+            created_pruners.append(self)
+
+        def archive_once(self, *, verify_inline=False):
+            self.archive_calls.append(verify_inline)
+            if len(self.archive_calls) == 1:
+                return PruneBatchResult(candidates=1, archived=1, logical_bytes=20)
+            return PruneBatchResult()
+
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "prune_terminal_snapshots",
+            "--phase",
+            "archive",
+            "--max-batches",
+            "2",
+            "--sleep-seconds",
+            "0",
+        ],
+    )
+    monkeypatch.setattr(
+        prune_cli.TerminalSnapshotPrunerConfig,
+        "from_environment",
+        staticmethod(
+            lambda: TerminalSnapshotPrunerConfig(
+                enabled=False,
+                dry_run=False,
+                batch_size=5,
+                retention_hours=24,
+                s3_bucket="archive-bucket",
+            )
+        ),
+    )
+    monkeypatch.setattr(prune_cli, "get_database_url", lambda: "postgresql://db")
+    monkeypatch.setattr(
+        prune_cli,
+        "create_engine",
+        lambda url, **kwargs: engine,
+    )
+    monkeypatch.setattr(
+        prune_cli,
+        "sessionmaker",
+        lambda **kwargs: ("SessionLocal", kwargs),
+    )
+    monkeypatch.setattr(prune_cli, "TerminalSnapshotPruner", FakePruner)
+
+    assert prune_cli.main() == 0
+
+    assert created_pruners[0].archive_calls == [False, False]
+
+
+def test_prune_cli_main_runs_verify_and_prune_phases(monkeypatch):
+    phase_calls = []
+    engine = object()
+
+    class FakePruner:
+        def __init__(self, session_factory, config):
+            self.session_factory = session_factory
+            self.config = config
+
+        def verify_archives_once(self):
+            phase_calls.append("verify")
+            return PruneBatchResult(candidates=1, verified=1, logical_bytes=20)
+
+        def prune_verified_once(self):
+            phase_calls.append("prune")
+            return PruneBatchResult(candidates=1, pruned=1, logical_bytes=20)
+
+    monkeypatch.setattr(
+        prune_cli.TerminalSnapshotPrunerConfig,
+        "from_environment",
+        staticmethod(
+            lambda: TerminalSnapshotPrunerConfig(
+                enabled=False,
+                dry_run=False,
+                batch_size=5,
+                retention_hours=24,
+                s3_bucket="archive-bucket",
+            )
+        ),
+    )
+    monkeypatch.setattr(prune_cli, "get_database_url", lambda: "postgresql://db")
+    monkeypatch.setattr(
+        prune_cli,
+        "create_engine",
+        lambda url, **kwargs: engine,
+    )
+    monkeypatch.setattr(
+        prune_cli,
+        "sessionmaker",
+        lambda **kwargs: ("SessionLocal", kwargs),
+    )
+    monkeypatch.setattr(prune_cli, "TerminalSnapshotPruner", FakePruner)
+
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "prune_terminal_snapshots",
+            "--phase",
+            "verify",
+            "--max-batches",
+            "1",
+            "--sleep-seconds",
+            "0",
+        ],
+    )
+    assert prune_cli.main() == 0
+
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "prune_terminal_snapshots",
+            "--phase",
+            "prune",
+            "--max-batches",
+            "1",
+            "--sleep-seconds",
+            "0",
+        ],
+    )
+    assert prune_cli.main() == 0
+
+    assert phase_calls == ["verify", "prune"]
 
 
 def test_prune_cli_main_runs_parallel_workers_with_shared_batch_budget(monkeypatch):


### PR DESCRIPTION
## Summary

- add a verified_at archive marker and migration for terminal snapshot archives
- add split pruning CLI phases: archive, verify, prune, while keeping full as the default behavior
- update archive/prune docs and tests for the separated pipeline and read-through safety

## Why

Large production drains are currently slow because each row is archived, read back, and pruned in one pass. Splitting archive, verification, and pruning lets us back up aggressively, verify separately, and only delete hot state after the archive row is verified.

## Validation

- /Users/edgars/Dev/genlayer-studio/.venv/bin/python -m pytest tests/unit/test_terminal_snapshot_pruner.py tests/unit/test_transactions_processor_improvements.py
- /Users/edgars/Dev/genlayer-studio/.venv/bin/black --check backend/database_handler/terminal_snapshot_pruner.py backend/database_handler/prune_terminal_snapshots.py backend/database_handler/models.py tests/unit/test_terminal_snapshot_pruner.py tests/db-sqlalchemy/test_terminal_snapshot_archive_pruning.py backend/database_handler/migration/versions/d0e1f2a3b4c5_add_snapshot_archive_verification.py
- /Users/edgars/Dev/genlayer-studio/.venv/bin/python -m py_compile backend/database_handler/terminal_snapshot_pruner.py backend/database_handler/prune_terminal_snapshots.py backend/database_handler/models.py backend/database_handler/migration/versions/d0e1f2a3b4c5_add_snapshot_archive_verification.py tests/unit/test_terminal_snapshot_pruner.py tests/db-sqlalchemy/test_terminal_snapshot_archive_pruning.py
- git diff --check
- Alembic script head check returned d0e1f2a3b4c5

DB integration tests were attempted but local POSTGRES_URL is not set, and Docker is not running on this machine to bring up tests/db-sqlalchemy/docker-compose.yml. CI should run the db-sqlalchemy harness.