### PR TITLE
fix(explorer): pin Radix slot for production builds

### DIFF
--- a/explorer/package.json
+++ b/explorer/package.json
@@ -15,7 +15,7 @@
     "@radix-ui/react-popover": "^1.1.15",
     "@radix-ui/react-select": "^2.2.6",
     "@radix-ui/react-separator": "^1.1.8",
-    "@radix-ui/react-slot": "^1.2.4",
+    "@radix-ui/react-slot": "1.2.4",
     "@radix-ui/react-tabs": "^1.1.13",
     "@radix-ui/react-tooltip": "^1.2.8",
     "class-variance-authority": "^0.7.1",


### PR DESCRIPTION
## Summary

- pin `@radix-ui/react-slot` to the last compatible `1.2.4` release
- prevent clean production installs from resolving `1.3.1`, which breaks the Next.js server build with `TypeError: createContext is not a function`

## Context

The production load-test workflow and the release workflow both build the Explorer image. The load-test job failed during that image build before any load scenarios ran. This dependency pin removes that release blocker.

## Validation

- clean `npm install --ignore-scripts`
- `npm run build` — passed, including `/address/[addr]` page-data collection
- pre-commit hooks — passed