### PR TITLE
fix: correct defects found while retiring SonarCloud

### DIFF
--- a/backend/database_handler/transactions_processor.py
+++ b/backend/database_handler/transactions_processor.py
@@ -408,9 +408,7 @@ class TransactionsProcessor:
                         bytes(value, encoding="utf-8")
                     ).decode("utf-8", errors="ignore")
                     byte_content = re.sub(r"^[\x00-\x1f]+", "", decoded_str)
-                    if byte_content or len(byte_content) >= 0:
-                        return byte_content
-                    return decoded_str
+                    return byte_content
                 except (ValueError, UnicodeDecodeError):
                     return value  # Return original if decoding fails
 

--- a/backend/protocol_rpc/fastapi_server.py
+++ b/backend/protocol_rpc/fastapi_server.py
@@ -61,17 +61,17 @@ async def lifespan(app: FastAPI):
 # Create FastAPI app
 app = FastAPI(title="GenLayer Studio RPC API", version="1.0.0", lifespan=lifespan)
 
-# Add CORS middleware
+# Rate limiting is inner so CORS decorates short-circuit responses such as 429s.
+app.add_middleware(RateLimitMiddleware)
+
+# This public RPC uses header-based API keys and no cookie authentication.
 app.add_middleware(
     CORSMiddleware,
     allow_origins=["*"],
-    allow_credentials=True,
+    allow_credentials=False,
     allow_methods=["*"],
     allow_headers=["*"],
 )
-
-# Add rate limiting middleware (executes after CORS, before route handler)
-app.add_middleware(RateLimitMiddleware)
 
 # Include health check endpoints
 app.include_router(health_router)

--- a/backend/protocol_rpc/health.py
+++ b/backend/protocol_rpc/health.py
@@ -160,10 +160,12 @@ def _get_readiness_permit_jitter_seconds() -> float:
         return 2.0
 
 
+def _generate_readiness_jitter_seconds() -> float:
+    return random.random() * _get_readiness_permit_jitter_seconds()
+
+
 # Per-process stable jitter in [0, jitter_s]
