### PR TITLE
Port studio to genvm-manager (v0.3)

### DIFF
--- a/.github/workflows/backend_integration_tests_pr.yml
+++ b/.github/workflows/backend_integration_tests_pr.yml
@@ -83,7 +83,7 @@ jobs:
             fi
           fi
           if [[ -n "$GENVM_REF_VALUE" ]]; then
-            GENVM_REF_VALUE="$(gh api "repos/genlayerlabs/genvm/commits/$GENVM_REF_VALUE" --jq .sha)"
+            GENVM_REF_VALUE="$(gh api "repos/genlayerlabs/genvm-manager/commits/$GENVM_REF_VALUE" --jq .sha)"
           fi
           sed -i "s|^GENVM_TAG=.*|GENVM_TAG=\"$GENVM_TAG_VALUE\"|" .env
           sed -i "s|^GENVM_REF=.*|GENVM_REF=\"$GENVM_REF_VALUE\"|" .env
@@ -283,7 +283,7 @@ jobs:
             fi
           fi
           if [[ -n "$GENVM_REF_VALUE" ]]; then
-            GENVM_REF_VALUE="$(gh api "repos/genlayerlabs/genvm/commits/$GENVM_REF_VALUE" --jq .sha)"
+            GENVM_REF_VALUE="$(gh api "repos/genlayerlabs/genvm-manager/commits/$GENVM_REF_VALUE" --jq .sha)"
           fi
           sed -i "s|^GENVM_TAG=.*|GENVM_TAG=\"$GENVM_TAG_VALUE\"|" .env
           sed -i "s|^GENVM_REF=.*|GENVM_REF=\"$GENVM_REF_VALUE\"|" .env

--- a/.github/workflows/load-test-oha.yml
+++ b/.github/workflows/load-test-oha.yml
@@ -102,7 +102,7 @@ jobs:
             fi
           fi
           if [[ -n "$GENVM_REF_VALUE" ]]; then
-            GENVM_REF_VALUE="$(gh api "repos/genlayerlabs/genvm/commits/$GENVM_REF_VALUE" --jq .sha)"
+            GENVM_REF_VALUE="$(gh api "repos/genlayerlabs/genvm-manager/commits/$GENVM_REF_VALUE" --jq .sha)"
           fi
           sed -i "s|^GENVM_TAG=.*|GENVM_TAG=\"$GENVM_TAG_VALUE\"|" .env
           sed -i "s|^GENVM_REF=.*|GENVM_REF=\"$GENVM_REF_VALUE\"|" .env

--- a/backend/node/base.py
+++ b/backend/node/base.py
@@ -74,22 +74,16 @@ def _env_bool(name: str, default: bool = False) -> bool:
     return raw.strip().lower() in {"1", "true", "yes", "on"}
 
 
-def _genvm_extra_args() -> list[str]:
-    """Extra CLI args for the genvm executor.
+def _genvm_debug_mode() -> str:
+    """genvm-manager `debug_mode` level for the run request.
 
-    `--debug-mode` enables the `:latest` and `:test` runner version
-    aliases (see genvm/executor/src/exe/run.rs:58-62). Convenient in
-    dev/stg where you want to iterate without pinning a specific runner
-    hash, but a footgun in prd: those aliases float, so two validators
-    on the same tx can resolve different runner binaries — breaks
-    determinism / consensus.
-
-    Gated on GENVM_DEBUG_MODE (default true to preserve dev/stg
-    convenience). Prd manifests should set GENVM_DEBUG_MODE=false so
-    contracts that try to use `py-genlayer:latest` or `py-genlayer:test`
-    fail fast at the executor.
+    `unsafe` (dev/stg default) captures unbounded output and enables the
+    `:latest`/`:test` runner aliases that studio's bundled contracts depend
+    on; only `unsafe`/`unsafe-tracing` resolve those floating aliases. Prd
+    sets GENVM_DEBUG_MODE=false -> `safe` (consensus-safe) so the aliases
+    fail fast.
     """
-    return ["--debug-mode"] if _env_bool("GENVM_DEBUG_MODE", default=True) else []
+    return "unsafe" if _env_bool("GENVM_DEBUG_MODE", default=True) else "safe"
 
 
 def _filter_genvm_log_by_level(genvm_log: list[dict]) -> list[dict]:
@@ -919,6 +913,7 @@ class Node:
             "contract_address": NO_ADDR,
             "sender_address": NO_ADDR,
             "origin_address": NO_ADDR,
+            "signer_address": NO_ADDR,
             "value": 0,
             "chain_id": 0,
         }
@@ -930,16 +925,16 @@ class Node:
             functools.partial(
                 genvmbase.Host,
                 calldata_bytes=calldata.encode(
-                    {"method": public_abi.SpecialMethod.GET_SCHEMA.value}
+                    {"": public_abi.SpecialMethod.GET_SCHEMA.value}
                 ),
                 state_proxy=state_proxy,
                 leader_results=None,
             ),
             message=message,
             permissions="rw",
-            extra_args=_genvm_extra_args(),
             host_data='{"node_address":"0x", "tx_id":"0x"}',
             capture_output=True,
+            debug_mode=_genvm_debug_mode(),
             is_sync=True,
             logger=self.logger,
             timeout=30,
@@ -1040,6 +1035,7 @@ class Node:
             "contract_address": contract_address,
             "sender_address": Address(from_address),
             "origin_address": Address(origin_address or from_address),
+            "signer_address": Address(origin_address or from_address),
             "value": int(value),
             "chain_id": get_simulator_chain_id(),
         }
@@ -1069,8 +1065,8 @@ class Node:
                 message=message,
                 permissions=perms,
                 capture_output=True,
+                debug_mode=_genvm_debug_mode(),
                 host_data=json.dumps(host_data),
-                extra_args=_genvm_extra_args(),
                 is_sync=is_sync,
                 manager_uri=self.manager.url,
                 timeout=timeout,

--- a/backend/node/genvm/__init__.py
+++ b/backend/node/genvm/__init__.py
@@ -1,5 +1,8 @@
 import hashlib
 
+from backend.node.genvm.origin.public_abi import root_offsets
+
 
 def get_code_slot() -> bytes:
-    return hashlib.sha3_256(b"\x00" * 32 + b"\x01\x00\x00\x00").digest()
+    offset = root_offsets.CODE.to_bytes(4, byteorder="little", signed=False)
+    return hashlib.sha3_256(b"\x00" * 32 + offset).digest()

--- a/backend/node/genvm/base.py
+++ b/backend/node/genvm/base.py
@@ -737,6 +737,7 @@ async def run_genvm_host(
     logger: genvm_logger.Logger | None = None,
     is_sync: bool,
     capture_output: bool = True,
+    debug_mode: str | None = None,
     message: typing.Any,
     host_data: str = "",
     extra_args: list[str] = [],
@@ -749,6 +750,7 @@ async def run_genvm_host(
     ctx = Context(logger=logger)
     fee_context = fee_context or GenVMFeeContext()
     effective_bucket_totals = fee_context.bucket_totals or [
+        10_000_000,
         10_000_000,
         10_000_000,
         10_000_000,
@@ -823,6 +825,7 @@ async def run_genvm_host(
                         message=message,
                         timeout=timeout,
                         capture_output=capture_output,
+                        debug_mode=debug_mode,
                         is_sync=is_sync,
                         host_data=host_data,
                         ctx=ctx,

--- a/backend/node/genvm/origin/__init__.py
+++ b/backend/node/genvm/origin/__init__.py
@@ -1,1 +1,0 @@
-# This code is taken from genvm repo

--- a/backend/node/genvm/origin/base_host.py
+++ b/backend/node/genvm/origin/base_host.py
@@ -1,31 +1,40 @@
-"""
-This module is a part of GenVM source code. When updating
-
-#. Open PR to https://github.com/genlayerlabs/genvm/blob/main/tests/runner/origin/base_host.py
-#. Keep interface integration-agnostic: no usage of environment variables, no assumptions
-"""
-
+import abc
+import asyncio
 import enum
 import socket
-import typing
-import asyncio
-import abc
 import time
+import typing
+from dataclasses import dataclass
 
 import aiohttp
 
-from dataclasses import dataclass
-
-
+from . import (
+    calldata as gvm_calldata,
+)
+from . import (
+    fees,
+    host_fns,
+    public_abi,
+)
 from .calldata import Address
-from . import calldata as gvm_calldata
-from . import fees
-from . import host_fns
-from . import public_abi
+from .logger import Logger
 
 ACCOUNT_ADDR_SIZE = 20
 SLOT_ID_SIZE = 32
 
+# Mirrors the executor's `DebugMode` enum (crates/common/src/debug_mode.rs).
+DebugMode = typing.Literal[
+    "disabled",
+    "safe",
+    "safe-unbounded",
+    "unsafe",
+    "unsafe-tracing",
+]
+
+# Default host-provided `node` fee constants (see fees.expr_prelude in
+# install/config/genvm.yaml). Values are strings (gas_data is Map<str, str>)
+# and are kept minimal/deterministic for tests. `validatorsPerRound` is
+# intentionally omitted so the prelude default table is used.
 DEFAULT_GAS_DATA: dict[str, str] = {
     "storageUnitPrice": "1",
     "receiptGasPerByte": "1",
@@ -35,10 +44,12 @@ DEFAULT_GAS_DATA: dict[str, str] = {
     "fixedProposeReceiptGas": "0",
     "fixedMessageRevealGas": "0",
     "genPerTimeUnit": "0",
+    # 0 = no per-phase timeunit floor, so default-allocation tests are unaffected.
+    "minTimeUnitsPerPhase": "0",
+    # 0 = no per-round execution-budget floor for balance-funded messages.
+    "messageBudgetFloor": "0",
 }
 DEFAULT_INITIAL_TIME_UNITS_ALLOCATION = 10 * 60
-
-from .logger import Logger
 
 
 class TimeoutAction(enum.StrEnum):
@@ -121,6 +132,7 @@ class Message(typing.TypedDict):
     contract_address: Address
     sender_address: Address
     origin_address: Address
+    signer_address: Address
     chain_id: int
     value: typing.NotRequired[int]
     is_init: bool
@@ -142,11 +154,9 @@ class EthSendInner(typing.TypedDict):
     address: Address
     calldata: bytes
     value: int
-    feeParams: typing.NotRequired[bytes]
-    fee_params: typing.NotRequired[fees.ExternalMessageParams]
-    declaredBudget: typing.NotRequired[int]
-    callKey: typing.NotRequired[bytes]
-    allocationSubtree: typing.NotRequired[list[dict]]
+    message_fee: int
+    receipt_fee: int
+    fee_params: fees.ExternalMessageParams
 
 
 class PostMessageInner(typing.TypedDict):
@@ -155,12 +165,13 @@ class PostMessageInner(typing.TypedDict):
     calldata: gvm_calldata.Decoded
     value: int
     on: typing.Literal["finalized", "accepted"]
-    feeParams: typing.NotRequired[bytes]
-    fee_params: typing.NotRequired[fees.InternalMessageParams]
-    declaredBudget: typing.NotRequired[int]
-    callKey: typing.NotRequired[bytes]
-    allocationSubtree: typing.NotRequired[list[dict]]
-    subtree: typing.NotRequired[bytes]
+    message_fee: int
+    receipt_fee: int
+    fee_params: fees.InternalMessageParams
+    # ABI-encoded allocation subtree carried in the receipt under commitment modes.
+    subtree: bytes
+    # Chain `useBalance`: fee funded from the emitting contract's balance.
+    use_balance: bool
 
 
 class DeployContractInner(typing.TypedDict):
@@ -170,18 +181,20 @@ class DeployContractInner(typing.TypedDict):
     value: int
     on: typing.Literal["finalized", "accepted"]
     salt_nonce: int
-    feeParams: typing.NotRequired[bytes]
-    fee_params: typing.NotRequired[fees.InternalMessageParams]
-    declaredBudget: typing.NotRequired[int]
-    callKey: typing.NotRequired[bytes]
-    allocationSubtree: typing.NotRequired[list[dict]]
-    subtree: typing.NotRequired[bytes]
+    message_fee: int
+    receipt_fee: int
+    fee_params: fees.InternalMessageParams
+    # ABI-encoded allocation subtree carried in the receipt under commitment modes.
+    subtree: bytes
+    # Chain `useBalance`: fee funded from the emitting contract's balance.
+    use_balance: bool
 
 
 class EmitEventInner(typing.TypedDict):
     type: typing.Literal["EmitEvent"]
     topics: list[bytes]
     blob: dict[str, gvm_calldata.Decoded]
+    storage_fee: int
 
 
 type ResultEmission = typing.Union[
@@ -370,8 +383,6 @@ async def host_loop(
                 )
                 return None
             case host_fns.Methods.CONSUME_FUEL:
-                # GenVM main sends fuel as a 32-byte little-endian U256
-                # (rc3 used 8 bytes); see executor/src/host/mod.rs consume_fuel.
                 gas = await recv_int(32)
                 await handler.consume_gas(gas)
             case host_fns.Methods.ETH_CALL:
@@ -402,15 +413,7 @@ async def host_loop(
                 except HostException as e:
                     await send_all(bytes([e.error_code]))
                 else:
-                    res = min(res, 2**53 - 1)
                     await send_all(bytes([host_fns.Errors.OK]))
-                    # GenVM main reads a 32-byte little-endian U256 here (rc3
-                    # read 8 bytes). Sending only 8 left the executor blocked
-                    # on the remaining 24 bytes while this loop waited for the
-                    # next method — a read-read deadlock that stalled every
-                    # nondet (exec_prompt/web) execution in PROPOSING until
-                    # LEADER_TIMEOUT. See executor/src/host/mod.rs
-                    # remaining_fuel_as_gen and wasi/genlayer_sdk.rs call sites.
                     await send_all(res.to_bytes(32, byteorder="little", signed=False))
             case host_fns.Methods.NOTIFY_NONDET_DISAGREEMENT:
                 call_no = await recv_int()
@@ -490,20 +493,34 @@ async def run_genvm(
     ctx: Context,
     is_sync: bool,
     capture_output: bool = True,
+    debug_mode: DebugMode | None = None,
     message: Message,
     host_data: str = "",
     gas_data: dict[str, str] | None = None,
     host: str,
     extra_args: list[str] = [],
+    # default config fee buckets use bucket_no 0 and 1
     bucket_totals: list[int] | None = None,
     code: bytes | None = None,
     calldata: bytes,
     leader_nondet_results: list[bytes] | None = None,
     message_fee_allocation: list[fees.MessageAllocationNode] | None = None,
+    reroute_to: str = "",
     request_extra: dict[str, gvm_calldata.Encodable] = {},
+    shutdown_early: asyncio.Event | None = None,
 ) -> RunHostAndProgramRes:
     logger = ctx.logger
-    effective_bucket_totals = bucket_totals or [10_000_000, 10_000_000, 10_000_000]
+
+    # `node` fee constants are an ExecutionData field (no longer in host_data).
+    effective_debug_mode = debug_mode or (
+        "safe-unbounded" if capture_output else "disabled"
+    )
+    effective_bucket_totals = bucket_totals or [
+        10_000_000,
+        10_000_000,
+        10_000_000,
+        10_000_000,
+    ]
     effective_gas_data = DEFAULT_GAS_DATA if gas_data is None else gas_data
     effective_message_fee_allocation = message_fee_allocation or []
 
@@ -532,7 +549,7 @@ async def run_genvm(
                     "major": 0,  # FIXME
                     "message": message,
                     "is_sync": is_sync,
-                    "capture_output": capture_output,
+                    "debug_mode": effective_debug_mode,
                     "host_data": host_data,
                     "max_execution_minutes": max_exec_mins,  # this parameter is needed to prevent zombie genvms
                     "timestamp": timestamp,
@@ -545,6 +562,9 @@ async def run_genvm(
                     "gas_data": effective_gas_data,
                     "message_fee_allocation": effective_message_fee_allocation,
                     "initial_time_units_allocation": DEFAULT_INITIAL_TIME_UNITS_ALLOCATION,
+                    # Debug-only executor-dir override; honored by the manager only
+                    # under debug_mode >= safe (tests run with safe/unsafe).
+                    "reroute_to": reroute_to,
                     **request_extra,
                 }
             ),
@@ -555,7 +575,7 @@ async def run_genvm(
             logger.trace("post /genvm/run", body=data)
             if resp.status != 200:
                 logger.error(
-                    f"genvm manager /genvm/run failed", status=resp.status, body=data
+                    "genvm manager /genvm/run failed", status=resp.status, body=data
                 )
                 if _is_retryable_manager_run_error(resp.status, data):
                     raise GenVMManagerRetryableError(resp.status, data)
@@ -647,10 +667,24 @@ async def run_genvm(
     timeout_fired = asyncio.Event()
 
     async def wrap_timeout(genvm_id: str):
+        reason = "unknown"
         if timeout is None:
-            return
-        await asyncio.sleep(timeout)
-        logger.debug("timeout reached", genvm_id=genvm_id)
+            if shutdown_early is None:
+                return  # nothing to do
+            else:
+                await shutdown_early.wait()
+                reason = "shutdown_early event set"
+        else:
+            if shutdown_early is None:
+                await asyncio.sleep(timeout)
+                reason = "timeout reached"
+            else:
+                try:
+                    await asyncio.wait_for(shutdown_early.wait(), timeout=timeout)
+                    reason = "shutdown_early event set"
+                except asyncio.TimeoutError:
+                    reason = "timeout reached"
+        logger.debug("timeout reached", genvm_id=genvm_id, reason=reason)
         timeout_fired.set()
         await _send_timeout(
             manager_uri,
@@ -877,7 +911,7 @@ async def run_genvm(
 
         if timeout_fired.is_set() and result_kind != public_abi.ResultCode.RETURN:
             result_kind = public_abi.ResultCode.VM_ERROR
-            result_data = str(public_abi.VmError.TIMEOUT)
+            result_data = str(public_abi.VmError.timeout())
 
         vm_error_description: str | None = None
         if result_kind == public_abi.ResultCode.VM_ERROR and isinstance(

--- a/backend/node/genvm/origin/calldata.py
+++ b/backend/node/genvm/origin/calldata.py
@@ -1,19 +1,25 @@
-from ...types import Address
-
 """
