### PR TITLE
[codex] Bound archive candidate scan

### DIFF
--- a/backend/database_handler/terminal_snapshot_pruner.py
+++ b/backend/database_handler/terminal_snapshot_pruner.py
@@ -814,34 +814,47 @@ class TerminalSnapshotPruner:
         ]
 
     def _fetch_archive_candidates(self, session: Session) -> list[SnapshotCandidate]:
+        candidate_scan_limit = self.config.batch_size * 5
         rows = (
             session.execute(
                 text(
                     """
+                    WITH candidate_rows AS MATERIALIZED (
+                        SELECT
+                            hash,
+                            status::text AS status,
+                            created_at,
+                            pg_column_size(contract_snapshot) AS snapshot_bytes,
+                            contract_snapshot::text AS snapshot_json
+                        FROM transactions
+                        WHERE contract_snapshot IS NOT NULL
+                          AND status IN ('FINALIZED', 'CANCELED')
+                          AND created_at < :cutoff
+                        ORDER BY created_at ASC, hash ASC
+                        LIMIT :candidate_scan_limit
+                        FOR UPDATE SKIP LOCKED
+                    )
                     SELECT
                         hash,
-                        status::text AS status,
+                        status,
                         created_at,
-                        pg_column_size(contract_snapshot) AS snapshot_bytes,
-                        contract_snapshot::text AS snapshot_json
-                    FROM transactions
-                    WHERE contract_snapshot IS NOT NULL
-                      AND status IN ('FINALIZED', 'CANCELED')
-                      AND created_at < :cutoff
-                      AND NOT EXISTS (
+                        snapshot_bytes,
+                        snapshot_json
+                    FROM candidate_rows
+                    WHERE NOT EXISTS (
                           SELECT 1
                           FROM transaction_snapshot_archives archives
-                          WHERE archives.tx_hash = transactions.hash
+                          WHERE archives.tx_hash = candidate_rows.hash
                             AND archives.archive_status IN ('archived', 'pruned')
                       )
                     ORDER BY created_at ASC, hash ASC
                     LIMIT :batch_size
-                    FOR UPDATE SKIP LOCKED
                     """
                 ),
                 {
                     "cutoff": self._cutoff(),
                     "batch_size": self.config.batch_size,
+                    "candidate_scan_limit": candidate_scan_limit,
                 },
             )
             .mappings()


### PR DESCRIPTION
## Summary\n- bound archive-phase candidate selection to a materialized hot-transaction window before checking archive rows\n- preserve existing archive/verify/prune semantics while avoiding a broad anti-join over the production transaction history\n\n## Context\nDuring the first v0.121.12 production split-pipeline run, archive/verify/prune worked end-to-end, but a second archive run left all workers active in the archive candidate SELECT for more than six minutes. The old/full candidate query continued to make progress, so the bottleneck is the archive-only anti-join shape.\n\n## Tests\n- python -m pytest tests/unit/test_terminal_snapshot_pruner.py\n- python -m py_compile backend/database_handler/terminal_snapshot_pruner.py\n