-_READINESS_JITTER_S: float = (
-    random.Random(os.getpid()).random() * _get_readiness_permit_jitter_seconds()
-)
+_READINESS_JITTER_S: float = _generate_readiness_jitter_seconds()
 
 
 def _evaluate_permit_readiness(

--- a/backend/protocol_rpc/message_handler/redis_worker_handler.py
+++ b/backend/protocol_rpc/message_handler/redis_worker_handler.py
@@ -11,7 +11,7 @@ import redis.asyncio as aioredis
 from loguru import logger
 
 from backend.protocol_rpc.message_handler.base import MessageHandler
-from backend.protocol_rpc.message_handler.types import LogEvent
+from backend.protocol_rpc.message_handler.types import EventScope, LogEvent
 from backend.protocol_rpc.configuration import GlobalConfiguration
 
 
@@ -127,9 +127,9 @@ class RedisWorkerMessageHandler(MessageHandler):
         Returns:
             The Redis channel name
         """
-        if log_event.scope.value == "Transaction":
+        if log_event.scope == EventScope.TRANSACTION:
             return self.TRANSACTION_CHANNEL
-        elif log_event.scope.value == "Consensus":
+        elif log_event.scope == EventScope.CONSENSUS:
             return self.CONSENSUS_CHANNEL
         else:
             return self.GENERAL_CHANNEL
@@ -206,10 +206,10 @@ class RedisWorkerMessageHandler(MessageHandler):
             self._log_message(log_event)
 
         # Publish to Redis if it's an important event
-        if log_event.transaction_hash or log_event.scope.value in [
-            "TRANSACTION",
-            "CONSENSUS",
-        ]:
+        if log_event.transaction_hash or log_event.scope in (
+            EventScope.TRANSACTION,
+            EventScope.CONSENSUS,
+        ):
             self._socket_emit(log_event)
 
     async def send_message_async(
@@ -227,10 +227,10 @@ class RedisWorkerMessageHandler(MessageHandler):
             self._log_message(log_event)
 
         # Publish to Redis if it's an important event and await completion
-        if log_event.transaction_hash or log_event.scope.value in [
-            "TRANSACTION",
-            "CONSENSUS",
-        ]:
+        if log_event.transaction_hash or log_event.scope in (
+            EventScope.TRANSACTION,
+            EventScope.CONSENSUS,
+        ):
             await self._publish_to_redis(log_event)
 
     async def close(self):

--- a/backend/protocol_rpc/message_handler/worker_handler.py
+++ b/backend/protocol_rpc/message_handler/worker_handler.py
@@ -11,7 +11,7 @@ import aiohttp
 from loguru import logger
 
 from backend.protocol_rpc.message_handler.base import MessageHandler
-from backend.protocol_rpc.message_handler.types import LogEvent
+from backend.protocol_rpc.message_handler.types import EventScope, LogEvent
 from backend.protocol_rpc.configuration import GlobalConfiguration
 
 
@@ -138,10 +138,10 @@ class WorkerMessageHandler(MessageHandler):
             self._log_message(log_event)
 
         # Forward to JSON-RPC server if it's an important event
-        if log_event.transaction_hash or log_event.scope.value in [
-            "TRANSACTION",
-            "CONSENSUS",
-        ]:
+        if log_event.transaction_hash or log_event.scope in (
+            EventScope.TRANSACTION,
+            EventScope.CONSENSUS,
+        ):
             self._socket_emit(log_event)
 
     async def close(self):

--- a/backend/validators/__init__.py
+++ b/backend/validators/__init__.py
@@ -1,4 +1,4 @@
-__all__ = ("Manager", "with_lock", "select_random_different_validator")
+__all__ = ("Manager", "select_random_different_validator")
 
 import asyncio
 import typing

--- a/tests/unit/protocol_rpc/test_redis_worker_handler.py
+++ b/tests/unit/protocol_rpc/test_redis_worker_handler.py
@@ -1,0 +1,62 @@
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+
+from backend.protocol_rpc.message_handler.redis_worker_handler import (
+    RedisWorkerMessageHandler,
+)
+from backend.protocol_rpc.message_handler.types import EventScope, EventType, LogEvent
+from backend.protocol_rpc.message_handler.worker_handler import WorkerMessageHandler
+
+
+def _scope_only_event(scope: EventScope) -> LogEvent:
+    return LogEvent(
+        name="scope-only",
+        type=EventType.INFO,
+        scope=scope,
+        message="scope-only event",
+    )
+
+
+@pytest.mark.parametrize(
+    ("scope", "channel"),
+    [
+        (EventScope.TRANSACTION, RedisWorkerMessageHandler.TRANSACTION_CHANNEL),
+        (EventScope.CONSENSUS, RedisWorkerMessageHandler.CONSENSUS_CHANNEL),
+    ],
+)
+def test_scope_only_events_are_published(scope, channel):
+    handler = RedisWorkerMessageHandler.__new__(RedisWorkerMessageHandler)
+    handler._log_message = Mock()
+    handler._socket_emit = Mock()
+    event = _scope_only_event(scope)
+
+    handler.send_message(event)
+
+    handler._socket_emit.assert_called_once_with(event)
+    assert handler._get_channel_for_event(event) == channel
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("scope", [EventScope.TRANSACTION, EventScope.CONSENSUS])
+async def test_scope_only_events_are_published_async(scope):
+    handler = RedisWorkerMessageHandler.__new__(RedisWorkerMessageHandler)
+    handler._log_message = Mock()
+    handler._publish_to_redis = AsyncMock()
+    event = _scope_only_event(scope)
+
+    await handler.send_message_async(event)
+
+    handler._publish_to_redis.assert_awaited_once_with(event)
+
+
+@pytest.mark.parametrize("scope", [EventScope.TRANSACTION, EventScope.CONSENSUS])
+def test_scope_only_events_are_forwarded_by_http_worker(scope):
+    handler = WorkerMessageHandler.__new__(WorkerMessageHandler)
+    handler._log_message = Mock()
+    handler._socket_emit = Mock()
+    event = _scope_only_event(scope)
+
+    handler.send_message(event)
+
+    handler._socket_emit.assert_called_once_with(event)

--- a/tests/unit/test_fallback_validator_model.py
+++ b/tests/unit/test_fallback_validator_model.py
@@ -1,5 +1,14 @@
 import backend.domain.types as domain
+import backend.validators as validators
 from backend.validators import select_random_different_validator
+
+
+def test_all_exports_exist():
+    namespace = {}
+
+    exec("from backend.validators import *", namespace)
+
+    assert set(validators.__all__).issubset(namespace)
 
 
 def create_test_validator(

--- a/tests/unit/test_rate_limit_middleware.py
+++ b/tests/unit/test_rate_limit_middleware.py
@@ -98,6 +98,20 @@ class TestMiddlewarePassthrough:
         call_next.assert_called_once()
 
 
+def test_rpc_app_cors_wraps_rate_limiting_without_credentials():
+    from fastapi.middleware.cors import CORSMiddleware
+
+    from backend.protocol_rpc.fastapi_server import app
+
+    cors_class, _, cors_options = app.user_middleware[0]
+    rate_limit_class, _, _ = app.user_middleware[1]
+
+    assert cors_class is CORSMiddleware
+    assert cors_options["allow_origins"] == ["*"]
+    assert cors_options["allow_credentials"] is False
+    assert rate_limit_class is RateLimitMiddleware
+
+
 class TestMiddlewareRateLimiting:
     @pytest.mark.asyncio
     async def test_allows_when_under_limit(self):

--- a/tests/unit/test_rpc_health_genvm_tracking.py
+++ b/tests/unit/test_rpc_health_genvm_tracking.py
@@ -12,6 +12,21 @@ import pytest
 import backend.protocol_rpc.health as health_module
 
 
+def test_readiness_jitter_uses_default_process_rng():
+    with (
+        patch.object(health_module.random, "random", return_value=0.25) as random_fn,
+        patch.object(
+            health_module,
+            "_get_readiness_permit_jitter_seconds",
+            return_value=8.0,
+        ),
+    ):
+        jitter = health_module._generate_readiness_jitter_seconds()
+
+    assert jitter == 2.0
+    random_fn.assert_called_once_with()
+
+
 class TestGenVMExecutionFailureTracking:
     """Test GenVM execution failure tracking functions."""
 


### PR DESCRIPTION
Five verified defects, harvested from a SonarCloud triage sweep before that project is retired (see #1710). Independent fixes, reviewable separately in the diff.

Context on the sweep: 198 findings triaged, 11 real (~1 in 18). Notably, all 70 `VULNERABILITY`-type findings yielded **zero** real defects. Two of the five below were found *while checking* a Sonar finding rather than being flagged by it.

## 1. CORS advertised credentialed access to any origin

`fastapi_server.py` had `allow_origins=["*"]` together with `allow_credentials=True`. Starlette responds by echoing the caller's Origin rather than a literal `*`, so any website could make credentialed cross-origin requests to hosted Studio.

Verified that credentials are not needed: authentication is the `X-API-Key` **header** (`rate_limit_middleware.py:64`), there is no `set_cookie` anywhere in the RPC backend, and the frontend does not use `withCredentials`. A custom header is already permitted by `allow_headers=["*"]`. Set `allow_credentials=False`; origins are unchanged, since this is deliberately a public RPC.

**Sonar did not flag this.** It was found while investigating the middleware-order issue below.

## 2. Rate-limit rejections carried no CORS headers

`add_middleware` inserts at index 0, so the last middleware added is outermost. CORS was added first and RateLimit second, making RateLimit outermost — its 429 short-circuit returned without passing back out through CORS, so browsers saw an opaque network/CORS failure instead of a readable 429. The inline comment asserted the opposite of what the code did.

RateLimit is now added first (inner), CORS last (outermost), and the comment states the actual relationship.

## 3. Consensus events were gated on a comparison that never matched

`redis_worker_handler.py` tested `log_event.scope.value in ["TRANSACTION", "CONSENSUS"]`, but the enum's values are `"Transaction"` and `"Consensus"`. The same class compared them correctly elsewhere. The test was therefore always false, and publication was gated solely on `transaction_hash` — scope-only consensus events were silently never published.

Present in **three** places (the sweep identified two; `worker_handler.py` had it as well). All now compare against `EventScope` members rather than string literals, so a value rename cannot silently reintroduce it.

## 4. Readiness jitter was identical across replicas

`health.py` seeded jitter with `random.Random(os.getpid())`. The stated intent is jitter stable within a process but different between processes, so replicas don't flip readiness in lockstep — but containerised replicas commonly share a PID, so every pod computed the same jitter and would withdraw readiness simultaneously, which is the behaviour the jitter exists to prevent. Now unseeded; per-process stability still comes from the module-level assignment.

## 5. Two smaller ones

- `transactions_processor.py`: `if byte_content or len(byte_content) >= 0:` — `len(x) >= 0` is always true, making the guard a no-op and the following return unreachable. Removed the tautology without changing behaviour. The *original* intent is ambiguous; this is deliberately not a behavioural change.
- `backend/validators/__init__.py`: `__all__` exported `with_lock`, which is defined nowhere, so `import *` would raise. Latent (no star-import exists today). Confirmed no definition or caller, then removed the entry.

## Verification

Backend unit tests pass (56 in the touched files). The new tests were checked against the **unfixed** code first — 6 of them fail without these changes, so they pin the defects rather than merely passing.

Items 1 and 2 affect a live hosted service; item 2's behaviour is browser-observable and worth a smoke check after deploy.