### PR TITLE
fix: clean up worker claims during shutdown

### DIFF
--- a/backend/consensus/worker.py
+++ b/backend/consensus/worker.py
@@ -5,7 +5,7 @@ import asyncio
 import time
 import uuid
 from contextlib import asynccontextmanager
-from typing import Callable, Optional, Any
+from typing import Callable, Optional, Any, Iterable
 from sqlalchemy.orm import Session
 from sqlalchemy import text, bindparam
 
@@ -724,6 +724,130 @@ class ConsensusWorker:
                     exc_info=True,
                 )
             raise
+
+    def abandon_owned_claims_for_shutdown(
+        self, session: Session, tracked_hashes: Iterable[str] | None = None
+    ) -> dict[str, int]:
+        """
+        Make this worker's in-flight claims safe to retry during process shutdown.
+
+        This is intentionally broader than `current_transactions`: a terminating
+        process may have stale or partially-cleared in-memory state, while the
+        database worker_id is the source of truth for ownership. `tracked_hashes`
+        covers the cancellation race where an active task's context manager clears
+        worker_id before this shutdown cleanup runs.
+        """
+        tracked_hashes = tuple(
+            sorted({tx_hash for tx_hash in (tracked_hashes or []) if tx_hash})
+        )
+
+        ownership_clause = "worker_id = :worker_id"
+        bindparams = []
+        params: dict[str, Any] = {
+            "worker_id": self.worker_id,
+            "max_recovery_cycles": self._max_recovery_cycles,
+        }
+        if tracked_hashes:
+            ownership_clause = f"({ownership_clause} OR (worker_id IS NULL AND hash IN :tracked_hashes))"
+            bindparams.append(bindparam("tracked_hashes", expanding=True))
+            params["tracked_hashes"] = tracked_hashes
+
+        release_finalized_query = text(
+            f"""
+            UPDATE transactions
+            SET blocked_at = NULL,
+                worker_id = NULL
+            WHERE {ownership_clause}
+              AND status IN :finalization_statuses
+            RETURNING hash, status
+            """
+        ).bindparams(
+            bindparam("finalization_statuses", expanding=True),
+            *bindparams,
+        )
+
+        reset_consensus_query = text(
+            f"""
+            WITH target AS (
+                SELECT hash, recovery_count
+                FROM transactions
+                WHERE {ownership_clause}
+                  AND status IN :consensus_statuses
+                FOR UPDATE
+            )
+            UPDATE transactions
+            SET blocked_at = NULL,
+                worker_id = NULL,
+                consensus_history = NULL,
+                recovery_count = target.recovery_count + 1,
+                status = CASE
+                    WHEN target.recovery_count + 1 >= :max_recovery_cycles
+                    THEN 'CANCELED'::transaction_status
+                    ELSE 'PENDING'::transaction_status
+                END,
+                consensus_data = CASE
+                    WHEN target.recovery_count + 1 >= :max_recovery_cycles
+                    THEN jsonb_build_object(
+                        'error', 'max_recovery_cycles_exceeded',
+                        'recovery_count', target.recovery_count + 1,
+                        'max_recovery_exhausted_at',
+                        EXTRACT(EPOCH FROM NOW())::bigint
+                    )
+                    ELSE NULL
+                END
+            FROM target
+            WHERE transactions.hash = target.hash
+            RETURNING transactions.hash, transactions.status,
+                      transactions.recovery_count
+            """
+        ).bindparams(
+            bindparam("consensus_statuses", expanding=True),
+            *bindparams,
+        )
+
+        try:
+            released = session.execute(
+                release_finalized_query,
+                {
+                    **params,
+                    "finalization_statuses": list(self._FINALIZATION_ELIGIBLE_STATUSES),
+                },
+            ).fetchall()
+            reset = session.execute(
+                reset_consensus_query,
+                {
+                    **params,
+                    "consensus_statuses": list(self._CONSENSUS_RECOVERABLE_STATUSES),
+                },
+            ).fetchall()
+            session.commit()
+        except Exception:
+            session.rollback()
+            logger.exception(
+                f"[Worker {self.worker_id}] Failed to abandon owned claims during shutdown"
+            )
+            raise
+
+        for row in released:
+            logger.info(
+                f"[Worker {self.worker_id}] Released shutdown finalization claim "
+                f"{row.hash} (status={row.status}, state preserved)"
+            )
+        for row in reset:
+            if row.status == TransactionStatus.CANCELED.value:
+                logger.error(
+                    f"[Worker {self.worker_id}] Canceled shutdown consensus claim "
+                    f"{row.hash} after {row.recovery_count} recovery cycles"
+                )
+            else:
+                logger.info(
+                    f"[Worker {self.worker_id}] Reset shutdown consensus claim "
+                    f"{row.hash} to PENDING "
+                    f"(cycle {row.recovery_count}/{self._max_recovery_cycles})"
+                )
+
+        self.current_transactions.clear()
+        return {"released": len(released), "reset": len(reset)}
 
     @asynccontextmanager
     async def _transaction_context(

--- a/backend/consensus/worker_service.py
+++ b/backend/consensus/worker_service.py
@@ -3,7 +3,6 @@
 import os
 import sys
 import asyncio
-import signal
 import time
 from contextlib import asynccontextmanager
 from typing import Optional
@@ -23,7 +22,6 @@ import backend.validators as validators
 from loguru import logger
 
 from backend.protocol_rpc.app_lifespan import create_genvm_manager
-
 
 # Configure loguru to route logs correctly for GCP Cloud Logging
 # GCP determines severity by stream: stdout=INFO, stderr=ERROR
@@ -74,7 +72,7 @@ _genvm_failure_unhealthy_threshold: int = int(
     os.environ.get("GENVM_FAILURE_UNHEALTHY_THRESHOLD", "3")
 )
 
-# Graceful shutdown flag - set when SIGTERM received
+# Graceful shutdown flag - set by /stop and lifespan shutdown
 shutting_down: bool = False
 
 
@@ -105,18 +103,10 @@ def get_genvm_failure_count() -> int:
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     """Manage the worker lifecycle."""
-    global worker, worker_task
+    global worker, worker_task, shutting_down
 
-    # Set up signal handlers for graceful shutdown
-    def handle_signal(sig, frame):
-        global shutting_down
-        logger.warning(f"Received signal {sig}, initiating graceful shutdown...")
-        shutting_down = True
-        # Worker will check this flag and stop claiming new transactions
-
-    signal.signal(signal.SIGTERM, handle_signal)
-    signal.signal(signal.SIGINT, handle_signal)
-
+    # Uvicorn owns SIGTERM/SIGINT and drives ASGI lifespan shutdown. Installing
+    # process signal handlers here can block this finally block from running.
     logger.info("Starting Consensus Worker Service...")
     print("Starting Consensus Worker Service...")
 
@@ -308,6 +298,8 @@ async def lifespan(app: FastAPI):
     try:
         yield
     finally:
+        shutting_down = True
+
         # CRITICAL: Always cleanup GenVM processes, even on crash
         # This prevents memory leaks from orphaned genvm subprocesses
 
@@ -315,54 +307,70 @@ async def lifespan(app: FastAPI):
         logger.info("Shutting down Consensus Worker Service...")
         print("Shutting down Consensus Worker Service...")
 
-        # Wait for current transactions to complete (graceful shutdown)
-        if worker and (worker.current_transactions or worker._active_tasks):
-            tx_count = len(worker.current_transactions)
-            task_count = len(worker._active_tasks)
-            logger.info(
-                f"Waiting for {tx_count} transactions / {task_count} tasks to complete before shutdown..."
-            )
-
-            # Get graceful shutdown timeout from env (default: 180 seconds)
-            # This gives the transactions time to finish before we force-stop
-            graceful_timeout = int(
-                os.environ.get("WORKER_GRACEFUL_SHUTDOWN_TIMEOUT_SECONDS", "180")
-            )
-            start_time = time.time()
-
-            while (worker.current_transactions or worker._active_tasks) and (
-                time.time() - start_time
-            ) < graceful_timeout:
-                await asyncio.sleep(1)
-                elapsed = int(time.time() - start_time)
-                if elapsed % 10 == 0:  # Log every 10 seconds
-                    logger.info(
-                        f"Still waiting for {len(worker.current_transactions)} transactions / "
-                        f"{len(worker._active_tasks)} tasks to complete ({elapsed}s elapsed)..."
-                    )
-
-            if worker.current_transactions:
-                logger.warning(
-                    f"Graceful shutdown timeout ({graceful_timeout}s) reached. "
-                    f"{len(worker.current_transactions)} transactions will be released back to the queue."
-                )
-                # Actually release the transactions to free the DB locks
-                for tx_hash in list(worker.current_transactions.keys()):
-                    try:
-                        with worker.get_session() as release_session:
-                            worker.release_transaction(release_session, tx_hash)
-                        logger.info(
-                            f"Successfully released transaction {tx_hash} during shutdown"
-                        )
-                    except Exception as e:
-                        logger.exception(
-                            f"Failed to release transaction {tx_hash} during shutdown: {e}"
-                        )
-                # Clear worker state
-                worker.current_transactions.clear()
-
         if worker:
             worker.stop()
+            tracked_hashes = list(worker.current_transactions.keys())
+            active_tasks = list(worker._active_tasks)
+            if tracked_hashes or active_tasks:
+                logger.info(
+                    f"Abandoning shutdown work for {len(tracked_hashes)} tracked transactions / "
+                    f"{len(active_tasks)} active tasks"
+                )
+            for task in active_tasks:
+                task.cancel()
+        else:
+            tracked_hashes = []
+            active_tasks = []
+
+        # Terminate validators/GenVM early. If liveness is killing this pod
+        # because GenVM is wedged, waiting for active tasks first burns the
+        # Kubernetes grace period and can strand DB claims.
+        if validators_manager:
+            terminate_timeout = float(
+                os.environ.get("WORKER_VALIDATORS_TERMINATE_TIMEOUT_SECONDS", "20")
+            )
+            try:
+                logger.info("Terminating validators manager and GenVM subprocesses...")
+                await asyncio.wait_for(
+                    validators_manager.terminate(),
+                    timeout=terminate_timeout,
+                )
+                logger.info("Validators manager terminated successfully")
+            except asyncio.TimeoutError:
+                logger.error(
+                    f"Timed out terminating validators manager after {terminate_timeout}s"
+                )
+            except Exception as e:
+                logger.error(f"Error terminating validators manager: {e}")
+
+        if active_tasks:
+            task_cancel_timeout = float(
+                os.environ.get("WORKER_TASK_CANCEL_TIMEOUT_SECONDS", "10")
+            )
+            try:
+                await asyncio.wait_for(
+                    asyncio.gather(*active_tasks, return_exceptions=True),
+                    timeout=task_cancel_timeout,
+                )
+            except asyncio.TimeoutError:
+                logger.warning(
+                    f"Timed out waiting {task_cancel_timeout}s for active tasks to cancel"
+                )
+
+        if worker:
+            try:
+                with worker.get_session() as shutdown_session:
+                    summary = worker.abandon_owned_claims_for_shutdown(
+                        shutdown_session,
+                        tracked_hashes=tracked_hashes,
+                    )
+                if summary["released"] or summary["reset"]:
+                    logger.info(
+                        "Abandoned shutdown claims: "
+                        f"{summary['released']} released, {summary['reset']} reset"
+                    )
+            except Exception as e:
+                logger.exception(f"Failed to abandon shutdown claims: {e}")
 
         if worker_task:
             worker_task.cancel()
@@ -370,15 +378,6 @@ async def lifespan(app: FastAPI):
                 await worker_task
             except asyncio.CancelledError:
                 pass
-
-        # Terminate validators manager to shut down background tasks
-        if validators_manager:
-            try:
-                logger.info("Terminating validators manager and GenVM subprocesses...")
-                await validators_manager.terminate()
-                logger.info("Validators manager terminated successfully")
-            except Exception as e:
-                logger.error(f"Error terminating validators manager: {e}")
 
         # Clean up message handler
         if msg_handler:
@@ -651,7 +650,9 @@ async def worker_status():
 @app.get("/stop")
 async def stop_worker():
     """Gracefully stop the worker. Used by K8s preStop lifecycle hook."""
-    global worker
+    global worker, shutting_down
+
+    shutting_down = True
 
     if worker:
         worker.stop()

--- a/tests/db-sqlalchemy/test_worker_shutdown_claim_cleanup.py
+++ b/tests/db-sqlalchemy/test_worker_shutdown_claim_cleanup.py
@@ -1,0 +1,240 @@
+import json
+from datetime import datetime, timedelta, timezone
+from unittest.mock import MagicMock
+
+from sqlalchemy import text
+from sqlalchemy.orm import Session
+
+from backend.consensus.worker import ConsensusWorker
+
+
+def _make_worker(session: Session, worker_id: str = "worker-a") -> ConsensusWorker:
+    return ConsensusWorker(
+        get_session=lambda: session,
+        msg_handler=MagicMock(),
+        consensus_service=MagicMock(),
+        validators_manager=MagicMock(),
+        genvm_manager=MagicMock(),
+        worker_id=worker_id,
+    )
+
+
+def _insert_tx(
+    session: Session,
+    *,
+    tx_hash: str,
+    status: str,
+    worker_id: str | None,
+    blocked_at: datetime | None,
+    recovery_count: int = 0,
+    consensus_history: dict | None = None,
+    consensus_data: dict | None = None,
+):
+    session.execute(
+        text(
+            """
+            INSERT INTO transactions (
+                hash, status, from_address, to_address, data, value, type,
+                nonce, leader_only, execution_mode, appealed, appeal_failed,
+                appeal_undetermined, appeal_leader_timeout,
+                appeal_validators_timeout, appeal_processing_time,
+                recovery_count, value_credited,
+                consensus_history, consensus_data,
+                created_at, blocked_at, worker_id
+            ) VALUES (
+                :hash, CAST(:status AS transaction_status),
+                '0xfromaddress', '0x1111111111111111111111111111111111111111',
+                CAST('{}' AS jsonb), 0, 2,
+                1, false, 'NORMAL', false, 0,
+                false, false, false, 0, :recovery_count, false,
+                CAST(:consensus_history AS jsonb), CAST(:consensus_data AS jsonb),
+                :created_at, :blocked_at, :worker_id
+            )
+            """
+        ),
+        {
+            "hash": tx_hash,
+            "status": status,
+            "recovery_count": recovery_count,
+            "consensus_history": (
+                json.dumps(consensus_history) if consensus_history is not None else None
+            ),
+            "consensus_data": (
+                json.dumps(consensus_data) if consensus_data is not None else None
+            ),
+            "created_at": datetime.now(timezone.utc) - timedelta(minutes=30),
+            "blocked_at": blocked_at,
+            "worker_id": worker_id,
+        },
+    )
+
+
+def _get_tx(session: Session, tx_hash: str):
+    return session.execute(
+        text(
+            """
+            SELECT hash, status::text AS status, worker_id, blocked_at,
+                   recovery_count, consensus_history, consensus_data
+            FROM transactions
+            WHERE hash = :hash
+            """
+        ),
+        {"hash": tx_hash},
+    ).one()
+
+
+def test_shutdown_cleanup_resets_owned_consensus_claims(session: Session):
+    now = datetime.now(timezone.utc)
+    owned_hash = "0x" + "01" * 32
+    tracked_hash = "0x" + "02" * 32
+    other_worker_hash = "0x" + "03" * 32
+
+    _insert_tx(
+        session,
+        tx_hash=owned_hash,
+        status="COMMITTING",
+        worker_id="worker-a",
+        blocked_at=now,
+        consensus_history={"current_monitoring": {"COMMITTING": 1}},
+        consensus_data={"partial": True},
+    )
+    _insert_tx(
+        session,
+        tx_hash=tracked_hash,
+        status="REVEALING",
+        worker_id=None,
+        blocked_at=None,
+        recovery_count=1,
+        consensus_history={"current_monitoring": {"REVEALING": 2}},
+        consensus_data={"partial": True},
+    )
+    _insert_tx(
+        session,
+        tx_hash=other_worker_hash,
+        status="COMMITTING",
+        worker_id="worker-b",
+        blocked_at=now,
+        consensus_history={"current_monitoring": {"COMMITTING": 3}},
+        consensus_data={"partial": True},
+    )
+    session.commit()
+
+    worker = _make_worker(session)
+
+    summary = worker.abandon_owned_claims_for_shutdown(
+        session, tracked_hashes=[tracked_hash]
+    )
+
+    assert summary == {"released": 0, "reset": 2}
+
+    owned = _get_tx(session, owned_hash)
+    assert owned.status == "PENDING"
+    assert owned.worker_id is None
+    assert owned.blocked_at is None
+    assert owned.recovery_count == 1
+    assert owned.consensus_history is None
+    assert owned.consensus_data is None
+
+    tracked = _get_tx(session, tracked_hash)
+    assert tracked.status == "PENDING"
+    assert tracked.worker_id is None
+    assert tracked.recovery_count == 2
+    assert tracked.consensus_history is None
+    assert tracked.consensus_data is None
+
+    other = _get_tx(session, other_worker_hash)
+    assert other.status == "COMMITTING"
+    assert other.worker_id == "worker-b"
+    assert other.blocked_at is not None
+    assert other.recovery_count == 0
+
+
+def test_shutdown_cleanup_preserves_finalization_state(session: Session):
+    now = datetime.now(timezone.utc)
+    owned_hash = "0x" + "11" * 32
+    tracked_hash = "0x" + "12" * 32
+    other_worker_hash = "0x" + "13" * 32
+
+    _insert_tx(
+        session,
+        tx_hash=owned_hash,
+        status="ACCEPTED",
+        worker_id="worker-a",
+        blocked_at=now,
+        consensus_history={"current_monitoring": {"ACCEPTED": 1}},
+        consensus_data={"receipt": "kept"},
+    )
+    _insert_tx(
+        session,
+        tx_hash=tracked_hash,
+        status="UNDETERMINED",
+        worker_id=None,
+        blocked_at=None,
+        consensus_history={"current_monitoring": {"UNDETERMINED": 2}},
+        consensus_data={"receipt": "also-kept"},
+    )
+    _insert_tx(
+        session,
+        tx_hash=other_worker_hash,
+        status="LEADER_TIMEOUT",
+        worker_id="worker-b",
+        blocked_at=now,
+        consensus_history={"current_monitoring": {"LEADER_TIMEOUT": 3}},
+        consensus_data={"receipt": "other"},
+    )
+    session.commit()
+
+    worker = _make_worker(session)
+
+    summary = worker.abandon_owned_claims_for_shutdown(
+        session, tracked_hashes=[tracked_hash]
+    )
+
+    assert summary == {"released": 2, "reset": 0}
+
+    owned = _get_tx(session, owned_hash)
+    assert owned.status == "ACCEPTED"
+    assert owned.worker_id is None
+    assert owned.blocked_at is None
+    assert owned.consensus_history == {"current_monitoring": {"ACCEPTED": 1}}
+    assert owned.consensus_data == {"receipt": "kept"}
+
+    tracked = _get_tx(session, tracked_hash)
+    assert tracked.status == "UNDETERMINED"
+    assert tracked.worker_id is None
+    assert tracked.consensus_history == {"current_monitoring": {"UNDETERMINED": 2}}
+    assert tracked.consensus_data == {"receipt": "also-kept"}
+
+    other = _get_tx(session, other_worker_hash)
+    assert other.status == "LEADER_TIMEOUT"
+    assert other.worker_id == "worker-b"
+    assert other.blocked_at is not None
+    assert other.consensus_data == {"receipt": "other"}
+
+
+def test_shutdown_cleanup_escalates_repeatedly_reset_claims(session: Session):
+    tx_hash = "0x" + "21" * 32
+    _insert_tx(
+        session,
+        tx_hash=tx_hash,
+        status="COMMITTING",
+        worker_id="worker-a",
+        blocked_at=datetime.now(timezone.utc),
+        recovery_count=2,
+        consensus_history={"current_monitoring": {"COMMITTING": 1}},
+        consensus_data={"partial": True},
+    )
+    session.commit()
+
+    worker = _make_worker(session)
+
+    summary = worker.abandon_owned_claims_for_shutdown(session)
+
+    assert summary == {"released": 0, "reset": 1}
+    row = _get_tx(session, tx_hash)
+    assert row.status == "CANCELED"
+    assert row.worker_id is None
+    assert row.blocked_at is None
+    assert row.recovery_count == 3
+    assert row.consensus_history is None
+    assert row.consensus_data["error"] == "max_recovery_cycles_exceeded"


### PR DESCRIPTION
## Summary
- remove the worker service's custom SIGTERM/SIGINT handler so Uvicorn can run ASGI lifespan shutdown
- on shutdown, stop claiming work, terminate validators/GenVM subprocesses quickly, cancel active tasks, then release/reset this worker's owned transaction claims
- preserve finalization-ready transaction state while resetting in-progress consensus statuses back to retryable PENDING, with recovery-count exhaustion still canceling repeated failures
- add DB coverage for owned claim reset, finalization-state preservation, and recovery exhaustion during shutdown cleanup

## Context
Rally prod canary evidence showed the worker received `/stop` and SIGTERM, the worker supervisor stopped quickly, but the process stayed alive until Kubernetes killed it with exit 137. This PR makes termination deterministic and prevents a terminating worker from stranding owned transaction claims when GenVM or active work does not complete inside the pod grace period.

## Verification
- `python3 -m py_compile backend/consensus/worker.py backend/consensus/worker_service.py tests/db-sqlalchemy/test_worker_shutdown_claim_cleanup.py`
- `pytest tests/db-sqlalchemy/test_worker_shutdown_claim_cleanup.py` could not run locally because this environment is missing `alembic` (`ModuleNotFoundError: No module named 'alembic'`).
- commit hooks passed: trailing whitespace, large files, JSON/YAML checks, merge conflict check, branch check, autoflake, black, eslint/prettier skips for no frontend files