-This module is responsible for working with genvm calldata
+GenVM calldata encoding and decoding module.
+
+This module provides:
+
+* ``encode``: Encode Python objects to calldata bytes
+* ``decode``: Decode calldata bytes to Python objects
+* ``to_str``: Human-readable string representation
+* ``CalldataEncodable``: ABC for custom encoding
+* Type aliases: ``Encodable``, ``Decoded``, ``EncodableWithDefault``
 
 Calldata natively supports following types:
 
 #. Primitive types:
 
-	#. python built-in: :py:class:`bool`, :py:obj:`None`, :py:class:`int`, :py:class:`str`, :py:class:`bytes`
-	#. :py:meth:`~genlayer.py.types.Address` type
+    #. python built-in: :py:class:`bool`, :py:obj:`None`, :py:class:`int`, :py:class:`str`, :py:class:`bytes`
+    #. :py:meth:`~genlayer.types.Address` type
 
 #. Composite types:
 
-	#. :py:class:`list` (and any other :py:class:`collections.abc.Sequence`)
-	#. :py:class:`dict` with :py:class:`str` keys (and any other :py:class:`collections.abc.Mapping` with :py:class:`str` keys)
+    #. :py:class:`list` (and any other :py:class:`collections.abc.Sequence`)
+    #. :py:class:`dict` with :py:class:`str` keys (and any other :py:class:`collections.abc.Mapping` with :py:class:`str` keys)
 
 For full calldata specification see `genvm repo <https://github.com/yeagerai/genvm/blob/main/doc/calldata.md>`_
 """
@@ -23,18 +29,42 @@ __all__ = (
     "decode",
     "to_str",
     "Encodable",
-    "Encodable",
     "EncodableWithDefault",
     "Decoded",
     "CalldataEncodable",
     "DecodingError",
 )
 
-import typing
-import collections.abc
-import dataclasses
 import abc
+import collections.abc
+import contextlib
+import dataclasses
 import json
+import typing
+
+
+@contextlib.contextmanager
+def context_notes(msg: str):
+    """
+    Helper context manager to add context to exceptions
+
+    .. warning::
+        This is a temporary workaround for lack of exception chaining in Python 3.11
+    """
+    try:
+        yield
+    except BaseException as e:
+        e.add_note(msg)
+        raise
+
+
+# GenLayer Address. This node already defines the canonical `Address` in
+# `backend.node.types`; import it here so the calldata encoder/decoder and the
+# node share a single type (a node `Address` in a message must encode as
+# SPECIAL_ADDR, and `decode` yields the same type the node uses everywhere).
+from backend.node.types import Address as Address
+
+Address.ZERO = Address(b"\x00" * 20)
 
 BITS_IN_TYPE = 3
 
@@ -65,7 +95,7 @@ class CalldataEncodable(metaclass=abc.ABCMeta):
         Override this method to return calldata-compatible type
 
         .. warning::
-                returning ``self`` may lead to an infinite loop or an exception
+            returning ``self`` may lead to an infinite loop or an exception
         """
         raise NotImplementedError()
 
@@ -99,7 +129,8 @@ Type that can be encoded into calldata, provided ``default`` function ``T -> Enc
 def encode_default_parameter(b):
     if not dataclasses.is_dataclass(b):
         return b
-    assert not isinstance(b, type)
+    if isinstance(b, type):
+        raise TypeError(f"expected dataclass instance, got type {b!r}")
 
     return {field.name: getattr(b, field.name) for field in dataclasses.fields(b)}
 
