### PR TITLE
fix(pruner): stop declaring Content-Encoding on snapshot archives

### DIFF
--- a/backend/database_handler/terminal_snapshot_pruner.py
+++ b/backend/database_handler/terminal_snapshot_pruner.py
@@ -443,7 +443,10 @@ class GCSSnapshotArchiveWriter:
         key = self.key_for_hash(candidate.tx_hash)
         bucket = self.client.bucket(self.bucket)
         blob = bucket.blob(key)
-        blob.content_encoding = "gzip"
+        # Deliberately not setting content_encoding: the body is already gzipped and
+        # the key ends in .json.gz. Declaring it makes GCS decompressively transcode
+        # on read, which returns a byte count that disagrees with the listed size and
+        # silently ignores Range requests, breaking external readers.
         blob.metadata = metadata
         if self.storage_class:
             blob.storage_class = self.storage_class
@@ -570,11 +573,12 @@ class S3SnapshotArchiveWriter:
         key = self.key_for_hash(candidate.tx_hash)
         compressed_digest = bytes.fromhex(compressed_sha256)
 
+        # ContentEncoding is likewise omitted; readers decompress the stored bytes
+        # themselves, and the header only invites clients to do it for them.
         put_kwargs: dict[str, Any] = {
             "Bucket": self.bucket,
             "Key": key,
             "Body": body,
-            "ContentEncoding": "gzip",
             "ContentType": "application/json",
             "ChecksumSHA256": base64.b64encode(compressed_digest).decode("ascii"),
             "Metadata": metadata,

--- a/tests/unit/test_terminal_snapshot_pruner.py
+++ b/tests/unit/test_terminal_snapshot_pruner.py
@@ -258,7 +258,7 @@ def test_s3_archive_writer_compresses_snapshot_with_checksum_and_metadata():
     assert call["StorageClass"] == "GLACIER_IR"
     assert call["ServerSideEncryption"] == "aws:kms"
     assert call["SSEKMSKeyId"] == "alias/studio-archive"
-    assert call["ContentEncoding"] == "gzip"
+    assert "ContentEncoding" not in call
     assert gzip.decompress(call["Body"]) == b'{"x":1}'
     expected_digest = hashlib.sha256(call["Body"]).digest()
     assert call["ChecksumSHA256"] == base64.b64encode(expected_digest).decode("ascii")
@@ -550,7 +550,7 @@ def test_gcs_archive_writer_uploads_compressed_snapshot_with_metadata():
     assert result.backend == "gcs"
     assert result.bucket == "archive-bucket"
     assert result.uri == f"gs://archive-bucket/{result.key}"
-    assert blob.content_encoding == "gzip"
+    assert blob.content_encoding is None
     assert blob.storage_class == "NEARLINE"
     assert blob.metadata["tx-hash"] == "0xABCDEF"
     assert blob.metadata["snapshot-sha256"] == hashlib.sha256(b'{"x":1}').hexdigest()


### PR DESCRIPTION
Snapshot archive objects are written gzip-compressed with keys ending in `.json.gz`, and additionally declare `Content-Encoding: gzip` on the stored object. That header is unnecessary for our own readers and actively breaks external ones.

## Impact

AWS DataSync cannot read the prd studio snapshot archives at all. A task over `simulator-440803-prd-studio-snapshot-archives` listed 233 objects and errored on all 233, transferring 0 bytes, reporting only a generic "Operation failed due to a transient error".

The cause is GCS decompressive transcoding. Verified against a real object with a stored size of 128 bytes:

| Request | Result |
| --- | --- |
| Plain `GET` | `x-guploader-response-body-transformations: gunzipped`, **125 bytes**, no `Content-Length` — while listing advertises **128** |
| `GET` with `Accept-Encoding: gzip` | 128 bytes, `Content-Length: 128` |
| `Range: bytes=0-9` | **HTTP 200, not 206** — range ignored, no `Content-Range` |

DataSync lists each object at its stored size, then issues a plain/ranged GET, receives a different byte count with no `Content-Length`, and has its ranges ignored. Every object fails to prepare. rclone (`corrupted on transfer: sizes differ`) and `aws s3 cp` against the S3-compatible endpoint fail the same way.

This is not an IAM problem. `roles/storage.objectViewer` and `roles/storage.bucketViewer` are both bound unconditionally, there is no CMEK, and uniform bucket-level access is on so object ACLs are disabled entirely.

## Why this is safe

Nothing depends on the transcoding:

- every GCS read uses `download_as_bytes(raw_download=True)`, i.e. stored bytes
- the app verifies the compressed checksum and calls `gzip.decompress()` itself
- the S3 reader likewise reads raw bytes and decompresses them itself

`raw_download=True` was in fact added by #1687 ("fix: read raw gcs snapshot archives") to work around this same transcoding from the read side. Removing the header addresses the cause instead. The existing `raw_download=True` calls keep working unchanged, since a raw download of a non-transcoded object returns the same bytes.

## Changes

- drop `blob.content_encoding = "gzip"` from the GCS writer
- drop `"ContentEncoding": "gzip"` from the S3 writer's `put_kwargs` — S3 does not transcode on GET so nothing changes server-side, but the header invites HTTP clients to decompress bodies readers already handle
- invert the two test assertions that pinned the old behaviour

## Follow-up (not in this PR)

Objects written before this change still carry the header and need a metadata-only backfill to become copyable:

```
gcloud storage objects update "gs://<bucket>/<prefix>/**" \
  --content-encoding="" --project=<project>
```

Recommend applying to a single object and re-running the DataSync task to confirm before the full prefix. Reversible with `--content-encoding=gzip`.

## Testing

`tests/unit/test_terminal_snapshot_pruner.py` — 47 passed.