### PR TITLE
[codex] port usage metrics percentage bounds to v0.123-dev

### DIFF
--- a/backend/services/usage_metrics_service.py
+++ b/backend/services/usage_metrics_service.py
@@ -1,6 +1,7 @@
 # backend/services/usage_metrics_service.py
 
 import asyncio
+import math
 import os
 from typing import Any, Optional
 from datetime import datetime
@@ -92,11 +93,11 @@ class UsageMetricsService:
                 "pendingTransactions": health_cache.pending_transactions,
                 "decisions": health_cache.total_decisions,
                 "users": health_cache.total_users,
-                "memoryUsage": health_cache.services.get("memory", {}).get(
-                    "percent", 0
+                "memoryUsage": self._bounded_percentage(
+                    health_cache.services.get("memory", {}).get("percent", 0)
                 ),
-                "cpuUsage": health_cache.services.get("memory", {}).get(
-                    "cpu_percent", 0
+                "cpuUsage": self._bounded_percentage(
+                    health_cache.services.get("memory", {}).get("cpu_percent", 0)
                 ),
             }
 
@@ -159,6 +160,19 @@ class UsageMetricsService:
             "initializing": "degraded",
         }
         return status_map.get(status, "down")
+
+    @staticmethod
+    def _bounded_percentage(value: Any) -> float:
+        """Return an API-safe percentage value in the inclusive 0-100 range."""
+        try:
+            percentage = float(value)
+        except (TypeError, ValueError):
+            return 0.0
+
+        if not math.isfinite(percentage):
+            return 0.0
+
+        return min(max(percentage, 0.0), 100.0)
 
     def _build_decision_payload(
         self, transaction: Transaction, finalization_data: dict

--- a/tests/unit/test_usage_metrics_service.py
+++ b/tests/unit/test_usage_metrics_service.py
@@ -107,6 +107,35 @@ async def test_system_health_metrics_include_stuck_head_events():
     ]
 
 
+@pytest.mark.asyncio
+async def test_system_health_metrics_bounds_percentage_values():
+    service = UsageMetricsService()
+    service._enabled = True
+    service._send_to_api = AsyncMock()
+
+    health_cache = SimpleNamespace(
+        status="healthy",
+        genvm_healthy=True,
+        uptime_percent=100.0,
+        pending_transactions=1,
+        total_decisions=2,
+        total_users=3,
+        issues=[],
+        pending_contracts=[],
+        services={
+            "consensus": {"active_workers": 1},
+            "memory": {"percent": -1.0, "cpu_percent": 250.0},
+        },
+    )
+
+    await service.send_system_health_metrics(health_cache)
+
+    service._send_to_api.assert_awaited_once()
+    payload = service._send_to_api.await_args.args[0]
+    assert payload["systemHealth"]["memoryUsage"] == 0.0
+    assert payload["systemHealth"]["cpuUsage"] == 100.0
+
+
 def test_extract_llm_token_metrics_keeps_only_llm_tokens():
     metrics = {
         "llm": {


### PR DESCRIPTION
## Summary
- Port the v0.121 usage metrics percentage-bounding hotfix to `v0.123-dev`.
- Bounds `memoryUsage` and `cpuUsage` before sending system health metrics so out-of-range process CPU samples cannot make health ingestion reject the payload.
- Preserves the existing v0.123-dev stuck-head health event coverage and adds the percentage-bounds regression test.

## Release source
- v0.121 PR: #1700
- v0.121 release tag: `v0.121.16`
- Released commit on v0.121: `65042fa8699b0f42cb92f3dec7b0fb1a29b0ec23`
- Original hotfix commit: `283c68f2171187f3f3b1016ac68c9fcd4d6371fe`

## Validation
- `.venv/bin/python -m pytest tests/unit/test_usage_metrics_service.py`