### PR TITLE
[codex] fix usage metrics percentage bounds

### DIFF
--- a/backend/services/usage_metrics_service.py
+++ b/backend/services/usage_metrics_service.py
@@ -1,6 +1,7 @@
 # backend/services/usage_metrics_service.py
 
 import asyncio
+import math
 import os
 from typing import Any, Optional
 from datetime import datetime
@@ -92,11 +93,11 @@ class UsageMetricsService:
                 "pendingTransactions": health_cache.pending_transactions,
                 "decisions": health_cache.total_decisions,
                 "users": health_cache.total_users,
-                "memoryUsage": health_cache.services.get("memory", {}).get(
-                    "percent", 0
+                "memoryUsage": self._bounded_percentage(
+                    health_cache.services.get("memory", {}).get("percent", 0)
                 ),
-                "cpuUsage": health_cache.services.get("memory", {}).get(
-                    "cpu_percent", 0
+                "cpuUsage": self._bounded_percentage(
+                    health_cache.services.get("memory", {}).get("cpu_percent", 0)
                 ),
             }
 
@@ -139,6 +140,19 @@ class UsageMetricsService:
             "initializing": "degraded",
         }
         return status_map.get(status, "down")
+
+    @staticmethod
+    def _bounded_percentage(value: Any) -> float:
+        """Return an API-safe percentage value in the inclusive 0-100 range."""
+        try:
+            percentage = float(value)
+        except (TypeError, ValueError):
+            return 0.0
+
+        if not math.isfinite(percentage):
+            return 0.0
+
+        return min(max(percentage, 0.0), 100.0)
 
     def _build_decision_payload(
         self, transaction: Transaction, finalization_data: dict

--- a/tests/unit/test_usage_metrics_service.py
+++ b/tests/unit/test_usage_metrics_service.py
@@ -61,6 +61,35 @@ async def test_system_health_metrics_include_max_recovery_events():
     ]
 
 
+@pytest.mark.asyncio
+async def test_system_health_metrics_bounds_percentage_values():
+    service = UsageMetricsService()
+    service._enabled = True
+    service._send_to_api = AsyncMock()
+
+    health_cache = SimpleNamespace(
+        status="healthy",
+        genvm_healthy=True,
+        uptime_percent=100.0,
+        pending_transactions=1,
+        total_decisions=2,
+        total_users=3,
+        issues=[],
+        pending_contracts=[],
+        services={
+            "consensus": {"active_workers": 1},
+            "memory": {"percent": -1.0, "cpu_percent": 250.0},
+        },
+    )
+
+    await service.send_system_health_metrics(health_cache)
+
+    service._send_to_api.assert_awaited_once()
+    payload = service._send_to_api.await_args.args[0]
+    assert payload["systemHealth"]["memoryUsage"] == 0.0
+    assert payload["systemHealth"]["cpuUsage"] == 100.0
+
+
 def test_extract_llm_token_metrics_keeps_only_llm_tokens():
     metrics = {
         "llm": {


### PR DESCRIPTION
## Summary
- Bound `memoryUsage` and `cpuUsage` before sending system health metrics to the usage metrics API.
- Add a regression test for out-of-range percentage values.

## Root cause
Rally JSONRPC pods were alive, but health metric ingestion was rejecting `systemHealth` payloads with HTTP 400: `cpuUsage must be a number between 0 and 100`. The reporter uses process CPU percent, which can exceed 100 on multi-core systems, while the metrics API expects a 0-100 percentage.

## Impact
This prevents a high CPU sample from causing the entire health report to be rejected, which should stop false `ALIVE BUT NOT REPORTING` alerts when RPC is otherwise healthy.

## Validation
- `.venv/bin/python -m pytest tests/unit/test_usage_metrics_service.py`