@@ -108,6 +139,7 @@ def encode[
     T
 ](
     x: EncodableWithDefault[T],
+    /,
     *,
     default: typing.Callable[
         [EncodableWithDefault[T]], Encodable
@@ -119,16 +151,17 @@ def encode[
     :param default: function to be applied to each object recursively, it must return object encodable to calldata
 
     .. warning::
-            All composite types in the end are coerced to :py:class:`dict` and :py:class:`list`, so custom type information is *not* be preserved.
-            Such types include:
+        All composite types in the end are coerced to :py:class:`dict` and :py:class:`list`, so custom type information is *not* be preserved.
+        Such types include:
 
-            #. :py:class:`CalldataEncodable`
-            #. :py:mod:`dataclasses`
+        #. :py:class:`CalldataEncodable`
+        #. :py:mod:`dataclasses`
     """
     mem = bytearray()
 
     def append_uleb128(i):
-        assert i >= 0
+        if i < 0:
+            raise ValueError(f"uleb128 requires non-negative integer, got {i}")
         if i == 0:
             mem.append(0)
         while i > 0:
@@ -145,12 +178,13 @@ def encode[
         le = (le << 3) | TYPE_MAP
         append_uleb128(le)
         for k in keys:
-            if not isinstance(k, str):
-                raise TypeError(f"key is not string `{repr(k)}`")
-            bts = k.encode("utf-8")
-            append_uleb128(len(bts))
-            mem.extend(bts)
-            impl(b[k])
+            with context_notes(f"key {k!r}"):
+                if not isinstance(k, str):
+                    raise TypeError(f"key is not string {type(k)}")
+                bts = k.encode("utf-8")
+                append_uleb128(len(bts))
+                mem.extend(bts)
+                impl(b[k])
 
     def impl(b: EncodableWithDefault[T]):
         b = default(b)
@@ -207,6 +241,7 @@ class DecodingError(ValueError):
 
 def decode(
     mem0: collections.abc.Buffer,
+    /,
     *,
     memview2bytes: typing.Callable[[memoryview], typing.Any] = bytes,
 ) -> Decoded:
@@ -280,7 +315,8 @@ def decode(
                             f"unordered calldata keys: `{prev}` >= `{key}`"
                         )
                 prev = key
-                assert key not in ret_dict
+                if key in ret_dict:
+                    raise DecodingError(f"duplicate calldata map key `{key}`")
                 ret_dict[key] = impl()
             return ret_dict
         raise DecodingError(f"invalid type {typ}")
@@ -291,13 +327,13 @@ def decode(
     return res
 
 
-def to_str(d: Encodable) -> str:
+def to_str(d: Encodable, /) -> str:
     """
     Transforms calldata DSL into human readable json-like format, should be used for debug purposes only
     """
     buf: list[str] = []
 
-    def impl(d: Encodable) -> None:
+    def impl(d: Encodable, /) -> None:
         if d is None:
             buf.append("null")
         elif d is True:

--- a/backend/node/genvm/origin/fees.py
+++ b/backend/node/genvm/origin/fees.py
@@ -1,7 +1,8 @@
 """Message-fee allocation tree types.
 
-Mirrors GenVM's ``tests/runner/origin/fees.py`` for the manager request
-schema used by main/rc4+.
+Mirrors the executor's `genvm_common::domain::fees` module: the fee parameters
+and the nested `MessageAllocationNode` tree that is passed alongside an
+execution and matched against emitted messages.
 """
 
 import typing
@@ -13,6 +14,8 @@ class InternalMessageParams(typing.TypedDict):
     leader_timeunits_allocation: int
     validator_timeunits_allocation: int
     execution_budget_per_round: int
+    # `appealRounds` is not carried here; the chain derives it as
+    # `len(rotations) - 1`, so `rotations` must be non-empty.
     rotations: list[int]
     max_price_gen_per_time_unit: int
     storage_fee_max_gas_price: int
@@ -24,6 +27,7 @@ class ExternalMessageParams(typing.TypedDict):
     max_gas_price: int
 
 
+# Externally-tagged `MessageAllocationNodeParams` enum: exactly one of the keys.
 class _InternalParams(typing.TypedDict):
     Internal: InternalMessageParams
 
@@ -39,6 +43,63 @@ class MessageAllocationNode(typing.TypedDict):
     recipient: Address | None
     call_key: bytes | None
     budget: int
+    # Lifecycle the node matches against (only meaningful for internal messages).
     on: typing.Literal["finalized", "accepted"]
     fee_params: MessageAllocationNodeParams
+    # Nested allocation subtree; the chain receives this flattened to
+    # parent-pointer form.
     children: list["MessageAllocationNode"]
+
+
+DEFAULT_EXTERNAL_MESSAGE_ALLOC: MessageAllocationNode = {
+    "budget": 2**200,
+    "recipient": None,
+    "call_key": None,
+    # Unused for external messages (no acceptance/finalize lifecycle).
+    "on": "finalized",
+    "fee_params": {
+        "External": {
+            "gas_limit": 2**200,
+            "max_gas_price": 0,
+        },
+    },
+    "children": [],
+}
+
+DEFAULT_INTERNAL_ACC_MESSAGE_ALLOC: MessageAllocationNode = {
+    "budget": 2**200,
+    "recipient": None,
+    "call_key": None,
+    "on": "accepted",
+    "fee_params": {
+        "Internal": {
+            "execution_budget_per_round": 2**10,
+            "rotations": [4] * 5,
+            "leader_timeunits_allocation": 5,
+            "validator_timeunits_allocation": 5,
+            "max_price_gen_per_time_unit": 2**200,
+            "storage_fee_max_gas_price": 2**200,
+            "receipt_fee_max_gas_price": 2**200,
+        },
+    },
+    "children": [],
+}
+
+DEFAULT_INTERNAL_FIN_MESSAGE_ALLOC: MessageAllocationNode = {
+    "budget": 2**200,
+    "recipient": None,
+    "call_key": None,
+    "on": "finalized",
+    "fee_params": {
+        "Internal": {
+            "execution_budget_per_round": 2**10,
+            "rotations": [4] * 5,
+            "leader_timeunits_allocation": 5,
+            "validator_timeunits_allocation": 5,
+            "max_price_gen_per_time_unit": 2**200,
+            "storage_fee_max_gas_price": 20,
+            "receipt_fee_max_gas_price": 20,
+        },
+    },
+    "children": [],
+}

--- a/backend/node/genvm/origin/host_fns.py
+++ b/backend/node/genvm/origin/host_fns.py
@@ -1,7 +1,10 @@
 # This file is auto-generated. Do not edit!
 
-from enum import IntEnum
+# fmt: off
+# ruff: noqa
+
 import typing
+from enum import IntEnum
 
 
 class Methods(IntEnum):
@@ -17,12 +20,25 @@ class Methods(IntEnum):
 
 class Errors(IntEnum):
     OK = 0
-    ABSENT = 1
+    EVM_REVERTED = 1
     FORBIDDEN = 2
-    OUT_OF_STORAGE_GAS = 3
+
+class VmErrorDetail:
+    __slots__ = ('value',)
+    def __init__(self, value: str):
+        self.value = value
+    def __str__(self) -> str:
+        return self.value
+    @staticmethod
+    def internal() -> 'VmErrorDetail':
+        return VmErrorDetail('internal')
+    @staticmethod
+    def external() -> 'VmErrorDetail':
+        return VmErrorDetail('external')
+
 
 
 CURRENT_MAJOR: typing.Final[int] = 0
 
 
-CURRENT_MAJOR_STR: typing.Final[str] = "v0.0.0"
+CURRENT_MAJOR_STR: typing.Final[str] = 'v0.0.0'

--- a/backend/node/genvm/origin/keccak.py
+++ b/backend/node/genvm/origin/keccak.py
@@ -1,0 +1,439 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership. The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# NOTE: source code from https://github.com/ctz/keccak
+# some code was truncated for use in this project
+"""
+Implements keccak hash
+
+Source code is taken from `https://github.com/ctz/keccak <https://github.com/ctz/keccak>`_ (Apache 2.0 license)
+"""
+
+__all__ = ("Keccak256", "KeccakHash")
+
+import collections.abc
+from copy import deepcopy
+from functools import reduce
+from math import log
+from operator import xor
+
+# The Keccak-f round constants.
+RoundConstants = [
+    0x0000000000000001,
+    0x0000000000008082,
+    0x800000000000808A,
+    0x8000000080008000,
+    0x000000000000808B,
+    0x0000000080000001,
+    0x8000000080008081,
+    0x8000000000008009,
+    0x000000000000008A,
+    0x0000000000000088,
+    0x0000000080008009,
+    0x000000008000000A,
+    0x000000008000808B,
+    0x800000000000008B,
+    0x8000000000008089,
+    0x8000000000008003,
+    0x8000000000008002,
+    0x8000000000000080,
+    0x000000000000800A,
+    0x800000008000000A,
+    0x8000000080008081,
+    0x8000000000008080,
+    0x0000000080000001,
+    0x8000000080008008,
+]
+
+RotationConstants = [
+    [0, 1, 62, 28, 27],
+    [36, 44, 6, 55, 20],
+    [3, 10, 43, 25, 39],
+    [41, 45, 15, 21, 8],
+    [18, 2, 61, 56, 14],
+]
+
+Masks = [(1 << i) - 1 for i in range(65)]
+
+
+def bits2bytes(x):
+    return (int(x) + 7) // 8
+
+
+def rol(value, left, bits):
+    """
+    Circularly rotate 'value' to the left,
+    treating it as a quantity of the given size in bits.
+    """
+    top = value >> (bits - left)
+    bot = (value & Masks[bits - left]) << left
+    return bot | top
+
+
+def ror(value, right, bits):
+    """
+    Circularly rotate 'value' to the right,
+    treating it as a quantity of the given size in bits.
+    """
+    top = value >> right
+    bot = (value & Masks[right]) << (bits - right)
+    return bot | top
+
+
+def multirate_padding(used_bytes, align_bytes):
+    """
+    The Keccak padding function.
+    """
+    padlen = align_bytes - used_bytes
+    if padlen == 0:
+        padlen = align_bytes
+    # note: padding done in 'internal bit ordering', wherein LSB is leftmost
+    if padlen == 1:
+        return [0x81]
+    else:
+        return [0x01] + ([0x00] * (padlen - 2)) + [0x80]
+
+
+def sha_padding(used_bytes, align_bytes):
+    """
+    The SHA3 padding function
+    """
+    padlen = align_bytes - (used_bytes % align_bytes)
+    if padlen == 1:
+        return [0x86]
+    elif padlen == 2:
+        return [0x06, 0x80]
+    else:
+        return [0x06] + ([0x00] * (padlen - 2)) + [0x80]
+
+
+def shake_padding(used_bytes, align_bytes):
+    """
+    The SHAKE padding function
+    """
+    padlen = align_bytes - (used_bytes % align_bytes)
+    if padlen == 1:
+        return [0x9F]
+    elif padlen == 2:
+        return [0x1F, 0x80]
+    else:
+        return [0x1F] + ([0x00] * (padlen - 2)) + [0x80]
+
+
+def keccak_f(state):
+    """
+    This is Keccak-f permutation.  It operates on and
+    mutates the passed-in KeccakState.  It returns nothing.
+    """
+
+    def keccak_round(a, rc):
+        w, h = state.W, state.H
+        rangew, rangeh = state.rangeW, state.rangeH
+        lanew = state.lanew
+        zero = state.zero
+
+        # theta
+        c = [reduce(xor, a[x]) for x in rangew]
+        d = [0] * w
+        for x in rangew:
+            d[x] = c[(x - 1) % w] ^ rol(c[(x + 1) % w], 1, lanew)
+            for y in rangeh:
+                a[x][y] ^= d[x]
+
+        # rho and pi
+        b = zero()
+        for x in rangew:
+            for y in rangeh:
+                b[y % w][(2 * x + 3 * y) % h] = rol(
+                    a[x][y], RotationConstants[y][x], lanew
+                )
+
+        # chi
+        for x in rangew:
+            for y in rangeh:
+                a[x][y] = b[x][y] ^ ((~b[(x + 1) % w][y]) & b[(x + 2) % w][y])
+
+        # iota
+        a[0][0] ^= rc
+
+    nr = 12 + 2 * int(log(state.lanew, 2))
+
+    for ir in range(nr):
+        keccak_round(state.s, RoundConstants[ir])
+
+
+class KeccakState:
+    """
+    A keccak state container.
+
+    The state is stored as a 5x5 table of integers.
+    """
+
+    __slots__ = ("lanew", "bitrate", "b", "s", "bitrate_bytes")
+
+    W = 5
+    H = 5
+
+    rangeW = range(W)
+    rangeH = range(H)
+
+    @staticmethod
+    def zero():
+        """
+        Returns an zero state table.
+        """
+        return [[0] * KeccakState.W for _ in KeccakState.rangeH]
+
+    @staticmethod
+    def format(st):
+        """
+        Formats the given state as hex, in natural byte order.
+        """
+        rows = []
+
+        def fmt(stx):
+            return "%016x" % stx
+
+        for y in KeccakState.rangeH:
+            row = []
+            for x in KeccakState.rangeW:
+                row.append(fmt(st[x][y]))
+            rows.append(" ".join(row))
+        return "\n".join(rows)
+
+    @staticmethod
+    def lane2bytes(s, w):
+        """
+        Converts the lane s to a sequence of byte values,
+        assuming a lane is w bits.
+        """
+        o = []
+        for b in range(0, w, 8):
+            o.append((s >> b) & 0xFF)
+        return o
+
+    @staticmethod
+    def bytes2lane(bb):
+        """
+        Converts a sequence of byte values to a lane.
+        """
+        r = 0
+        for b in reversed(bb):
+            r = r << 8 | b
+        return r
+
+    @staticmethod
+    def ilist2bytes(bb):
+        """
+        Converts a sequence of byte values to a bytestring.
+        """
+        return bytes(bb)
+
+    @staticmethod
+    def bytes2ilist(ss):
+        """
+        Converts a string or bytestring to a sequence of byte values.
+        """
+        return map(ord, ss) if isinstance(ss, str) else list(ss)
+
+    def __init__(self, bitrate, b):
+        self.bitrate = bitrate
+        self.b = b
+
+        # only byte-aligned
+        assert self.bitrate % 8 == 0
+        self.bitrate_bytes = bits2bytes(self.bitrate)
+
+        assert self.b % 25 == 0
+        self.lanew = self.b // 25
+
+        self.s = KeccakState.zero()
+
+    def __str__(self):
+        return KeccakState.format(self.s)
+
+    def absorb(self, bb):
+        """
+        Mixes in the given bitrate-length string to the state.
+        """
+        assert len(bb) == self.bitrate_bytes
+
+        bb += [0] * bits2bytes(self.b - self.bitrate)
+        i = 0
+
+        for y in self.rangeH:
+            for x in self.rangeW:
+                self.s[x][y] ^= KeccakState.bytes2lane(bb[i : i + 8])
+                i += 8
+
+    def squeeze(self):
+        """
+        Returns the bitrate-length prefix of the state to be output.
+        """
+        return self.get_bytes()[: self.bitrate_bytes]
+
+    def get_bytes(self):
+        """
+        Convert whole state to a byte string.
+        """
+        out = [0] * bits2bytes(self.b)
+        i = 0
+        for y in self.rangeH:
+            for x in self.rangeW:
+                v = KeccakState.lane2bytes(self.s[x][y], self.lanew)
+                out[i : i + 8] = v
+                i += 8
+        return out
+
+    def set_bytes(self, bb):
+        """
+        Set whole state from byte string, which is assumed
+        to be the correct length.
+        """
+        i = 0
+        for y in self.rangeH:
+            for x in self.rangeW:
+                self.s[x][y] = KeccakState.bytes2lane(bb[i : i + 8])
+                i += 8
+
+
+class KeccakSponge:
+    __slots__ = ("state", "padfn", "permfn", "buffer")
+
+    def __init__(self, bitrate, width, padfn, permfn):
+        self.state = KeccakState(bitrate, width)
+        self.padfn = padfn
+        self.permfn = permfn
+        self.buffer = []
+
+    def copy(self):
+        return deepcopy(self)
+
+    def absorb_block(self, bb):
+        assert len(bb) == self.state.bitrate_bytes
+        self.state.absorb(bb)
+        self.permfn(self.state)
+
+    def absorb(self, s):
+        self.buffer += s
+
+        while len(self.buffer) >= self.state.bitrate_bytes:
+            self.absorb_block(self.buffer[: self.state.bitrate_bytes])
+            self.buffer = self.buffer[self.state.bitrate_bytes :]
+
+    def absorb_final(self):
+        padded = self.buffer + self.padfn(len(self.buffer), self.state.bitrate_bytes)
+        self.absorb_block(padded)
+        self.buffer = []
+
+    def squeeze_once(self):
+        rc = self.state.squeeze()
+        self.permfn(self.state)
+        return rc
+
+    def squeeze(self, l):
+        z = self.squeeze_once()
+        while len(z) < l:
+            z += self.squeeze_once()
+        return z[:l]
+
+
+class KeccakHash:
+    """
+    The Keccak hash function, with a hashlib-compatible interface.
+    """
+
+    __slots__ = ("sponge", "digest_size", "block_size")
+
+    def __init__(self, bitrate_bits: int, capacity_bits: int, output_bits: int):
+        """
+        Create a new Keccak hash instance.
+
+        :param bitrate_bits: bitrate in bits
+        :param capacity_bits: capacity in bits
+        :param output_bits: output length in bits (must be divisible by 8)
+        """
+        # our in-absorption sponge. this is never given padding
+        assert bitrate_bits + capacity_bits in (25, 50, 100, 200, 400, 800, 1600)
+        self.sponge = KeccakSponge(
+            bitrate_bits, bitrate_bits + capacity_bits, multirate_padding, keccak_f
+        )
+
+        # hashlib interface members
+        assert output_bits % 8 == 0
+        self.digest_size = bits2bytes(output_bits)
+        self.block_size = bits2bytes(bitrate_bits)
+
+    def __repr__(self):
+        inf = (
+            self.sponge.state.bitrate,
+            self.sponge.state.b - self.sponge.state.bitrate,
+            self.digest_size * 8,
+        )
+        return "<KeccakHash with r=%d, c=%d, image=%d>" % inf
+
+    def copy(self) -> "KeccakHash":
+        """Return a copy of this hash object."""
+        return deepcopy(self)
+
+    def update(self, s: collections.abc.Buffer, /) -> None:
+        """
+        Feed data into the hash.
+
+        :param s: bytes-like data to absorb
+        """
+        self.sponge.absorb(s)
+
+    def digest(self) -> bytes:
+        """
+        Return the digest of the data fed so far.
+
+        :returns: hash digest as bytes
+        """
+        finalised = self.sponge.copy()
+        finalised.absorb_final()
+        digest = finalised.squeeze(self.digest_size)
+        return KeccakState.ilist2bytes(digest)
+
+    def hexdigest(self) -> str:
+        """
+        Return the hex-encoded digest of the data fed so far.
+
+        :returns: hash digest as hex string
+        """
+        return self.digest().hex()
+
+    @staticmethod
+    def preset(bitrate_bits, capacity_bits, output_bits):
+        """
+        Returns a factory function for the given bitrate, sponge capacity and output length.
+        The function accepts an optional initial input, ala hashlib.
+        """
+
+        def create(initial_input: collections.abc.Buffer | None = None):
+            h = KeccakHash(bitrate_bits, capacity_bits, output_bits)
+            if initial_input is not None:
+                h.update(initial_input)
+            return h
+
+        return create
+
+
+Keccak256 = KeccakHash.preset(1088, 512, 256)
+"""
+Default preset for Keccak hash that is the same as one used in eth
+"""

--- a/backend/node/genvm/origin/log_asserts.py
+++ b/backend/node/genvm/origin/log_asserts.py
@@ -1,0 +1,122 @@
+"""Assertions over the executor's structured log records.
+
+The manager captures every executor-emitted log line and surfaces them as
+``RunHostAndProgramRes.genvm_log`` — a list of JSON objects shaped like
+``{"message": ..., "target": ..., <extra fields>...}``. Capture is *unbounded*
+under ``debug_mode >= safe-unbounded`` (integration tests run ``unsafe``), so no
+record is evicted regardless of how chatty the run is.
+
+The ADR-012 load action emits one stable ``"runner load"`` record per load,
+carrying:
+
+- ``runner``      — the canonical runner id (``chain:``/``custom:``/``name:hash``);
+- ``runner_load_cost``  — the flat per-load constant
+    (``public_abi::memory_limiter_consts::RUNNER_LOAD_COST``);
+- ``size``        — the charged content size (archive ``total_size``);
+- ``status``      — ``"charged"`` (first load in this VM) or ``"cached"``
+                    (already in the VM's loaded set — free).
+
+This module is deliberately message-agnostic: a matcher's ``message`` defaults
+to ``"runner load"`` but may name any message, so the same machinery serves
+future charge-related log lines.
+
+Numeric fields (``size``, ``runner_load_cost``) are emitted by the executor as JSON
+*strings* (the logger's default ``Display`` capture), so every comparison here
+is done on the string form — an assertion may write ``4096`` or ``'4096'``
+interchangeably.
+
+Assertion schema entries may include ``match`` for subset matching over record
+fields, ``runner_prefix`` to isolate runner ids such as ``custom:``, count bounds
+(``count``/``min``/``max``), and ``size_is_code_len`` for init steps whose load
+size must equal the raw contract code length.
+
+`check` returns a list of human-readable failure strings (empty == all passed).
+`extract` is a convenience returning the matching records for eyeballing.
+"""
+
+import typing
+
+DEFAULT_MESSAGE = "runner load"
+
+
+def _record_matches(record: dict, crit: dict, runner_prefix: str | None) -> bool:
+    for k, v in crit.items():
+        if str(record.get(k)) != str(v):
+            return False
+    if runner_prefix is not None:
+        runner = record.get("runner")
+        if not isinstance(runner, str) or not runner.startswith(runner_prefix):
+            return False
+    return True
+
+
+def _select(genvm_log: list[dict], crit: dict, runner_prefix: str | None) -> list[dict]:
+    crit = dict(crit)
+    crit.setdefault("message", DEFAULT_MESSAGE)
+    return [r for r in genvm_log if _record_matches(r, crit, runner_prefix)]
+
+
+def extract(
+    genvm_log: list[dict],
+    *,
+    match: dict | None = None,
+    runner_prefix: str | None = None,
+) -> list[dict]:
+    """Return the ``genvm_log`` records matching ``match`` (defaulting to the
+    ``runner load`` message) and an optional ``runner`` prefix."""
+    return _select(genvm_log, match or {}, runner_prefix)
+
+
+def check(
+    genvm_log: list[dict],
+    asserts: list[dict],
+    *,
+    code_len: int | None = None,
+) -> list[str]:
+    """Evaluate ``asserts`` against ``genvm_log``; return a list of failures."""
+    errors: list[str] = []
+    for i, a in enumerate(asserts):
+        crit = a.get("match", {})
+        runner_prefix = a.get("runner_prefix")
+        matched = _select(genvm_log, crit, runner_prefix)
+        n = len(matched)
+
+        label = f"assert[{i}] match={crit}"
+        if runner_prefix is not None:
+            label += f" runner_prefix={runner_prefix!r}"
+
+        if "count" in a and n != a["count"]:
+            errors.append(f'{label}: expected count {a["count"]}, got {n}')
+        if "min" in a and n < a["min"]:
+            errors.append(f'{label}: expected at least {a["min"]}, got {n}')
+        if "max" in a and n > a["max"]:
+            errors.append(f'{label}: expected at most {a["max"]}, got {n}')
+
+        if a.get("size_is_code_len"):
+            if code_len is None:
+                errors.append(
+                    f"{label}: size_is_code_len set but this step ships no code"
+                )
+            else:
+                bad = [r for r in matched if str(r.get("size")) != str(code_len)]
+                if bad:
+                    got = [r.get("size") for r in bad]
+                    errors.append(
+                        f"{label}: expected size == code_len {code_len}, got {got}"
+                    )
+    return errors
+
+
+def summarize(genvm_log: list[dict]) -> list[dict]:
+    """Compact view of every ``runner load`` record, for failure context."""
+    out = []
+    for r in _select(genvm_log, {}, None):
+        out.append(
+            {
+                "runner": r.get("runner"),
+                "runner_load_cost": r.get("runner_load_cost"),
+                "size": r.get("size"),
+                "status": r.get("status"),
+            }
+        )
+    return typing.cast(list[dict], out)

--- a/backend/node/genvm/origin/logger.py
+++ b/backend/node/genvm/origin/logger.py
@@ -1,4 +1,5 @@
 import abc
+import collections.abc
 import json
 import sys
 import traceback
@@ -27,9 +28,6 @@ class Logger(metaclass=abc.ABCMeta):
         return _WithKeysLogger(self, keys)
 
 
-import collections.abc
-
-
 def _log_unwrap(x, seen: set[int]):
     if isinstance(x, bytes):
         return x.hex()
@@ -38,13 +36,12 @@ def _log_unwrap(x, seen: set[int]):
     if isinstance(x, (str, int, float, bool)):
         return x
     if isinstance(x, BaseException):
-        tb = traceback.format_exception(x)
         return _log_unwrap(
             {
                 "message": x.args[0] if len(x.args) == 1 else x.args,
                 "type": x.__class__.__name__,
                 "notes": getattr(x, "__notes__", []),
-                "traceback": tb,
+                "traceback": traceback.format_exception(x),
             },
             seen,
         )
@@ -53,11 +50,13 @@ def _log_unwrap(x, seen: set[int]):
         return f"<{x_id}>"
     seen.add(x_id)
     if isinstance(x, dict):
-        return {k: _log_unwrap(v, seen) for k, v in x.items()}
-    if isinstance(x, collections.abc.Sequence):
-        return [_log_unwrap(v, seen) for v in x]
+        res = {k: _log_unwrap(v, seen) for k, v in x.items()}
+    elif isinstance(x, collections.abc.Sequence):
+        res = [_log_unwrap(v, seen) for v in x]
+    else:
+        res = repr(x)
     seen.remove(x_id)
-    return repr(x)
+    return res
 
 
 class _WithKeysLogger(Logger):

--- a/backend/node/genvm/origin/public_abi.py
+++ b/backend/node/genvm/origin/public_abi.py
@@ -1,7 +1,10 @@
 # This file is auto-generated. Do not edit!
 
-from enum import IntEnum, StrEnum
+# fmt: off
+# ruff: noqa
+
 import typing
+from enum import IntEnum, StrEnum
 
 
 class ResultCode(IntEnum):
@@ -23,30 +26,245 @@ class EntryKind(IntEnum):
     CONSENSUS_STAGE = 2
 
 
-class MemoryLimiterConsts(IntEnum):
-    TABLE_ENTRY = 64
-    FILE_MAPPING = 256
-    FD_ALLOCATION = 96
+class Permissions(IntEnum):
+    CAN_USE_BALANCE_FOR_MESSAGE_FEES = 1
+
+
+class _MemoryLimiterConsts(typing.NamedTuple):
+    TABLE_ENTRY: int = 64
+    FILE_MAPPING: int = 256
+    FD_ALLOCATION: int = 96
+    RUNNER_LOAD_COST: int = 4096
+    VM_SPAWN_COST: int = 134217728
+
+memory_limiter_consts: typing.Final = _MemoryLimiterConsts()
+
+
+class _RootOffsets(typing.NamedTuple):
+    MAJOR: int = 0
+    CONTRACT: int = 1
+    CODE: int = 2
+    LOCKED_SLOTS: int = 3
+    UPGRADERS: int = 4
+    CODE_SLOT: int = 5
+    PERMISSIONS: int = 37
+
+root_offsets: typing.Final = _RootOffsets()
+
+
+class _TopLimits(typing.NamedTuple):
+    NONDET_BLOCKS: int = 4096
+    LOCKED_SLOTS: int = 256
+    UPGRADERS: int = 32
+    VM_RECURSION: int = 512
+    WEB_REQUEST_MIN_SPACE: int = 65536
+    WEB_RENDER_MIN_SPACE: int = 134217728
+    MAX_FDS: int = 1024
+    WASM_CALL_DEPTH: int = 1024
+    WASM_STACK_VALUE_SLOTS: int = 65535
+
+top_limits: typing.Final = _TopLimits()
 
 
 class SpecialMethod(StrEnum):
-    GET_SCHEMA = "#get-schema"
-    ERRORED_MESSAGE = "#error"
+    GET_SCHEMA = '#get-schema'
+    ERRORED_MESSAGE = '#error'
 
+class _VmErrorWasmTrap:
+    @staticmethod
+    def val() -> 'VmError':
+        return VmError('wasm_trap')
+    @staticmethod
+    def unreachable() -> 'VmError':
+        return VmError('wasm_trap unreachable')
+    @staticmethod
+    def stack_overflow() -> 'VmError':
+        return VmError('wasm_trap stack_overflow')
+    @staticmethod
+    def memory_out_of_bounds() -> 'VmError':
+        return VmError('wasm_trap memory_out_of_bounds')
+    @staticmethod
+    def table_out_of_bounds() -> 'VmError':
+        return VmError('wasm_trap table_out_of_bounds')
+    @staticmethod
+    def indirect_call_to_null() -> 'VmError':
+        return VmError('wasm_trap indirect_call_to_null')
+    @staticmethod
+    def bad_signature() -> 'VmError':
+        return VmError('wasm_trap bad_signature')
+    @staticmethod
+    def integer_overflow() -> 'VmError':
+        return VmError('wasm_trap integer_overflow')
+    @staticmethod
+    def integer_divide_by_zero() -> 'VmError':
+        return VmError('wasm_trap integer_divide_by_zero')
+    @staticmethod
+    def bad_conversion_to_integer() -> 'VmError':
+        return VmError('wasm_trap bad_conversion_to_integer')
+    @staticmethod
+    def heap_misaligned() -> 'VmError':
+        return VmError('wasm_trap heap_misaligned')
+    @staticmethod
+    def atomic_wait_non_shared_memory() -> 'VmError':
+        return VmError('wasm_trap atomic_wait_non_shared_memory')
+    @staticmethod
+    def out_of_fuel() -> 'VmError':
+        return VmError('wasm_trap out_of_fuel')
+    @staticmethod
+    def interrupt() -> 'VmError':
+        return VmError('wasm_trap interrupt')
+    @staticmethod
+    def nondet_instruction() -> 'VmError':
+        return VmError('wasm_trap nondet_instruction')
+    @staticmethod
+    def fault() -> 'VmError':
+        return VmError('wasm_trap fault')
 
-class VmError(StrEnum):
-    TIMEOUT = "timeout"
-    EXIT_CODE = "exit_code"
-    VALIDATOR_DISAGREES = "validator_disagrees"
-    VERSION_TOO_BIG = "version_too_big"
-    OOM = "OOM"
-    INVALID_CONTRACT = "invalid_contract"
+class _VmErrorOutOfMemory:
+    @staticmethod
+    def val() -> 'VmError':
+        return VmError('out_of memory')
+    @staticmethod
+    def wasm_memory() -> 'VmError':
+        return VmError('out_of memory wasm_memory')
+    @staticmethod
+    def wasm_table() -> 'VmError':
+        return VmError('out_of memory wasm_table')
+
+class _VmErrorOutOfReceipt:
+    @staticmethod
+    def nondet_output() -> 'VmError':
+        return VmError('out_of receipt nondet_output')
+    @staticmethod
+    def message() -> 'VmError':
+        return VmError('out_of receipt message')
+    @staticmethod
+    def event() -> 'VmError':
+        return VmError('out_of receipt event')
+
+class _VmErrorOutOfMessageFee:
+    @staticmethod
+    def total() -> 'VmError':
+        return VmError('out_of message_fee total')
+    @staticmethod
+    def node() -> 'VmError':
+        return VmError('out_of message_fee node')
+
+class _VmErrorOutOf:
+    @staticmethod
+    def storage() -> 'VmError':
+        return VmError('out_of storage')
+    @staticmethod
+    def vm_recursion() -> 'VmError':
+        return VmError('out_of vm_recursion')
+    @staticmethod
+    def nondet_blocks() -> 'VmError':
+        return VmError('out_of nondet_blocks')
+    @staticmethod
+    def locked_slots() -> 'VmError':
+        return VmError('out_of locked_slots')
+    @staticmethod
+    def upgraders() -> 'VmError':
+        return VmError('out_of upgraders')
+    @staticmethod
+    def fds() -> 'VmError':
+        return VmError('out_of fds')
+    @staticmethod
+    def memory() -> '_VmErrorOutOfMemory':
+        return _VmErrorOutOfMemory()
+    @staticmethod
+    def receipt() -> '_VmErrorOutOfReceipt':
+        return _VmErrorOutOfReceipt()
+    @staticmethod
+    def message_fee() -> '_VmErrorOutOfMessageFee':
+        return _VmErrorOutOfMessageFee()
+
+class _VmErrorFee:
+    @staticmethod
+    def no_matching_node() -> 'VmError':
+        return VmError('fee no_matching_node')
+    @staticmethod
+    def below_minimum() -> 'VmError':
+        return VmError('fee below_minimum')
+    @staticmethod
+    def too_many_rounds() -> 'VmError':
+        return VmError('fee too_many_rounds')
+
+class _VmErrorEvm:
+    @staticmethod
+    def reverted() -> 'VmError':
+        return VmError('evm reverted')
+
+class _VmErrorInvalidContractWasm:
+    @staticmethod
+    def validating() -> 'VmError':
+        return VmError('invalid_contract wasm validating')
+    @staticmethod
+    def linking() -> 'VmError':
+        return VmError('invalid_contract wasm linking')
+    @staticmethod
+    def entrypoint() -> 'VmError':
+        return VmError('invalid_contract wasm entrypoint')
+
+class _VmErrorInvalidContract:
+    @staticmethod
+    def val() -> 'VmError':
+        return VmError('invalid_contract')
+    @staticmethod
+    def absent_runner_comment() -> 'VmError':
+        return VmError('invalid_contract absent_runner_comment')
+    @staticmethod
+    def not_utf8_text() -> 'VmError':
+        return VmError('invalid_contract not_utf8_text')
+    @staticmethod
+    def malformed_runner() -> 'VmError':
+        return VmError('invalid_contract malformed_runner')
+    @staticmethod
+    def major_mismatch() -> 'VmError':
+        return VmError('invalid_contract major_mismatch')
+    @staticmethod
+    def wasm() -> '_VmErrorInvalidContractWasm':
+        return _VmErrorInvalidContractWasm()
+
+class _VmErrorExitCode:
+    @staticmethod
+    def val_i32(v: int) -> 'VmError':
+        return VmError(f'exit_code {v}')
+
+class VmError:
+    __slots__ = ('value',)
+    def __init__(self, value: str):
+        self.value = value
+    def __str__(self) -> str:
+        return self.value
+    @staticmethod
+    def timeout() -> 'VmError':
+        return VmError('timeout')
+    @staticmethod
+    def absent_leader_nondet_output() -> 'VmError':
+        return VmError('absent_leader_nondet_output')
+    @staticmethod
+    def host_forbidden() -> 'VmError':
+        return VmError('host_forbidden')
+    @staticmethod
+    def exit_code() -> '_VmErrorExitCode':
+        return _VmErrorExitCode()
+    @staticmethod
+    def wasm_trap() -> '_VmErrorWasmTrap':
+        return _VmErrorWasmTrap()
+    @staticmethod
+    def out_of() -> '_VmErrorOutOf':
+        return _VmErrorOutOf()
+    @staticmethod
+    def fee() -> '_VmErrorFee':
+        return _VmErrorFee()
+    @staticmethod
+    def evm() -> '_VmErrorEvm':
+        return _VmErrorEvm()
+    @staticmethod
+    def invalid_contract() -> '_VmErrorInvalidContract':
+        return _VmErrorInvalidContract()
+
 
 
 EVENT_MAX_TOPICS: typing.Final[int] = 4
-
-
-ABSENT_VERSION: typing.Final[str] = "v0.1.0"
-
-
-CODE_SLOT_OFFSET: typing.Final[int] = 1

--- a/backend/node/llm.lua
+++ b/backend/node/llm.lua
@@ -42,7 +42,7 @@ llm.exec_prompt_template_transform = function(args)
 	}
 end
 
--- check https://github.com/genlayerlabs/genvm/blob/v0.1.2/executor/modules/implementation/scripting/llm-default.lua
+-- check https://github.com/genlayerlabs/genvm-manager/blob/main/install/config/genvm-llm-default.lua
 
 -- Used to look up mock responses for testing
 -- It returns the response that is linked to a substring of the message

--- a/backend/node/types.py
+++ b/backend/node/types.py
@@ -29,8 +29,12 @@ class Address:
     _as_bytes: bytes
     _as_hex: str | None
 
-    def __init__(self, val: str | collections.abc.Buffer):
+    def __init__(self, val: "str | collections.abc.Buffer | Address"):
         self._as_hex = None
+        if isinstance(val, Address):
+            self._as_bytes = val._as_bytes
+            self._as_hex = val._as_hex
+            return
         if isinstance(val, str):
             if len(val) == 2 + Address.SIZE * 2 and val.startswith("0x"):
                 # 0x-prefixed hex string (42 chars)

--- a/backend/node/web.lua
+++ b/backend/node/web.lua
@@ -45,11 +45,19 @@ function Render(ctx, payload)
         '&mode=' .. payload.mode ..
         '&waitAfterLoaded=' .. tostring(payload.wait_after_loaded or 0)
 
+    -- The webdriver is a trusted internal endpoint (studio sets webdriver_host to
+    -- a Docker service hostname, e.g. http://webdriver:5001, which resolves to a
+    -- private address). The web module runs with the SSRF-filtering resolver, which
+    -- drops non-globally-routable addresses, so this internal request must opt out
+    -- via `unfiltered`. The contract-controlled `payload.url` is validated by
+    -- `web.check_url` above and only rendered by the webdriver, never fetched here.
     local result = lib.rs.request(ctx, {
         method = 'GET',
         url = web.rs.config.webdriver_host .. '/render' .. url_params,
         headers = {},
         error_on_status = true,
+        response_body_max_size = payload.size_limit,
+        unfiltered = true,
     })
 
     lib.log({
@@ -84,7 +92,10 @@ end
 function Request(ctx, payload)
     ---@cast payload WebRequestPayload
 
-    web.check_url(payload.url)
+    -- `check_url` returns true when the host is in `always_allow_hosts`; such
+    -- hosts are sent through the unfiltered client, everything else through the
+    -- SSRF-guarded resolver (see the real request call below).
+    local allowlisted = web.check_url(payload.url)
 
     -- Return mock response if it exists and matches
     if ctx.host_data.mock_web_response and ctx.host_data.mock_web_response.nondet_web_request then
@@ -108,6 +119,8 @@ function Request(ctx, payload)
         headers = payload.headers,
         body = payload.body,
         sign = payload.sign,
+        response_body_max_size = payload.size_limit,
+        unfiltered = allowlisted,
     })
 
     if success then

--- a/backend/protocol_rpc/fees.py
+++ b/backend/protocol_rpc/fees.py
@@ -795,7 +795,12 @@ def genvm_fee_context(
         data_bucket_total = (
             bucket_total if bucket_total > 0 else GENVM_UNMETERED_DATA_FEE_BUCKET
         )
-        bucket_totals = [data_bucket_total, data_bucket_total, message_bucket_total]
+        bucket_totals = [
+            data_bucket_total,
+            message_bucket_total,
+            GENVM_UNMETERED_DATA_FEE_BUCKET,
+            GENVM_UNMETERED_DATA_FEE_BUCKET,
+        ]
     else:
         bucket_totals = None
     return bucket_totals, gas_data

--- a/docker/Dockerfile.backend
+++ b/docker/Dockerfile.backend
@@ -10,36 +10,19 @@ ARG GENVM_BUILD_CORES=0
 # nixos/nix ships bash only inside the default nix profile (no /bin/bash).
 SHELL ["/nix/var/nix/profiles/default/bin/bash", "-x", "-c"]
 
-# Source builds bind Studio to a GenVM branch/SHA. The flake target follows
-# TARGETARCH (amd64-linux / arm64-linux); both build natively — runners are
-# universal wasm and come prebuilt from genvm's GCS cache either way.
-# Recipe mirrors genvm's own release CI (.github/workflows/release.yaml +
-# support/ci/pipelines/build.sh): patch flake-config.json, prefetch deps,
-# nix build manager/executor/runners-all, merge the outputs.
+# Source builds bind Studio to a genvm-manager branch/SHA. The flake target
+# follows TARGETARCH (amd64-linux / arm64-linux); runners are included by
+# genvm-manager's combined genvm package.
 RUN set -euo pipefail ; \
     if [ -n "$GENVM_REF" ]; then \
         # filter-syscalls=false: nix's seccomp filter cannot load under
         # qemu/Rosetta emulation (cross-platform local builds); harmless on
         # native hosts since the image already runs with sandbox disabled.
         printf 'experimental-features = nix-command flakes\nfilter-syscalls = false\ncores = %s\n' "$GENVM_BUILD_CORES" >> /etc/nix/nix.conf ; \
-        nix-env -iA nixpkgs.python3 nixpkgs.gnused ; \
-        git clone https://github.com/genlayerlabs/genvm /src/genvm ; \
+        git clone --recurse-submodules https://github.com/genlayerlabs/genvm-manager /src/genvm ; \
         cd /src/genvm ; \
         git checkout "$GENVM_REF" ; \
-        FULL_SHA="$(git rev-parse HEAD)" ; \
-        SHORT_SHA="$(git rev-parse --short HEAD)" ; \
-        if [ -n "${GENVM_EXECUTOR_VERSION_NAME:-}" ]; then \
-            EXECUTOR_VERSION="$GENVM_EXECUTOR_VERSION_NAME" ; \
-        else \
-            # Executor version must extend a version the committed manifest knows:
-            # genvm's patch-manifest renames the highest base `vX.Y.Z` entry to our
-            # `vX.Y.Z-dev<sha>` tag (suffix branch of its version matching), so
-            # derive the base from the bound ref's own manifest.
-            BASE_VER="$(grep -oE '^  v[0-9]+\.[0-9]+\.[0-9]+:' modules/install/data/manifest.yaml | tr -d ' :' | sort -V | tail -n1)" ; \
-            test -n "$BASE_VER" ; \
-            EXECUTOR_VERSION="${BASE_VER}-dev${SHORT_SHA}" ; \
-        fi ; \
-        printf '{"executor-version":"%s","repo-url":"https://github.com/genlayerlabs/genvm.git","head-revision":"%s"}\n' "$EXECUTOR_VERSION" "$FULL_SHA" > flake-config.json ; \
+        git submodule update --init --recursive ; \
         if [[ "$TARGETARCH" == "amd64" ]] || [[ -z "$TARGETARCH" ]]; then \
             GT="amd64-linux" ; \
         elif [[ "$TARGETARCH" == "arm64" ]]; then \
@@ -47,38 +30,16 @@ RUN set -euo pipefail ; \
         else \
             echo "ERROR: Unsupported TARGETARCH $TARGETARCH" ; exit 1 ; \
         fi ; \
-        # Upstream workaround: genvm support/rust.nix patchelf's its rust
-        # toolchain with a hardcoded x86-64 ELF loader, which breaks native
-        # aarch64-linux builds ('.cargo-wrapped: cannot execute'). Point it at
-        # the aarch64 loader on arm64. Drop once fixed in genvm.
-        if [[ "$GT" == "arm64-linux" ]]; then \
-            LOADER_MATCHES="$(grep -c 'ld-linux-x86-64\.so\.2' support/rust.nix || true)" ; \
-            if [[ "$LOADER_MATCHES" == "1" ]]; then \
-                sed -i 's|ld-linux-x86-64\.so\.2|ld-linux-aarch64.so.1|' support/rust.nix ; \
-            elif [[ "$LOADER_MATCHES" != "0" ]]; then \
-                echo "ERROR: unexpected ld-linux-x86-64 matches ($LOADER_MATCHES) in support/rust.nix — revisit the arm64 loader workaround" ; exit 1 ; \
-            fi ; \
-        fi ; \
-        python3 support/runner-script.py dependencies prefetch-needed --all --target "manager-$GT" --target "executor-$GT" --target runners-all ; \
-        nix build -o /out-manager ".#manager-$GT" ; \
-        nix build -o /out-executor ".#executor-$GT" ; \
-        # Preload prebuilt runner tars (fixed-output derivations) from genvm's
-        # public GCS cache so `runners-all` rarely compiles anything; the same
-        # trick genvm CI uses (support/ci/pipelines/test-rust.sh). Best-effort:
-        # anything missing is built from source by the next nix build.
-        python3 support/runner-script.py download --nix-preload --allow-partial --dest /tmp/runners-dl --registry /out-executor/executor/*/data/all.json || true ; \
-        nix build -o /out-runners ".#runners-all" ; \
+        nix build -o /out-genvm ".?submodules=1#genvm-$GT" ; \
         mkdir -p /genvm-out ; \
-        cp -rL --no-preserve=ownership /out-manager/. /genvm-out/ ; \
-        cp -rL --no-preserve=ownership /out-executor/. /genvm-out/ ; \
-        cp -rL --no-preserve=ownership /out-runners/. /genvm-out/ ; \
+        cp -rL --no-preserve=ownership /out-genvm/. /genvm-out/ ; \
         # Keep nix-store modes (exec bits!) but make everything owner-writable
         # so post-install can create venvs/cache dirs inside /genvm later.
         chmod -R u+w /genvm-out ; \
         # Drop sources + nix store build artifacts so this layer (and the
         # buildx/gha cache entry for it) stays close to the size of /genvm-out.
-        rm -f /out-manager /out-executor /out-runners ; \
-        rm -rf /src/genvm /tmp/runners-dl ; \
+        rm -f /out-genvm ; \
+        rm -rf /src/genvm ; \
         nix-collect-garbage -d || true ; \
     else \
         mkdir -p /genvm-out ; \
@@ -138,6 +99,7 @@ ENV RUST_BACKTRACE=1
 
 # Download and extract GenVM binaries. Keep downloads in the extraction layer so
 # architecture tarballs do not remain in lower image layers.
+ARG GENVM_ARTIFACT_URL="https://storage.googleapis.com/genvm-artifacts/temp/4d9a7b73/genvm-amd64-linux.tar.xz"
 COPY --from=genvm-source-build /genvm-out/ /genvm/
 COPY .e2e-genvm-prebuilt/ /genvm-prebuilt/
 RUN cd /genvm \
@@ -148,35 +110,21 @@ RUN cd /genvm \
             rm -f /genvm/.gitkeep ; \
             has_prebuilt=1 ; \
         fi \
-    && if [[ "$has_prebuilt" == "0" && -n "$GENVM_TAG" && -n "$GENVM_REF" ]] || [[ "$has_prebuilt" == "0" && -z "$GENVM_TAG" && -z "$GENVM_REF" ]]; then \
-            echo "ERROR: exactly one of GENVM_TAG or GENVM_REF must be set" ; exit 1 ; \
+    && if [[ "$has_prebuilt" == "0" && -z "$GENVM_ARTIFACT_URL" && -z "$GENVM_REF" ]]; then \
+            echo "ERROR: either GENVM_ARTIFACT_URL or GENVM_REF must be set" ; exit 1 ; \
         fi \
     && if [[ "$has_prebuilt" == "0" && -z "$GENVM_REF" ]]; then \
-        if [[ "$TARGETPLATFORM" == "linux/amd64" ]] || [[ -z "$TARGETPLATFORM" ]]; then \
-            ARCH_FILE="genvm-linux-amd64.tar.xz" ; \
-        elif [[ "$TARGETPLATFORM" == "linux/arm64" ]] ; \
-        then \
-            ARCH_FILE="genvm-linux-arm64.tar.xz" ; \
-        else \
-            echo "Sorry, $TARGETPLATFORM is not supported yet" ; exit 1 ; \
-        fi \
-    && curl -L --proto '=https' --proto-redir '=https' \
+        curl -L --proto '=https' --proto-redir '=https' \
         --fail --retry 3 --retry-delay 2 \
-        --connect-timeout 10 --max-time 300 \
+        --connect-timeout 10 --max-time 600 \
         --progress-bar \
-        -o "$ARCH_FILE" \
-        "https://github.com/genlayerlabs/genvm/releases/download/$GENVM_TAG/$ARCH_FILE" \
-    && curl -L --proto '=https' --proto-redir '=https' \
-        --fail --retry 3 --retry-delay 2 \
-        --connect-timeout 10 --max-time 300 \
-        --progress-bar \
-        -o "genvm-runners-all.tar.xz" \
-        "https://github.com/genlayerlabs/genvm/releases/download/$GENVM_TAG/genvm-runners-all.tar.xz" \
-    && tar -xf "$ARCH_FILE" \
-    && tar -xf genvm-runners-all.tar.xz \
-    && rm -- ./*.tar.xz ; \
+        -o genvm.tar.xz \
+        "$GENVM_ARTIFACT_URL" \
+    && tar -xf genvm.tar.xz \
+    && rm genvm.tar.xz ; \
     fi \
     && chown -R backend-user:backend-group /genvm \
+    && chmod -R u+w /genvm \
     # Source path: skip lief bin-patch — nix outputs are already
     # $ORIGIN-rpath-patched by genvm's patch-rpath, and lief SIGABRTs on the
     # zig/musl-linked amd64 executor ("Can't read got entries"). E2E prebuilt

--- a/docker/Dockerfile.consensus-worker
+++ b/docker/Dockerfile.consensus-worker
@@ -11,36 +11,19 @@ ARG GENVM_BUILD_CORES=0
 # nixos/nix ships bash only inside the default nix profile (no /bin/bash).
 SHELL ["/nix/var/nix/profiles/default/bin/bash", "-x", "-c"]
 
-# Source builds bind Studio to a GenVM branch/SHA. The flake target follows
-# TARGETARCH (amd64-linux / arm64-linux); both build natively — runners are
-# universal wasm and come prebuilt from genvm's GCS cache either way.
-# Recipe mirrors genvm's own release CI (.github/workflows/release.yaml +
-# support/ci/pipelines/build.sh): patch flake-config.json, prefetch deps,
-# nix build manager/executor/runners-all, merge the outputs.
+# Source builds bind Studio to a genvm-manager branch/SHA. The flake target
+# follows TARGETARCH (amd64-linux / arm64-linux); runners are included by
+# genvm-manager's combined genvm package.
 RUN set -euo pipefail ; \
     if [ -n "$GENVM_REF" ]; then \
         # filter-syscalls=false: nix's seccomp filter cannot load under
         # qemu/Rosetta emulation (cross-platform local builds); harmless on
         # native hosts since the image already runs with sandbox disabled.
         printf 'experimental-features = nix-command flakes\nfilter-syscalls = false\ncores = %s\n' "$GENVM_BUILD_CORES" >> /etc/nix/nix.conf ; \
-        nix-env -iA nixpkgs.python3 nixpkgs.gnused ; \
-        git clone https://github.com/genlayerlabs/genvm /src/genvm ; \
+        git clone --recurse-submodules https://github.com/genlayerlabs/genvm-manager /src/genvm ; \
         cd /src/genvm ; \
         git checkout "$GENVM_REF" ; \
-        FULL_SHA="$(git rev-parse HEAD)" ; \
-        SHORT_SHA="$(git rev-parse --short HEAD)" ; \
-        if [ -n "${GENVM_EXECUTOR_VERSION_NAME:-}" ]; then \
-            EXECUTOR_VERSION="$GENVM_EXECUTOR_VERSION_NAME" ; \
-        else \
-            # Executor version must extend a version the committed manifest knows:
-            # genvm's patch-manifest renames the highest base `vX.Y.Z` entry to our
-            # `vX.Y.Z-dev<sha>` tag (suffix branch of its version matching), so
-            # derive the base from the bound ref's own manifest.
-            BASE_VER="$(grep -oE '^  v[0-9]+\.[0-9]+\.[0-9]+:' modules/install/data/manifest.yaml | tr -d ' :' | sort -V | tail -n1)" ; \
-            test -n "$BASE_VER" ; \
-            EXECUTOR_VERSION="${BASE_VER}-dev${SHORT_SHA}" ; \
-        fi ; \
-        printf '{"executor-version":"%s","repo-url":"https://github.com/genlayerlabs/genvm.git","head-revision":"%s"}\n' "$EXECUTOR_VERSION" "$FULL_SHA" > flake-config.json ; \
+        git submodule update --init --recursive ; \
         if [[ "$TARGETARCH" == "amd64" ]] || [[ -z "$TARGETARCH" ]]; then \
             GT="amd64-linux" ; \
         elif [[ "$TARGETARCH" == "arm64" ]]; then \
@@ -48,38 +31,16 @@ RUN set -euo pipefail ; \
         else \
             echo "ERROR: Unsupported TARGETARCH $TARGETARCH" ; exit 1 ; \
         fi ; \
-        # Upstream workaround: genvm support/rust.nix patchelf's its rust
-        # toolchain with a hardcoded x86-64 ELF loader, which breaks native
-        # aarch64-linux builds ('.cargo-wrapped: cannot execute'). Point it at
-        # the aarch64 loader on arm64. Drop once fixed in genvm.
-        if [[ "$GT" == "arm64-linux" ]]; then \
-            LOADER_MATCHES="$(grep -c 'ld-linux-x86-64\.so\.2' support/rust.nix || true)" ; \
-            if [[ "$LOADER_MATCHES" == "1" ]]; then \
-                sed -i 's|ld-linux-x86-64\.so\.2|ld-linux-aarch64.so.1|' support/rust.nix ; \
-            elif [[ "$LOADER_MATCHES" != "0" ]]; then \
-                echo "ERROR: unexpected ld-linux-x86-64 matches ($LOADER_MATCHES) in support/rust.nix — revisit the arm64 loader workaround" ; exit 1 ; \
-            fi ; \
-        fi ; \
-        python3 support/runner-script.py dependencies prefetch-needed --all --target "manager-$GT" --target "executor-$GT" --target runners-all ; \
-        nix build -o /out-manager ".#manager-$GT" ; \
-        nix build -o /out-executor ".#executor-$GT" ; \
-        # Preload prebuilt runner tars (fixed-output derivations) from genvm's
-        # public GCS cache so `runners-all` rarely compiles anything; the same
-        # trick genvm CI uses (support/ci/pipelines/test-rust.sh). Best-effort:
-        # anything missing is built from source by the next nix build.
-        python3 support/runner-script.py download --nix-preload --allow-partial --dest /tmp/runners-dl --registry /out-executor/executor/*/data/all.json || true ; \
-        nix build -o /out-runners ".#runners-all" ; \
+        nix build -o /out-genvm ".?submodules=1#genvm-$GT" ; \
         mkdir -p /genvm-out ; \
-        cp -rL --no-preserve=ownership /out-manager/. /genvm-out/ ; \
-        cp -rL --no-preserve=ownership /out-executor/. /genvm-out/ ; \
-        cp -rL --no-preserve=ownership /out-runners/. /genvm-out/ ; \
+        cp -rL --no-preserve=ownership /out-genvm/. /genvm-out/ ; \
         # Keep nix-store modes (exec bits!) but make everything owner-writable
         # so post-install can create venvs/cache dirs inside /genvm later.
         chmod -R u+w /genvm-out ; \
         # Drop sources + nix store build artifacts so this layer (and the
         # buildx/gha cache entry for it) stays close to the size of /genvm-out.
-        rm -f /out-manager /out-executor /out-runners ; \
-        rm -rf /src/genvm /tmp/runners-dl ; \
+        rm -f /out-genvm ; \
+        rm -rf /src/genvm ; \
         nix-collect-garbage -d || true ; \
     else \
         mkdir -p /genvm-out ; \
@@ -139,6 +100,7 @@ ENV RUST_BACKTRACE=1
 
 
 # Download and extract GenVM binaries (sequential for Docker compatibility)
+ARG GENVM_ARTIFACT_URL="https://storage.googleapis.com/genvm-artifacts/temp/4d9a7b73/genvm-amd64-linux.tar.xz"
 COPY --from=genvm-source-build /genvm-out/ /genvm/
 COPY .e2e-genvm-prebuilt/ /genvm-prebuilt/
 RUN cd /genvm \
@@ -149,44 +111,21 @@ RUN cd /genvm \
         rm -f /genvm/.gitkeep ; \
         has_prebuilt=1 ; \
     fi \
-    && if [[ "$has_prebuilt" == "0" && -n "$GENVM_TAG" && -n "$GENVM_REF" ]] || [[ "$has_prebuilt" == "0" && -z "$GENVM_TAG" && -z "$GENVM_REF" ]]; then \
-        echo "ERROR: exactly one of GENVM_TAG or GENVM_REF must be set" ; exit 1 ; \
+    && if [[ "$has_prebuilt" == "0" && -z "$GENVM_ARTIFACT_URL" && -z "$GENVM_REF" ]]; then \
+        echo "ERROR: either GENVM_ARTIFACT_URL or GENVM_REF must be set" ; exit 1 ; \
     fi \
     && echo "=== Starting GenVM $GENVM_TAG download ===" \
     && if [[ "$has_prebuilt" == "0" && -z "$GENVM_REF" ]]; then \
-    if [[ "$TARGETPLATFORM" == "linux/amd64" ]] || [[ -z "$TARGETPLATFORM" ]]; then \
-        ARCH_FILE="genvm-linux-amd64.tar.xz" ; \
-    elif [[ "$TARGETPLATFORM" == "linux/arm64" ]]; then \
-        ARCH_FILE="genvm-linux-arm64.tar.xz" ; \
-    else \
-        echo "ERROR: Unsupported platform $TARGETPLATFORM" ; exit 1 ; \
-    fi \
-    && echo "Platform: $TARGETPLATFORM -> Architecture file: $ARCH_FILE" \
-    && echo "Downloading $ARCH_FILE..." \
+    echo "Downloading genvm-manager artifact..." \
     && curl -L --fail --retry 3 --retry-delay 2 \
-        --connect-timeout 10 --max-time 300 \
+        --connect-timeout 10 --max-time 600 \
         --progress-bar \
-        -o "$ARCH_FILE" \
-        "https://github.com/genlayerlabs/genvm/releases/download/$GENVM_TAG/$ARCH_FILE" \
-    && echo "✓ Downloaded $ARCH_FILE" \
-    && echo "Downloading genvm-runners-all.tar.xz..." \
-    && curl -L --fail --retry 3 --retry-delay 2 \
-        --connect-timeout 10 --max-time 300 \
-        --progress-bar \
-        -o "genvm-runners-all.tar.xz" \
-        "https://github.com/genlayerlabs/genvm/releases/download/$GENVM_TAG/genvm-runners-all.tar.xz" \
-    && echo "✓ Downloaded genvm-runners-all.tar.xz" \
-    && echo "Verifying downloads..." \
-    && ls -lah *.tar.xz \
-    && for f in *.tar.xz; do \
-        if [ ! -s "$f" ]; then \
-            echo "ERROR: $f is empty or missing" ; exit 1 ; \
-        fi ; \
-    done \
+        -o genvm.tar.xz \
+        "$GENVM_ARTIFACT_URL" \
+    && echo "✓ Downloaded artifact" \
     && echo "Extracting archives..." \
-    && tar -xf "$ARCH_FILE" \
-    && tar -xf "genvm-runners-all.tar.xz" \
-    && rm -- ./*.tar.xz ; \
+    && tar -xf genvm.tar.xz \
+    && rm genvm.tar.xz ; \
     fi \
     && echo "Configuring GenVM manager threads..." \
     && CONFIG_FILE="/genvm/config/genvm-manager.yaml" \
@@ -201,6 +140,7 @@ RUN cd /genvm \
     && echo "GenVM installed successfully:" \
     && ls -la \
     && chown -R worker-user:worker-group /genvm \
+    && chmod -R u+w /genvm \
     # Source path: skip lief bin-patch — nix outputs are already
     # $ORIGIN-rpath-patched by genvm's patch-rpath, and lief SIGABRTs on the
     # zig/musl-linked amd64 executor ("Can't read got entries"). E2E prebuilt

--- a/examples/contracts/_hello_world.py
+++ b/examples/contracts/_hello_world.py
@@ -1,16 +1,15 @@
-# v0.2.16
-# { "Depends": "py-genlayer:1zr6nqk597d97kg0dyxg0shhrykx5v02zjgnyrajapy4wlqvfvwh" }
+# v0.3.0
+# { "Depends": "py-genlayer:9b8kjyda2ycxyq4ea6g4yfpnydxhd52gqba5rb8dw7krkh5mn9p0" }
 
 # Always put above lines as first in the contract file
-# v0.1.2 is genvm ABI version, lower versions may restrict some calls that were introduced in newer version (i.e. events)
 # In actual genlayer network `:latest` is not allowed and hash must be specified
 
-# this imports all types into globals and `genlayer.std` as `gl` (will be imported lazily on first access)
+# `gl` gives access to submodules and decorators, `genlayer.types` brings type aliases into scope
 import genlayer as gl
-from genlayer import *
+from genlayer.types import *
 
 
-# extend `gl.contract.Contract` to mark class as a contract. There can be only one class that extends `gl.contract.Contract`
+# extend `gl.contract.Contract` to mark class as a contract. There can be only one class that extends it
 class Storage(gl.contract.Contract):
     # below you must declare all class fields that you are going to use
     # this fields persist between contract calls

--- a/examples/contracts/faucet.py
+++ b/examples/contracts/faucet.py
@@ -1,8 +1,8 @@
-# v0.2.17
-# { "Depends": "py-genlayer:1zr6nqk597d97kg0dyxg0shhrykx5v02zjgnyrajapy4wlqvfvwh" }
+# v0.3.0
+# { "Depends": "py-genlayer:9b8kjyda2ycxyq4ea6g4yfpnydxhd52gqba5rb8dw7krkh5mn9p0" }
 
 import genlayer as gl
-from genlayer import *
+from genlayer.types import *
 
 
 @gl.evm.contract_interface
@@ -21,6 +21,6 @@ class Faucet(gl.contract.Contract):
     @gl.public.write.payable
     def send(self, recipient: str) -> None:
         v = gl.message.value
-        if v == u256(0):
+        if v == 0:
             raise gl.vm.UserError("send some value")
         _Recipient(Address(recipient)).emit_transfer(value=v)

--- a/examples/contracts/football_prediction_market.py
+++ b/examples/contracts/football_prediction_market.py
@@ -1,8 +1,8 @@
-# v0.2.16
-# { "Depends": "py-genlayer:1zr6nqk597d97kg0dyxg0shhrykx5v02zjgnyrajapy4wlqvfvwh" }
+# v0.3.0
+# { "Depends": "py-genlayer:9b8kjyda2ycxyq4ea6g4yfpnydxhd52gqba5rb8dw7krkh5mn9p0" }
 
 import genlayer as gl
-from genlayer import *
+from genlayer.types import *
 
 import json
 import typing
@@ -38,7 +38,7 @@ class PredictionMarket(gl.contract.Contract):
         )
         self.team1 = team1
         self.team2 = team2
-        self.winner = u256(0)
+        self.winner = 0
         self.score = ""
 
     @gl.public.write
@@ -78,9 +78,7 @@ your output must be only JSON without any formatting prefix or suffix.
 This result should be perfectly parsable by a JSON parser without errors.
             """
             result = (
-                gl.nondet.exec_prompt(task, response_format="text")
-                .replace("```json", "")
-                .replace("```", "")
+                gl.nondet.exec_prompt(task).replace("```json", "").replace("```", "")
             )
             print(result)
             return json.loads(result)

--- a/examples/contracts/llm_erc20.py
+++ b/examples/contracts/llm_erc20.py
@@ -1,17 +1,17 @@
-# v0.2.16
-# { "Depends": "py-genlayer:1zr6nqk597d97kg0dyxg0shhrykx5v02zjgnyrajapy4wlqvfvwh" }
+# v0.3.0
+# { "Depends": "py-genlayer:9b8kjyda2ycxyq4ea6g4yfpnydxhd52gqba5rb8dw7krkh5mn9p0" }
 
 import json
 
 import genlayer as gl
-from genlayer import *
+from genlayer.types import *
 
 
 class LlmErc20(gl.contract.Contract):
-    balances: TreeMap[Address, u256]
+    balances: gl.storage.TreeMap[Address, u256]
 
     def __init__(self, total_supply: int) -> None:
-        self.balances[gl.message.sender_address] = u256(total_supply)
+        self.balances[gl.message.sender_address] = total_supply
 
     @gl.public.write
     def transfer(self, amount: int, to_address: str) -> None:
@@ -55,7 +55,7 @@ The total sum of all balances should remain the same before and after the transa
 
         def get_transfer_result() -> str:
             return (
-                gl.nondet.exec_prompt(prompt_input + task, response_format="text")
+                gl.nondet.exec_prompt(prompt_input + task)
                 .replace("```json", "")
                 .replace("```", "")
             )

--- a/examples/contracts/log_indexer.py
+++ b/examples/contracts/log_indexer.py
@@ -1,22 +1,22 @@
-# v0.3-dev
+# v0.3.0
 # {
 #   "Seq": [
-#     { "Depends": "py-lib-genlayer-embeddings:1md4i1njqn0h0psgjdl97mz10rpp1268ychpn6l2dmr81fbvxknb" },
-#     { "Depends": "py-genlayer:1zr6nqk597d97kg0dyxg0shhrykx5v02zjgnyrajapy4wlqvfvwh" }
+#     { "Depends": "py-lib-genlayer-embeddings:kr2rb2dcp01mw9khpg3tg2jasx4f82mcsy3eg08rjj1zdcm9q350" },
+#     { "Depends": "py-genlayer:9b8kjyda2ycxyq4ea6g4yfpnydxhd52gqba5rb8dw7krkh5mn9p0" }
 #   ]
 # }
 
 import numpy as np
 import genlayer as gl
-from genlayer import *
-from genlayer.storage import allow
+from genlayer.types import *
+from genlayer.storage import TreeMap
 import genlayer_embeddings as gle
 
 from dataclasses import dataclass
 import typing
 
 
-@allow
+@gl.storage.allow
 @dataclass
 class StoreValue:
     log_id: u256
@@ -52,7 +52,7 @@ class LogIndexer(gl.contract.Contract):
                 continue
             if log_id not in self.log_vector_ids:
                 continue
-            if self.log_vector_ids[log_id] != u32(result.id):
+            if self.log_vector_ids[log_id] != result.id:
                 continue
             return {
                 "vector": list(str(x) for x in result.key),
@@ -64,7 +64,7 @@ class LogIndexer(gl.contract.Contract):
 
     @gl.public.write
     def add_log(self, log: str, log_id: int) -> None:
-        key = u256(log_id)
+        key = log_id
         if key in self.log_vector_ids:
             self.vector_store.get_by_id(self.log_vector_ids[key]).value = StoreValue(
                 text=log, log_id=key
@@ -73,11 +73,11 @@ class LogIndexer(gl.contract.Contract):
 
         emb = self.get_embedding(log)
         vector_id = self.vector_store.insert(emb, StoreValue(text=log, log_id=key))
-        self.log_vector_ids[key] = u32(vector_id)
+        self.log_vector_ids[key] = vector_id
 
     @gl.public.write
     def update_log(self, log_id: int, log: str) -> None:
-        key = u256(log_id)
+        key = log_id
         if key in self.log_vector_ids:
             self.vector_store.get_by_id(self.log_vector_ids[key]).value = StoreValue(
                 text=log, log_id=key
@@ -86,10 +86,10 @@ class LogIndexer(gl.contract.Contract):
 
         emb = self.get_embedding(log)
         vector_id = self.vector_store.insert(emb, StoreValue(text=log, log_id=key))
-        self.log_vector_ids[key] = u32(vector_id)
+        self.log_vector_ids[key] = vector_id
 
     @gl.public.write
     def remove_log(self, id: int) -> None:
-        key = u256(id)
+        key = id
         if key in self.log_vector_ids:
             self.removed_log_ids[key] = True

--- a/examples/contracts/storage.py
+++ b/examples/contracts/storage.py
@@ -1,5 +1,5 @@
-# v0.2.16
-# { "Depends": "py-genlayer:1zr6nqk597d97kg0dyxg0shhrykx5v02zjgnyrajapy4wlqvfvwh" }
+# v0.3.0
+# { "Depends": "py-genlayer:9b8kjyda2ycxyq4ea6g4yfpnydxhd52gqba5rb8dw7krkh5mn9p0" }
 
 import genlayer as gl
 

--- a/examples/contracts/tip_jar.py
+++ b/examples/contracts/tip_jar.py
@@ -1,8 +1,8 @@
-# v0.2.16
-# { "Depends": "py-genlayer:1zr6nqk597d97kg0dyxg0shhrykx5v02zjgnyrajapy4wlqvfvwh" }
+# v0.3.0
+# { "Depends": "py-genlayer:9b8kjyda2ycxyq4ea6g4yfpnydxhd52gqba5rb8dw7krkh5mn9p0" }
 
 import genlayer as gl
-from genlayer import *
+from genlayer.types import *
 
 
 class TipJar(gl.contract.Contract):
@@ -11,12 +11,12 @@ class TipJar(gl.contract.Contract):
 
     def __init__(self):
         self.owner = gl.message.sender_address
-        self.total_tips = u256(0)
+        self.total_tips = 0
 
     @gl.public.write.payable
     def tip(self) -> None:
         v = gl.message.value
-        if v == u256(0):
+        if v == 0:
             raise gl.vm.UserError("send some value")
         self.total_tips = self.total_tips + v
 

--- a/examples/contracts/user_storage.py
+++ b/examples/contracts/user_storage.py
@@ -1,18 +1,12 @@
-# v0.2.16
-# { "Depends": "py-genlayer:1jb45aa8ynh2a9c9xn3b7qqh8sm5q93hwfp7jqmwsfhh8jpz09h6" }
+# v0.3.0
+# { "Depends": "py-genlayer:9b8kjyda2ycxyq4ea6g4yfpnydxhd52gqba5rb8dw7krkh5mn9p0" }
 
-# BACKWARD-COMPAT CANARY - DO NOT UPGRADE TO THE MAIN-SDK IDIOM.
-# This contract is deliberately kept on the v0.3.0-rc3 runner (old SDK:
-# star-exported `gl`, gl.Contract base) to verify that contracts deployed
-# against older runners keep executing on the genvm-main executor.
-# (The blank line above is load-bearing: the executor parses the leading
-# comment block as version + runner JSON, so the note must sit outside it.)
-
-from genlayer import *
+import genlayer as gl
+from genlayer.types import *
 
 
-class UserStorage(gl.Contract):
-    storage: TreeMap[Address, str]
+class UserStorage(gl.contract.Contract):
+    storage: gl.storage.TreeMap[Address, str]
 
     # constructor
     def __init__(self):

--- a/examples/contracts/wizard_of_coin.py
+++ b/examples/contracts/wizard_of_coin.py
@@ -1,5 +1,5 @@
-# v0.2.16
-# { "Depends": "py-genlayer:1zr6nqk597d97kg0dyxg0shhrykx5v02zjgnyrajapy4wlqvfvwh" }
+# v0.3.0
+# { "Depends": "py-genlayer:9b8kjyda2ycxyq4ea6g4yfpnydxhd52gqba5rb8dw7krkh5mn9p0" }
 import genlayer as gl
 
 import json
@@ -40,7 +40,7 @@ This result should be perfectly parseable by a JSON parser without errors.
 """
 
         def get_wizard_answer():
-            result = gl.nondet.exec_prompt(prompt, response_format="text")
+            result = gl.nondet.exec_prompt(prompt)
             result = result.replace("```json", "").replace("```", "")
             print(result)
             return result

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,64 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": [
+          "systems"
+        ]
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1783776592,
+        "narHash": "sha256-UgCQzxeWI75XM8G+hPrPh+MKzEPjG3SpAj7dtqSbksA=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e7a3ca8092b61ff85b6a45bf863ea2b2d6a661b3",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs",
+        "systems": "systems"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,32 @@
+{
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    systems = {
+      url = "github:nix-systems/default";
+    };
+    flake-utils = {
+      url = "github:numtide/flake-utils";
+      inputs.systems.follows = "systems";
+    };
+  };
+
+  outputs = inputs@{ self, nixpkgs, flake-utils, ... }:
+    flake-utils.lib.eachDefaultSystem
+      (system:
+        let
+          pkgs = import nixpkgs { inherit system; config.allowUnfree = true; };
+        in
+        {
+          devShells.default = pkgs.mkShell {
+            packages = with pkgs; [
+              python312
+              pre-commit
+              nodejs
+            ];
+
+            shellHook = ''
+            '';
+          };
+        }
+      );
+}

--- a/tests/common/request.py
+++ b/tests/common/request.py
@@ -90,7 +90,7 @@ def call_contract_method(
     method_args: list,
 ):
     encoded_data = eth_utils.hexadecimal.encode_hex(
-        calldata.encode({"method": method_name, "args": method_args})
+        calldata.encode({"": method_name, "args": method_args})
     )
     method_response = post_request_localhost(
         payload(

--- a/tests/direct/contracts/error_llm_contract_direct.py
+++ b/tests/direct/contracts/error_llm_contract_direct.py
@@ -1,10 +1,10 @@
-# { "Depends": "py-genlayer:1jb45aa8ynh2a9c9xn3b7qqh8sm5q93hwfp7jqmwsfhh8jpz09h6" }
+# { "Depends": "py-genlayer:9b8kjyda2ycxyq4ea6g4yfpnydxhd52gqba5rb8dw7krkh5mn9p0" }
 
-from genlayer import *
+import genlayer as gl
 import json
 
 
-class ErrorLLMContractDirect(gl.Contract):
+class ErrorLLMContractDirect(gl.contract.Contract):
     """
     Copy of tests/integration/icontracts/contracts/error_llm_contract.py for direct-mode testing.
 

--- a/tests/direct/contracts/error_web_contract_direct.py
+++ b/tests/direct/contracts/error_web_contract_direct.py
@@ -1,9 +1,9 @@
-# { "Depends": "py-genlayer:1jb45aa8ynh2a9c9xn3b7qqh8sm5q93hwfp7jqmwsfhh8jpz09h6" }
+# { "Depends": "py-genlayer:9b8kjyda2ycxyq4ea6g4yfpnydxhd52gqba5rb8dw7krkh5mn9p0" }
 
-from genlayer import *
+import genlayer as gl
 
 
-class ErrorWebContractDirect(gl.Contract):
+class ErrorWebContractDirect(gl.contract.Contract):
     """
     Copy of tests/integration/icontracts/contracts/error_web_contract.py for direct-mode testing.
 

--- a/tests/direct/storage_read_bench.py
+++ b/tests/direct/storage_read_bench.py
@@ -1,15 +1,16 @@
-# { "Depends": "py-genlayer:1jb45aa8ynh2a9c9xn3b7qqh8sm5q93hwfp7jqmwsfhh8jpz09h6" }
-from genlayer import *
+# { "Depends": "py-genlayer:9b8kjyda2ycxyq4ea6g4yfpnydxhd52gqba5rb8dw7krkh5mn9p0" }
+import genlayer as gl
+from genlayer.types import *
 
 
-class ReadBench(gl.Contract):
+class ReadBench(gl.contract.Contract):
     value: u256
-    items: DynArray[u256]
+    items: gl.storage.DynArray[u256]
 
     def __init__(self, count: int):
-        self.value = u256(42)
+        self.value = 42
         for i in range(count):
-            self.items.append(u256(i))
+            self.items.append(i)
 
     @gl.public.view
     def read_one(self) -> int:
@@ -17,7 +18,7 @@ class ReadBench(gl.Contract):
 
     @gl.public.view
     def read_n(self, n: int) -> int:
-        total = u256(0)
+        total = 0
         for i in range(int(n)):
             total += self.items[i]
         return int(total)

--- a/tests/integration/icontracts/contracts/company_naming.py
+++ b/tests/integration/icontracts/contracts/company_naming.py
@@ -1,14 +1,14 @@
-# { "Depends": "py-genlayer:1zr6nqk597d97kg0dyxg0shhrykx5v02zjgnyrajapy4wlqvfvwh" }
+# { "Depends": "py-genlayer:9b8kjyda2ycxyq4ea6g4yfpnydxhd52gqba5rb8dw7krkh5mn9p0" }
 
 import json
 import genlayer as gl
-from genlayer import *
+from genlayer.types import *
 
 MAX_SCORE_DIFFERENCE = 3
 
 
 class CompanyNaming(gl.contract.Contract):
-    scores: TreeMap[str, u256]
+    scores: gl.storage.TreeMap[str, u256]
 
     def __init__(self):
         pass
@@ -49,7 +49,7 @@ This result should be perfectly parseable by a JSON parser without errors.
 """
 
         def leader_fn():
-            result = gl.nondet.exec_prompt(task, response_format="text")
+            result = gl.nondet.exec_prompt(task)
             result = _extract_json_from_string(result)
             result = json.loads(result)
             return result
@@ -65,7 +65,7 @@ This result should be perfectly parseable by a JSON parser without errors.
                 <= MAX_SCORE_DIFFERENCE
             )
 
-        analysis = gl.vm.run_nondet(leader_fn, validator_fn)
+        analysis = gl.vm.run_nondet_default(leader_fn, validator_fn)
 
         score = analysis["score"]
         self.scores[company_name] = score

--- a/tests/integration/icontracts/contracts/error_execution_contract.py
+++ b/tests/integration/icontracts/contracts/error_execution_contract.py
@@ -1,12 +1,12 @@
-# v0.1.0
-# { "Depends": "py-genlayer:1zr6nqk597d97kg0dyxg0shhrykx5v02zjgnyrajapy4wlqvfvwh" }
+# v0.3.0
+# { "Depends": "py-genlayer:9b8kjyda2ycxyq4ea6g4yfpnydxhd52gqba5rb8dw7krkh5mn9p0" }
 
 import genlayer as gl
-from genlayer import *
+from genlayer.types import *
 
 
 class ErrorExecutionContract(gl.contract.Contract):
-    state: TreeMap[str, str]
+    state: gl.storage.TreeMap[str, str]
 
     def __init__(self, testcase: int, target_address: str | None = None):
 

--- a/tests/integration/icontracts/contracts/error_llm_contract.py
+++ b/tests/integration/icontracts/contracts/error_llm_contract.py
@@ -1,5 +1,5 @@
-# v0.1.0
-# { "Depends": "py-genlayer:1zr6nqk597d97kg0dyxg0shhrykx5v02zjgnyrajapy4wlqvfvwh" }
+# v0.3.0
+# { "Depends": "py-genlayer:9b8kjyda2ycxyq4ea6g4yfpnydxhd52gqba5rb8dw7krkh5mn9p0" }
 
 import genlayer as gl
 import json
@@ -29,7 +29,7 @@ This result should be perfectly parseable by a JSON parser without errors.
 """
 
         def get_llm_answer():
-            result = gl.nondet.exec_prompt(prompt, response_format="text")
+            result = gl.nondet.exec_prompt(prompt)
             result = result.replace("```json", "").replace("```", "")
             return result
 
@@ -37,7 +37,7 @@ This result should be perfectly parseable by a JSON parser without errors.
 
     def test_system_error(self):
         prompt = "What is 2+2?"
-        result = gl.nondet.exec_prompt(prompt, response_format="text")
+        result = gl.nondet.exec_prompt(prompt)
 
     def test_invalid_json(self):
         prompt = """What is 2+2?
@@ -47,7 +47,7 @@ This result should not be parseable by a JSON parser.
 """
 
         def get_llm_answer():
-            result = gl.nondet.exec_prompt(prompt, response_format="text")
+            result = gl.nondet.exec_prompt(prompt)
             result = result.replace("```json", "").replace("```", "")
             result = json.loads(result)
             return result

--- a/tests/integration/icontracts/contracts/error_web_contract.py
+++ b/tests/integration/icontracts/contracts/error_web_contract.py
@@ -1,5 +1,5 @@
-# v0.1.0
-# { "Depends": "py-genlayer:1zr6nqk597d97kg0dyxg0shhrykx5v02zjgnyrajapy4wlqvfvwh" }
+# v0.3.0
+# { "Depends": "py-genlayer:9b8kjyda2ycxyq4ea6g4yfpnydxhd52gqba5rb8dw7krkh5mn9p0" }
 
 import genlayer as gl
 

--- a/tests/integration/icontracts/contracts/faucet.py
+++ b/tests/integration/icontracts/contracts/faucet.py
@@ -1,8 +1,8 @@
-# v0.2.17
-# { "Depends": "py-genlayer:1zr6nqk597d97kg0dyxg0shhrykx5v02zjgnyrajapy4wlqvfvwh" }
+# v0.3.0
+# { "Depends": "py-genlayer:9b8kjyda2ycxyq4ea6g4yfpnydxhd52gqba5rb8dw7krkh5mn9p0" }
 
 import genlayer as gl
-from genlayer import *
+from genlayer.types import *
 
 
 @gl.evm.contract_interface
@@ -21,7 +21,7 @@ class Faucet(gl.contract.Contract):
     @gl.public.write.payable
     def send(self, recipient: str) -> None:
         v = gl.message.value
-        if v == u256(0):
+        if v == 0:
             raise gl.vm.UserError("send some value")
         _Recipient(Address(recipient)).emit_transfer(value=v)
 

--- a/tests/integration/icontracts/contracts/genvm_smoke_v1.py
+++ b/tests/integration/icontracts/contracts/genvm_smoke_v1.py
@@ -1,4 +1,4 @@
-# { "Depends": "py-genlayer:1zr6nqk597d97kg0dyxg0shhrykx5v02zjgnyrajapy4wlqvfvwh" }
+# { "Depends": "py-genlayer:9b8kjyda2ycxyq4ea6g4yfpnydxhd52gqba5rb8dw7krkh5mn9p0" }
 import genlayer as gl
 
 
@@ -14,8 +14,7 @@ class GenVMSmoke(gl.contract.Contract):
 
         def ask_llm() -> str:
             return gl.nondet.exec_prompt(
-                "Respond with exactly the two characters OK and nothing else.",
-                response_format="text",
+                "Respond with exactly the two characters OK and nothing else."
             ).strip()
 
         self.prompt_result = gl.eq_principle.strict_eq(ask_llm).strip()

--- a/tests/integration/icontracts/contracts/intelligent_oracle.py
+++ b/tests/integration/icontracts/contracts/intelligent_oracle.py
@@ -1,12 +1,11 @@
-# v0.1.0
-# { "Depends": "py-genlayer:1zr6nqk597d97kg0dyxg0shhrykx5v02zjgnyrajapy4wlqvfvwh" }
+# v0.3.0
+# { "Depends": "py-genlayer:9b8kjyda2ycxyq4ea6g4yfpnydxhd52gqba5rb8dw7krkh5mn9p0" }
 
 import json
 from enum import Enum
 from datetime import datetime
 from urllib.parse import urlparse
 import genlayer as gl
-from genlayer import *
 
 
 class Status(Enum):
@@ -20,10 +19,10 @@ class IntelligentOracle(gl.contract.Contract):
     prediction_market_id: str
     title: str
     description: str
-    potential_outcomes: DynArray[str]
-    rules: DynArray[str]
-    data_source_domains: DynArray[str]
-    resolution_urls: DynArray[str]
+    potential_outcomes: gl.storage.DynArray[str]
+    rules: gl.storage.DynArray[str]
+    data_source_domains: gl.storage.DynArray[str]
+    resolution_urls: gl.storage.DynArray[str]
     earliest_resolution_date: str  # Store as ISO format string
     status: str  # Store as string since Enum isn't supported
     analysis: str  # Store analysis results
@@ -225,13 +224,12 @@ Provide your response in **valid JSON** format with the following structure:
 - **Clarity:** Make sure your reasoning is easy to understand.
 - **Validity:** Ensure the JSON output is properly formatted and free of errors. Do not include trailing commas.
                 """
-                result = gl.nondet.exec_prompt(task, response_format="text")
+                result = gl.nondet.exec_prompt(task)
                 print(result)
                 return result
 
             result = gl.eq_principle.prompt_comparative(
                 evaluate_single_source,
-                # main SDK: prompt_comparative's principle is positional-only
                 "`outcome` field must be exactly the same. All other fields must be similar",
             )
 
@@ -308,13 +306,12 @@ Provide your response in **valid JSON** format with the following structure:
 
             """
 
-            result = gl.nondet.exec_prompt(task, response_format="text")
+            result = gl.nondet.exec_prompt(task)
             print(result)
             return result
 
         result = gl.eq_principle.prompt_comparative(
             evaluate_all_sources,
-            # main SDK: prompt_comparative's principle is positional-only
             "`outcome` field must be exactly the same. All other fields must be similar",
         )
 

--- a/tests/integration/icontracts/contracts/intelligent_oracle_factory.py
+++ b/tests/integration/icontracts/contracts/intelligent_oracle_factory.py
@@ -1,13 +1,12 @@
-# v0.1.0
-# { "Depends": "py-genlayer:1zr6nqk597d97kg0dyxg0shhrykx5v02zjgnyrajapy4wlqvfvwh" }
+# v0.3.0
+# { "Depends": "py-genlayer:9b8kjyda2ycxyq4ea6g4yfpnydxhd52gqba5rb8dw7krkh5mn9p0" }
 
 import genlayer as gl
-from genlayer import *
 
 
 class Registry(gl.contract.Contract):
     # Declare persistent storage fields
-    contract_addresses: DynArray[str]
+    contract_addresses: gl.storage.DynArray[str]
     intelligent_oracle_code: str
 
     def __init__(self, intelligent_oracle_code: str):

--- a/tests/integration/icontracts/contracts/multi_file_contract/__init__.py
+++ b/tests/integration/icontracts/contracts/multi_file_contract/__init__.py
@@ -1,5 +1,5 @@
 import genlayer as gl
-from genlayer import *
+from genlayer.types import *
 
 
 class MultiFileContract(gl.contract.Contract):
@@ -11,8 +11,8 @@ class MultiFileContract(gl.contract.Contract):
         self.other_addr = gl.contract.deploy(
             code=text.encode("utf-8"),
             args=["123"],
-            salt_nonce=u256(1),
-            value=u256(0),
+            salt_nonce=1,
+            value=0,
         )
 
     @gl.public.write

--- a/tests/integration/icontracts/contracts/multi_file_contract/other.py
+++ b/tests/integration/icontracts/contracts/multi_file_contract/other.py
@@ -1,4 +1,4 @@
-# { "Depends": "py-genlayer:1zr6nqk597d97kg0dyxg0shhrykx5v02zjgnyrajapy4wlqvfvwh" }
+# { "Depends": "py-genlayer:9b8kjyda2ycxyq4ea6g4yfpnydxhd52gqba5rb8dw7krkh5mn9p0" }
 
 import genlayer as gl
 

--- a/tests/integration/icontracts/contracts/multi_file_contract/runner.json
+++ b/tests/integration/icontracts/contracts/multi_file_contract/runner.json
@@ -1,3 +1,3 @@
 {
-    "Depends": "py-genlayer-multi:0jw6688wgnbqghr2wwg2mqkf2ryb5if7w6bp5zcwbq6zlks5ybg4"
+    "Depends": "py-genlayer-multi:mgqted4jvgzwawnd7sp7kjhfwwpr83a7wxhhdxcs4yk07jzt9c9g"
 }

--- a/tests/integration/icontracts/contracts/multi_read_erc20.py
+++ b/tests/integration/icontracts/contracts/multi_read_erc20.py
@@ -1,12 +1,12 @@
-# v0.1.0
-# { "Depends": "py-genlayer:1zr6nqk597d97kg0dyxg0shhrykx5v02zjgnyrajapy4wlqvfvwh" }
+# v0.3.0
+# { "Depends": "py-genlayer:9b8kjyda2ycxyq4ea6g4yfpnydxhd52gqba5rb8dw7krkh5mn9p0" }
 
 import genlayer as gl
-from genlayer import *
+from genlayer.types import *
 
 
 class multi_read_erc20(gl.contract.Contract):
-    balances: TreeMap[Address, TreeMap[Address, u256]]
+    balances: gl.storage.TreeMap[Address, gl.storage.TreeMap[Address, u256]]
 
     def __init__(self):
         pass

--- a/tests/integration/icontracts/contracts/multi_tenant_storage.py
+++ b/tests/integration/icontracts/contracts/multi_tenant_storage.py
@@ -1,8 +1,8 @@
-# v0.1.0
-# { "Depends": "py-genlayer:1zr6nqk597d97kg0dyxg0shhrykx5v02zjgnyrajapy4wlqvfvwh" }
+# v0.3.0
+# { "Depends": "py-genlayer:9b8kjyda2ycxyq4ea6g4yfpnydxhd52gqba5rb8dw7krkh5mn9p0" }
 
 import genlayer as gl
-from genlayer import *
+from genlayer.types import *
 
 
 class MultiTentantStorage(gl.contract.Contract):
@@ -13,9 +13,9 @@ class MultiTentantStorage(gl.contract.Contract):
     This is done to test contract calls between different contracts.
     """
 
-    all_storage_contracts: DynArray[Address]
-    available_storage_contracts: DynArray[Address]
-    mappings: TreeMap[
+    all_storage_contracts: gl.storage.DynArray[Address]
+    available_storage_contracts: gl.storage.DynArray[Address]
+    mappings: gl.storage.TreeMap[
         Address, Address
     ]  # mapping of user address to storage contract address
 

--- a/tests/integration/icontracts/contracts/payable_escrow.py
+++ b/tests/integration/icontracts/contracts/payable_escrow.py
@@ -1,8 +1,8 @@
-# v0.2.5
-# { "Depends": "py-genlayer:1zr6nqk597d97kg0dyxg0shhrykx5v02zjgnyrajapy4wlqvfvwh" }
+# v0.3.0
+# { "Depends": "py-genlayer:9b8kjyda2ycxyq4ea6g4yfpnydxhd52gqba5rb8dw7krkh5mn9p0" }
 
 import genlayer as gl
-from genlayer import *
+from genlayer.types import *
 
 
 class PayableEscrow(gl.contract.Contract):
@@ -11,12 +11,12 @@ class PayableEscrow(gl.contract.Contract):
 
     def __init__(self):
         self.depositor = Address(b"\x00" * 20)
-        self.deposited = u256(0)
+        self.deposited = 0
 
     @gl.public.write.payable
     def deposit(self) -> None:
         v = gl.message.value
-        if v == u256(0):
+        if v == 0:
             raise gl.vm.UserError("zero value")
         self.depositor = gl.message.sender_address
         self.deposited = self.deposited + v
@@ -26,9 +26,9 @@ class PayableEscrow(gl.contract.Contract):
         if gl.message.sender_address != self.depositor:
             raise gl.vm.UserError("not depositor")
         amount = self.deposited
-        if amount == u256(0):
+        if amount == 0:
             raise gl.vm.UserError("nothing to withdraw")
-        self.deposited = u256(0)
+        self.deposited = 0
         gl.contract.get_at(Address(to)).emit_transfer(value=amount)
 
     @gl.public.view

--- a/tests/integration/icontracts/contracts/read_erc20.py
+++ b/tests/integration/icontracts/contracts/read_erc20.py
@@ -1,8 +1,8 @@
-# v0.1.0
-# { "Depends": "py-genlayer:1zr6nqk597d97kg0dyxg0shhrykx5v02zjgnyrajapy4wlqvfvwh" }
+# v0.3.0
+# { "Depends": "py-genlayer:9b8kjyda2ycxyq4ea6g4yfpnydxhd52gqba5rb8dw7krkh5mn9p0" }
 
 import genlayer as gl
-from genlayer import *
+from genlayer.types import *
 
 
 class read_erc20(gl.contract.Contract):

--- a/tests/integration/icontracts/contracts/utf8_roundtrip_contract.py
+++ b/tests/integration/icontracts/contracts/utf8_roundtrip_contract.py
@@ -1,5 +1,5 @@
-# v0.1.0
-# { "Depends": "py-genlayer:1zr6nqk597d97kg0dyxg0shhrykx5v02zjgnyrajapy4wlqvfvwh" }
+# v0.3.0
+# { "Depends": "py-genlayer:9b8kjyda2ycxyq4ea6g4yfpnydxhd52gqba5rb8dw7krkh5mn9p0" }
 
 import genlayer as gl
 

--- a/tests/integration/icontracts/tests/test_error_llm.py
+++ b/tests/integration/icontracts/tests/test_error_llm.py
@@ -54,6 +54,7 @@ def test_llm_invalid_api_key():
 
 def test_llm_invalid_unknown_key():
     """Test LLM call with unknown API key"""
+    # UNKNOWN_KEY must be defined (to any non-empty invalid value) in the env: an undefined var resolves to "" -> zero providers -> CANCELED instead of the expected GenVM internal error.
     # Create a validator with an unknown API key
     for _ in range(5):
         result = post_request_localhost(

--- a/tests/integration/icontracts/tests/test_utf8_roundtrip_contract.py
+++ b/tests/integration/icontracts/tests/test_utf8_roundtrip_contract.py
@@ -21,7 +21,7 @@ def test_utf8_roundtrip_contract_over_rpc(setup_validators):
     contract_address = extract_contract_address(deploy_receipt)
 
     method_data = eth_utils.hexadecimal.encode_hex(
-        calldata.encode({"method": "get_enriched_submission", "args": []})
+        calldata.encode({"": "get_enriched_submission", "args": []})
     )
     raw_response = requests.post(
         RPC_URL,

--- a/tests/integration/test_upgrade_contract.py
+++ b/tests/integration/test_upgrade_contract.py
@@ -161,18 +161,18 @@ def write_contract_method(
 # Test Contracts
 # =============================================================================
 
-CONTRACT_V1 = """# v0.1.0
-# { "Depends": "py-genlayer:1zr6nqk597d97kg0dyxg0shhrykx5v02zjgnyrajapy4wlqvfvwh" }
+CONTRACT_V1 = """# v0.3.0
+# { "Depends": "py-genlayer:9b8kjyda2ycxyq4ea6g4yfpnydxhd52gqba5rb8dw7krkh5mn9p0" }
 
 import genlayer as gl
-from genlayer import *
+from genlayer.types import *
 
 class UpgradeTest(gl.contract.Contract):
     counter: u64
     name: str
 
     def __init__(self):
-        self.counter = u64(0)
+        self.counter = 0
         self.name = "initial"
 
     @gl.public.view
@@ -189,25 +189,25 @@ class UpgradeTest(gl.contract.Contract):
 
     @gl.public.write
     def increment(self) -> None:
-        self.counter = u64(int(self.counter) + 1)
+        self.counter = int(self.counter) + 1
 
     @gl.public.write
     def set_name(self, new_name: str) -> None:
         self.name = new_name
 """
 
-CONTRACT_V2 = """# v0.1.0
-# { "Depends": "py-genlayer:1zr6nqk597d97kg0dyxg0shhrykx5v02zjgnyrajapy4wlqvfvwh" }
+CONTRACT_V2 = """# v0.3.0
+# { "Depends": "py-genlayer:9b8kjyda2ycxyq4ea6g4yfpnydxhd52gqba5rb8dw7krkh5mn9p0" }
 
 import genlayer as gl
-from genlayer import *
+from genlayer.types import *
 
 class UpgradeTest(gl.contract.Contract):
     counter: u64
     name: str
 
     def __init__(self):
-        self.counter = u64(0)
+        self.counter = 0
         self.name = "initial"
 
     @gl.public.view
@@ -224,7 +224,7 @@ class UpgradeTest(gl.contract.Contract):
 
     @gl.public.write
     def increment(self) -> None:
-        self.counter = u64(int(self.counter) + 2)  # CHANGED: now increments by 2
+        self.counter = int(self.counter) + 2  # CHANGED: now increments by 2
 
     @gl.public.write
     def set_name(self, new_name: str) -> None:
@@ -235,11 +235,11 @@ class UpgradeTest(gl.contract.Contract):
         return "new in v2"  # NEW METHOD
 """
 
-CONTRACT_V3_WITH_NEW_STATE = """# v0.1.0
-# { "Depends": "py-genlayer:1zr6nqk597d97kg0dyxg0shhrykx5v02zjgnyrajapy4wlqvfvwh" }
+CONTRACT_V3_WITH_NEW_STATE = """# v0.3.0
+# { "Depends": "py-genlayer:9b8kjyda2ycxyq4ea6g4yfpnydxhd52gqba5rb8dw7krkh5mn9p0" }
 
 import genlayer as gl
-from genlayer import *
+from genlayer.types import *
 
 class UpgradeTest(gl.contract.Contract):
     counter: u64
@@ -247,7 +247,7 @@ class UpgradeTest(gl.contract.Contract):
     extra_field: str  # NEW FIELD
 
     def __init__(self):
-        self.counter = u64(0)
+        self.counter = 0
         self.name = "initial"
         self.extra_field = "default"
 
@@ -269,35 +269,35 @@ class UpgradeTest(gl.contract.Contract):
 
     @gl.public.write
     def increment(self) -> None:
-        self.counter = u64(int(self.counter) + 1)
+        self.counter = int(self.counter) + 1
 
     @gl.public.write
     def set_name(self, new_name: str) -> None:
         self.name = new_name
 """
 
-INVALID_CONTRACT = """# v0.1.0
-# { "Depends": "py-genlayer:1zr6nqk597d97kg0dyxg0shhrykx5v02zjgnyrajapy4wlqvfvwh" }
+INVALID_CONTRACT = """# v0.3.0
+# { "Depends": "py-genlayer:9b8kjyda2ycxyq4ea6g4yfpnydxhd52gqba5rb8dw7krkh5mn9p0" }
 
 import genlayer as gl
-from genlayer import *
+from genlayer.types import *
 
 class BrokenContract(gl.contract.Contract):
     def __init__(self):
         this is not valid python syntax!!!
 """
 
-SIMPLE_CONTRACT = """# v0.1.0
-# { "Depends": "py-genlayer:1zr6nqk597d97kg0dyxg0shhrykx5v02zjgnyrajapy4wlqvfvwh" }
+SIMPLE_CONTRACT = """# v0.3.0
+# { "Depends": "py-genlayer:9b8kjyda2ycxyq4ea6g4yfpnydxhd52gqba5rb8dw7krkh5mn9p0" }
 
 import genlayer as gl
-from genlayer import *
+from genlayer.types import *
 
 class SimpleContract(gl.contract.Contract):
     value: u64
 
     def __init__(self):
-        self.value = u64(42)
+        self.value = 42
 
     @gl.public.view
     def get_value(self) -> u64:

--- a/tests/load/contracts/counter.py
+++ b/tests/load/contracts/counter.py
@@ -1,17 +1,18 @@
-# v0.2.16
-# { "Depends": "py-genlayer:1jb45aa8ynh2a9c9xn3b7qqh8sm5q93hwfp7jqmwsfhh8jpz09h6" }
-from genlayer import *
+# v0.3.0
+# { "Depends": "py-genlayer:9b8kjyda2ycxyq4ea6g4yfpnydxhd52gqba5rb8dw7krkh5mn9p0" }
+import genlayer as gl
+from genlayer.types import *
 
 
-class Counter(gl.Contract):
+class Counter(gl.contract.Contract):
     count: bigint
 
     def __init__(self):
-        self.count = bigint(0)
+        self.count = 0
 
     @gl.public.write
     def increment(self) -> None:
-        self.count += bigint(1)
+        self.count += 1
 
     @gl.public.view
     def get_count(self) -> bigint:

--- a/tests/test_linter_endpoint.py
+++ b/tests/test_linter_endpoint.py
@@ -11,7 +11,7 @@ TEST_CONTRACT_WITH_ISSUES = """# Missing magic comment
 
 from genlayer import *
 
-class TestContract(gl.Contract):
+class TestContract(gl.contract.Contract):
     balance: int  # Should be u256
 
     # Missing __init__ method
@@ -22,11 +22,12 @@ class TestContract(gl.Contract):
 """
 
 # Valid contract
-VALID_CONTRACT = """# { "Depends": "py-genlayer:test" }
+VALID_CONTRACT = """# { "Depends": "py-genlayer:9b8kjyda2ycxyq4ea6g4yfpnydxhd52gqba5rb8dw7krkh5mn9p0" }
 
-from genlayer import *
+import genlayer as gl
+from genlayer.types import *
 
-class TestContract(gl.Contract):
+class TestContract(gl.contract.Contract):
     balance: u256
 
     def __init__(self):

--- a/tests/unit/test_genvm_debug_mode_gate.py
+++ b/tests/unit/test_genvm_debug_mode_gate.py
@@ -1,11 +1,12 @@
-"""Test the GENVM_DEBUG_MODE env-var gate around the executor's
-`--debug-mode` flag.
+"""Test the GENVM_DEBUG_MODE env-var gate around the genvm-manager
+`debug_mode` run-request level.
 
-`--debug-mode` enables `:latest` and `:test` runner version aliases in
-the genvm executor. Those aliases float across deploys and break
+The `unsafe` level enables `:latest` and `:test` runner version aliases
+in the genvm executor. Those aliases float across deploys and break
 determinism, so prd must have them disabled. The gate defaults to true
-(dev/stg keeps the convenience) but prd manifests should set
-GENVM_DEBUG_MODE=false.
+(dev/stg keeps the convenience via `unsafe`) but prd manifests should
+set GENVM_DEBUG_MODE=false, which drops to the consensus-safe `safe`
+level so the aliases fail fast.
 """
 
 import importlib
@@ -16,7 +17,7 @@ import pytest
 @pytest.fixture
 def base_module():
     """Reload backend.node.base so each test sees fresh env-var
-    evaluation. `_genvm_extra_args` reads `os.getenv` at call time, so
+    evaluation. `_genvm_debug_mode` reads `os.getenv` at call time, so
     reload isn't strictly required — but it guards against any future
     module-level memoization regression."""
     from backend.node import base
@@ -26,24 +27,25 @@ def base_module():
 
 
 def test_debug_mode_enabled_by_default(monkeypatch, base_module):
-    """Unset env var → include --debug-mode (dev/stg convenience)."""
+    """Unset env var → 'unsafe' (dev/stg convenience: aliases + capture)."""
     monkeypatch.delenv("GENVM_DEBUG_MODE", raising=False)
-    assert base_module._genvm_extra_args() == ["--debug-mode"]
+    assert base_module._genvm_debug_mode() == "unsafe"
 
 
 def test_debug_mode_enabled_when_true(monkeypatch, base_module):
     for value in ("true", "TRUE", "1", "yes", "on"):
         monkeypatch.setenv("GENVM_DEBUG_MODE", value)
-        assert base_module._genvm_extra_args() == [
-            "--debug-mode"
-        ], f"GENVM_DEBUG_MODE={value!r} should enable --debug-mode"
+        assert (
+            base_module._genvm_debug_mode() == "unsafe"
+        ), f"GENVM_DEBUG_MODE={value!r} should enable 'unsafe'"
 
 
 def test_debug_mode_disabled_when_false(monkeypatch, base_module):
-    """Prd setting: GENVM_DEBUG_MODE=false strips --debug-mode so the
-    executor rejects `py-genlayer:latest` / `:test` runner aliases."""
+    """Prd setting: GENVM_DEBUG_MODE=false → 'safe' so the executor rejects
+    `py-genlayer:9b8kjyda2ycxyq4ea6g4yfpnydxhd52gqba5rb8dw7krkh5mn9p0` / `:test` runner aliases.
+    """
     for value in ("false", "FALSE", "0", "no", "off", "anything-else"):
         monkeypatch.setenv("GENVM_DEBUG_MODE", value)
         assert (
-            base_module._genvm_extra_args() == []
-        ), f"GENVM_DEBUG_MODE={value!r} should disable --debug-mode"
+            base_module._genvm_debug_mode() == "safe"
+        ), f"GENVM_DEBUG_MODE={value!r} should disable to 'safe'"

--- a/tests/unit/test_node_state_proxy_metrics.py
+++ b/tests/unit/test_node_state_proxy_metrics.py
@@ -15,6 +15,7 @@ from backend.node.genvm.origin.base_host import RunHostAndProgramRes
 from backend.node.genvm.origin.public_abi import ResultCode
 from backend.node.types import Address, ExecutionMode, ExecutionResultStatus
 from backend.protocol_rpc.fees import (
+    GENVM_UNMETERED_DATA_FEE_BUCKET,
     StudioFeePolicy,
     create_fee_accounting,
     required_fee_deposit,
@@ -319,8 +320,9 @@ async def test_run_genvm_receives_fee_context_from_transaction_accounting():
     fee_context = run_genvm_host.await_args.kwargs["fee_context"]
     assert fee_context.bucket_totals == [
         fees_distribution["executionBudgetPerRound"],
-        fees_distribution["executionBudgetPerRound"],
         0,
+        GENVM_UNMETERED_DATA_FEE_BUCKET,
+        GENVM_UNMETERED_DATA_FEE_BUCKET,
     ]
     assert fee_context.gas_data["intrinsicGas"] == "21000"
 

--- a/tests/unit/test_studio_fees.py
+++ b/tests/unit/test_studio_fees.py
@@ -1554,7 +1554,12 @@ def test_genvm_fee_context_uses_transaction_execution_budget_and_policy():
         ),
     )
 
-    assert bucket_totals == [123, 123, 0]
+    assert bucket_totals == [
+        123,
+        0,
+        GENVM_UNMETERED_DATA_FEE_BUCKET,
+        GENVM_UNMETERED_DATA_FEE_BUCKET,
+    ]
     assert gas_data == {
         "storageUnitPrice": "3",
         "receiptGasPerByte": "36",
@@ -1608,8 +1613,9 @@ def test_genvm_fee_context_sets_message_bucket_independently():
 
     assert bucket_totals == [
         GENVM_UNMETERED_DATA_FEE_BUCKET,
-        GENVM_UNMETERED_DATA_FEE_BUCKET,
         55,
+        GENVM_UNMETERED_DATA_FEE_BUCKET,
+        GENVM_UNMETERED_DATA_FEE_BUCKET,
     ]
 
 
@@ -1876,7 +1882,12 @@ def test_genvm_fee_context_uses_locked_fee_policy_by_default():
 
     bucket_totals, gas_data = genvm_fee_context(accounting)
 
-    assert bucket_totals == [execution_budget, execution_budget, 0]
+    assert bucket_totals == [
+        execution_budget,
+        0,
+        GENVM_UNMETERED_DATA_FEE_BUCKET,
+        GENVM_UNMETERED_DATA_FEE_BUCKET,
+    ]
     assert gas_data["genPerTimeUnit"] == "2"
     assert gas_data["storageUnitPrice"] == "3"
     assert gas_data["receiptGasPerByte"] == "36"


### PR DESCRIPTION
Depends-On: https://github.com/genlayerlabs/genlayer-studio/pull/1697
Depends-On: https://github.com/genlayerlabs/genlayer-py/pull/96
Depends-On: https://github.com/genlayerlabs/genlayer-js/pull/192
Depends-On: https://github.com/genlayerlabs/genlayer-testing-suite/pull/98

Ports studio to genvm-manager (v0.3).

NOTE: I did not touch linters, gltest and other stuff

## Compatibility with old stuff

1. I checked that deployed studio is v0.2.16, so in new manager I added version for v0.2.16 with all runners, old layout and other stuff
2. I changed callldata abi for method call: `"method"` key became `""` so that it's value is prefix of binary calldata
  a. v0.2.16 has a hard remaping for exposing to contracts "method" and giving back only `""`
  b. currently manager if sees `"method"` in input calldata will remap it to `""` automatically and print an error
  c. **migration of genlayer-js and genlayer-py is needed!** migration in node and studio is more or less handled, I believe
3. code slot changed, this poses issues and I have not supported full v0.3 <-> v0.2 interop, I may need your help
  a. you may be interested in https://github.com/genlayerlabs/genvm-manager/blob/02741163aa89b10331f1585d9ea42868a816945f/docs/website/src/impl-spec/appendix/manager-api.yaml#L256
  b. maybe for real db we can add a field for each contract alongisde storage or whatever

## Other notes

there will be hash breaking commit to v0.3 with changing runners for allocating from balance

I have not yet supported builds releasesd and other stuff, as we are not merged into core and not even near that. For that reason I uploaded a hardcoded x86_64 artifact for you builded form commit for convenience

I ran **some** tests, deployed UI and verified basic functionality working. However, more complicated stuff may not work, it is a draft of changes