### PR TITLE
fix: coalesce duplicate gen_call reads

### DIFF
--- a/backend/protocol_rpc/endpoints.py
+++ b/backend/protocol_rpc/endpoints.py
@@ -86,6 +86,13 @@ _RATE_LIMIT_MAX = int(
 _address_request_log: dict[str, list[float]] = {}  # {address: [timestamp, ...]}
 
 _rate_limit_logger = logging.getLogger(__name__ + ".rate_limit")
+_gen_call_singleflight_logger = logging.getLogger(__name__ + ".singleflight")
+
+_GEN_CALL_SINGLEFLIGHT_ENABLED = os.environ.get(
+    "GEN_CALL_SINGLEFLIGHT_ENABLED", "true"
+).lower() not in {"0", "false", "no", "off"}
+_gen_call_singleflight_tasks: dict[str, asyncio.Task[str]] = {}
+_gen_call_singleflight_lock = asyncio.Lock()
 
 
 def _check_rate_limit(address: str) -> None:
@@ -128,6 +135,66 @@ async def _admit_genvm_call(method: str, to_address: str | None):
         yield
     finally:
         _genvm_admission_semaphore.release()
+
+
+def _gen_call_singleflight_key(params: dict) -> str | None:
+    if not _GEN_CALL_SINGLEFLIGHT_ENABLED:
+        return None
+    if not isinstance(params, dict) or params.get("type") != "read":
+        return None
+
+    payload = json.dumps(params, sort_keys=True, separators=(",", ":"), default=str)
+    return hashlib.sha256(payload.encode()).hexdigest()
+
+
+async def _execute_gen_call_with_admission(
+    session: Session,
+    accounts_manager: AccountsManager,
+    msg_handler: IMessageHandler,
+    transactions_parser: TransactionParser,
+    validators_manager: validators.Manager,
+    genvm_manager: GenVMManager,
+    params: dict,
+) -> str:
+    to_address = params.get("to") if isinstance(params, dict) else None
+    async with _admit_genvm_call("gen_call", to_address):
+        receipt = await _execute_call_with_snapshot(
+            session,
+            accounts_manager,
+            msg_handler,
+            transactions_parser,
+            validators_manager,
+            genvm_manager,
+            params,
+        )
+    return eth_utils.hexadecimal.encode_hex(receipt.result[1:])[2:]
+
+
+async def _run_singleflight_gen_call(
+    key: str,
+    session: Session,
+    accounts_manager: AccountsManager,
+    msg_handler: IMessageHandler,
+    transactions_parser: TransactionParser,
+    validators_manager: validators.Manager,
+    genvm_manager: GenVMManager,
+    params: dict,
+) -> str:
+    try:
+        return await _execute_gen_call_with_admission(
+            session,
+            accounts_manager,
+            msg_handler,
+            transactions_parser,
+            validators_manager,
+            genvm_manager,
+            params,
+        )
+    finally:
+        task = asyncio.current_task()
+        async with _gen_call_singleflight_lock:
+            if _gen_call_singleflight_tasks.get(key) is task:
+                _gen_call_singleflight_tasks.pop(key, None)
 
 
 # ---------------------------------------------------------------------------
@@ -1203,9 +1270,9 @@ async def gen_call(
     genvm_manager: GenVMManager,
     params: dict,
 ) -> str:
-    to_address = params.get("to") if isinstance(params, dict) else None
-    async with _admit_genvm_call("gen_call", to_address):
-        receipt = await _execute_call_with_snapshot(
+    singleflight_key = _gen_call_singleflight_key(params)
+    if singleflight_key is None:
+        return await _execute_gen_call_with_admission(
             session,
             accounts_manager,
             msg_handler,
@@ -1214,7 +1281,30 @@ async def gen_call(
             genvm_manager,
             params,
         )
-    return eth_utils.hexadecimal.encode_hex(receipt.result[1:])[2:]
+
+    async with _gen_call_singleflight_lock:
+        task = _gen_call_singleflight_tasks.get(singleflight_key)
+        if task is None:
+            task = asyncio.create_task(
+                _run_singleflight_gen_call(
+                    singleflight_key,
+                    session,
+                    accounts_manager,
+                    msg_handler,
+                    transactions_parser,
+                    validators_manager,
+                    genvm_manager,
+                    params,
+                )
+            )
+            _gen_call_singleflight_tasks[singleflight_key] = task
+        else:
+            _gen_call_singleflight_logger.debug(
+                "Coalescing duplicate gen_call read for key %s",
+                singleflight_key[:12],
+            )
+
+    return await asyncio.shield(task)
 
 
 def sim_lint_contract(source_code: str, filename: str = "contract.py") -> dict:

--- a/tests/unit/test_rpc_genvm_admission.py
+++ b/tests/unit/test_rpc_genvm_admission.py
@@ -101,6 +101,191 @@ async def test_gen_call_rejects_before_validator_snapshot_when_genvm_full(monkey
 
 
 @pytest.mark.asyncio
+async def test_gen_call_coalesces_identical_read_calls_before_admission(monkeypatch):
+    semaphore = asyncio.Semaphore(1)
+    started = asyncio.Event()
+    release = asyncio.Event()
+    execute_calls = 0
+
+    monkeypatch.setattr(endpoints, "_GEN_CALL_SINGLEFLIGHT_ENABLED", True)
+    monkeypatch.setattr(endpoints, "_gen_call_singleflight_tasks", {})
+    monkeypatch.setattr(endpoints, "_gen_call_singleflight_lock", asyncio.Lock())
+    monkeypatch.setattr(endpoints, "_genvm_admission_semaphore", semaphore)
+
+    async def fake_execute_call_with_snapshot(*args, **kwargs):
+        nonlocal execute_calls
+        execute_calls += 1
+        started.set()
+        await release.wait()
+        return MagicMock(result=b"\x00\x12\x34")
+
+    monkeypatch.setattr(
+        endpoints, "_execute_call_with_snapshot", fake_execute_call_with_snapshot
+    )
+
+    params = {
+        "type": "read",
+        "to": "0x" + "ab" * 20,
+        "from": "0x" + "cd" * 20,
+        "data": "0x1234",
+        "transaction_hash_variant": "latest-nonfinal",
+    }
+
+    first = asyncio.create_task(
+        endpoints.gen_call(
+            session=MagicMock(),
+            accounts_manager=MagicMock(),
+            msg_handler=MagicMock(),
+            transactions_parser=MagicMock(),
+            validators_manager=MagicMock(),
+            genvm_manager=MagicMock(),
+            params=params,
+        )
+    )
+    await started.wait()
+
+    second = asyncio.create_task(
+        endpoints.gen_call(
+            session=MagicMock(),
+            accounts_manager=MagicMock(),
+            msg_handler=MagicMock(),
+            transactions_parser=MagicMock(),
+            validators_manager=MagicMock(),
+            genvm_manager=MagicMock(),
+            params=dict(params),
+        )
+    )
+
+    release.set()
+    assert await asyncio.gather(first, second) == ["1234", "1234"]
+    assert execute_calls == 1
+    assert semaphore._value == 1
+    assert endpoints._gen_call_singleflight_tasks == {}
+
+
+@pytest.mark.asyncio
+async def test_gen_call_keeps_different_callers_separate(monkeypatch):
+    semaphore = asyncio.Semaphore(2)
+    both_started = asyncio.Event()
+    release = asyncio.Event()
+    execute_calls = 0
+
+    monkeypatch.setattr(endpoints, "_GEN_CALL_SINGLEFLIGHT_ENABLED", True)
+    monkeypatch.setattr(endpoints, "_gen_call_singleflight_tasks", {})
+    monkeypatch.setattr(endpoints, "_gen_call_singleflight_lock", asyncio.Lock())
+    monkeypatch.setattr(endpoints, "_genvm_admission_semaphore", semaphore)
+
+    async def fake_execute_call_with_snapshot(*args, **kwargs):
+        nonlocal execute_calls
+        execute_calls += 1
+        if execute_calls == 2:
+            both_started.set()
+        await release.wait()
+        return MagicMock(result=b"\x00\x12\x34")
+
+    monkeypatch.setattr(
+        endpoints, "_execute_call_with_snapshot", fake_execute_call_with_snapshot
+    )
+
+    base_params = {
+        "type": "read",
+        "to": "0x" + "ab" * 20,
+        "data": "0x1234",
+        "transaction_hash_variant": "latest-nonfinal",
+    }
+
+    first = asyncio.create_task(
+        endpoints.gen_call(
+            session=MagicMock(),
+            accounts_manager=MagicMock(),
+            msg_handler=MagicMock(),
+            transactions_parser=MagicMock(),
+            validators_manager=MagicMock(),
+            genvm_manager=MagicMock(),
+            params={**base_params, "from": "0x" + "cd" * 20},
+        )
+    )
+    second = asyncio.create_task(
+        endpoints.gen_call(
+            session=MagicMock(),
+            accounts_manager=MagicMock(),
+            msg_handler=MagicMock(),
+            transactions_parser=MagicMock(),
+            validators_manager=MagicMock(),
+            genvm_manager=MagicMock(),
+            params={**base_params, "from": "0x" + "ef" * 20},
+        )
+    )
+
+    await both_started.wait()
+    release.set()
+    assert await asyncio.gather(first, second) == ["1234", "1234"]
+    assert execute_calls == 2
+    assert semaphore._value == 2
+
+
+@pytest.mark.asyncio
+async def test_gen_call_does_not_coalesce_write_calls(monkeypatch):
+    semaphore = asyncio.Semaphore(2)
+    both_started = asyncio.Event()
+    release = asyncio.Event()
+    execute_calls = 0
+
+    monkeypatch.setattr(endpoints, "_GEN_CALL_SINGLEFLIGHT_ENABLED", True)
+    monkeypatch.setattr(endpoints, "_gen_call_singleflight_tasks", {})
+    monkeypatch.setattr(endpoints, "_gen_call_singleflight_lock", asyncio.Lock())
+    monkeypatch.setattr(endpoints, "_genvm_admission_semaphore", semaphore)
+
+    async def fake_execute_call_with_snapshot(*args, **kwargs):
+        nonlocal execute_calls
+        execute_calls += 1
+        if execute_calls == 2:
+            both_started.set()
+        await release.wait()
+        return MagicMock(result=b"\x00\x12\x34")
+
+    monkeypatch.setattr(
+        endpoints, "_execute_call_with_snapshot", fake_execute_call_with_snapshot
+    )
+
+    params = {
+        "type": "write",
+        "to": "0x" + "ab" * 20,
+        "from": "0x" + "cd" * 20,
+        "data": "0x1234",
+    }
+
+    first = asyncio.create_task(
+        endpoints.gen_call(
+            session=MagicMock(),
+            accounts_manager=MagicMock(),
+            msg_handler=MagicMock(),
+            transactions_parser=MagicMock(),
+            validators_manager=MagicMock(),
+            genvm_manager=MagicMock(),
+            params=params,
+        )
+    )
+    second = asyncio.create_task(
+        endpoints.gen_call(
+            session=MagicMock(),
+            accounts_manager=MagicMock(),
+            msg_handler=MagicMock(),
+            transactions_parser=MagicMock(),
+            validators_manager=MagicMock(),
+            genvm_manager=MagicMock(),
+            params=dict(params),
+        )
+    )
+
+    await both_started.wait()
+    release.set()
+    assert await asyncio.gather(first, second) == ["1234", "1234"]
+    assert execute_calls == 2
+    assert endpoints._gen_call_singleflight_tasks == {}
+
+
+@pytest.mark.asyncio
 async def test_sim_call_rejects_before_validator_snapshot_when_genvm_full(monkeypatch):
     monkeypatch.setattr(endpoints, "_GENVM_CONCURRENCY", 1)
     monkeypatch.setattr(endpoints, "_genvm_admission_semaphore", asyncio.Semaphore(0))


### PR DESCRIPTION
## Summary
- Add a singleflight layer for read-only `gen_call` requests.
- Identical concurrent read calls now share the same in-flight execution task before acquiring the GenVM admission slot.
- Keep calls with different params separate, including different `from`, status/variant, calldata, value, or sim config.
- Leave write/deploy `gen_call` simulations uncoalesced.

## Why
Rally produced repeated identical expensive read calls while JSON-RPC execution slots were saturated. Coalescing prevents duplicate reads from consuming multiple GenVM slots and reduces pressure on the JSON-RPC pods while preserving request-specific semantics through a full canonical params hash.

## Timeout audit
The Studio Python `gen_call` path does not wrap the handler in a short request timeout. GenVM execution defaults to a 10 minute budget in `Node._run_genvm`. The hosted GCP stack did have shorter proxy timeouts: 60s nginx sidecar read timeout and 300s BackendConfig timeout. Those are addressed separately in devexp-apps-workload PR #277 by extending hosted JSON-RPC timeouts to 1200s.

## Validation
- `.venv/bin/python -m pytest tests/unit/test_rpc_genvm_admission.py`
- pre-commit hooks from `git commit` passed (`autoflake`, `black`, merge checks, etc.)