### PR TITLE
fix: use Docker service name 'postgres' as default DB host in alembic.ini

### DIFF
--- a/backend/database_handler/alembic.ini
+++ b/backend/database_handler/alembic.ini
@@ -60,8 +60,9 @@ version_path_separator = os  # Use os.pathsep. Default configuration used for ne
 # are written from script.py.mako
 # output_encoding = utf-8
 
-# This can be overrided with `DB_URL`. See more in `env.py`
-sqlalchemy.url = postgresql://postgres:postgres@localhost/genlayer_state
+# Default URL uses Docker service name 'postgres' as host.
+# Overridden at runtime by env.py using DBHOST, DBUSER, DBPASSWORD, DBPORT, DBNAME env vars.
+sqlalchemy.url = postgresql://postgres:postgres@postgres:5432/genlayer_state
 
 [post_write_hooks]
 # post_write_hooks defines scripts or Python functions that are run


### PR DESCRIPTION
## Summary

This PR fixes the database migration container failing on fresh `genlayer up` by updating the default `sqlalchemy.url` in `alembic.ini` to use the Docker service name `postgres` instead of `localhost`.

## Problem

The `database-migration` container was failing with:
```
connection to server at "localhost" (::1), port 5432 failed: Connection refused
```

This happened because `alembic.ini` hardcoded `localhost` as the database host, but in Docker Compose the PostgreSQL service is accessible via the service name `postgres`, not `localhost`.

## Solution

Changed the default `sqlalchemy.url` in `alembic.ini` from:
```
postgresql://postgres:postgres@localhost/genlayer_state
```
to:
```
postgresql://postgres:postgres@postgres:5432/genlayer_state
```

This matches the Docker Compose service name and the default `DBHOST` value in `.env.example`.

## Testing

- Verified that `env.py` still properly overrides this URL with environment variables
- The change only affects the default fallback value when `DBHOST` is not set

Fixes #1698

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated database configuration to support PostgreSQL connections through the Docker service.
  * Clarified that runtime environment settings can override connection details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->