### PR TITLE
fix: preserve serialized receipt errors in usage metrics

### DIFF
--- a/backend/services/usage_metrics_service.py
+++ b/backend/services/usage_metrics_service.py
@@ -297,7 +297,9 @@ class UsageMetricsService:
         if consensus_data is not None and consensus_data.leader_receipt:
             first_receipt = consensus_data.leader_receipt[0]
             if first_receipt is not None:
-                execution_result = getattr(first_receipt, "execution_result", None)
+                execution_result = self._receipt_field(
+                    first_receipt, "execution_result"
+                )
                 if execution_result is not None:
                     # Handle both enum and string values
                     if hasattr(execution_result, "value"):

--- a/tests/unit/test_bug_hunt_v0_123_dev.py
+++ b/tests/unit/test_bug_hunt_v0_123_dev.py
@@ -1,0 +1,18 @@
+from types import SimpleNamespace
+
+from backend.services.usage_metrics_service import UsageMetricsService
+
+
+def test_usage_metrics_preserves_error_from_serialized_leader_receipt():
+    """Finalization metrics must not turn a VM error into a successful decision."""
+    consensus_data = SimpleNamespace(
+        leader_receipt=[{"execution_result": "ERROR"}],
+    )
+
+    result = UsageMetricsService()._extract_execution_result(
+        finalization_data={},
+        consensus_data=consensus_data,
+        consensus_history=None,
+    )
+
+    assert result == "error"


### PR DESCRIPTION
## What

Fixes a confirmed `v0.123-dev` usage-metrics defect and retains its regression coverage.

Serialized dictionary leader receipts were read with attribute access, causing `ERROR` execution results to fall through to the default `success` classification. The extractor now uses the existing dict/object-safe receipt helper.

This finding is separate from the catalog in #1704.

## Validation

- Usage-metrics and regression tests: 12 passed
- Black check: passed