### PR TITLE
fix: preserve exact faucet amounts in wei

### DIFF
--- a/frontend/src/components/Simulator/AccountSelect.vue
+++ b/frontend/src/components/Simulator/AccountSelect.vue
@@ -6,6 +6,7 @@ import { Wallet, Droplets } from 'lucide-vue-next';
 import { PlusIcon } from '@heroicons/vue/16/solid';
 import { notify } from '@kyvg/vue3-notification';
 import { useEventTracking, useWallet, useRpcClient } from '@/hooks';
+import { parseGenAmountToWei } from '@/utils/tokenAmount';
 import { computed, ref, watch, onMounted } from 'vue';
 
 const store = useAccountsStore();
@@ -72,21 +73,20 @@ const handleCreateNewAccount = async () => {
 
 const handleFundAccount = async () => {
   if (!store.selectedAccount?.address) return;
-  const amount = parseFloat(faucetAmount.value);
-  if (isNaN(amount) || amount <= 0) {
+  const weiAmount = parseGenAmountToWei(faucetAmount.value);
+  if (weiAmount === null || weiAmount <= 0n) {
     notify({ title: 'Enter a valid amount', type: 'error' });
     return;
   }
 
   isFunding.value = true;
   try {
-    const weiAmount = BigInt(Math.floor(amount * 1e18));
     await rpcClient.fundAccount(
       store.selectedAccount.address,
-      Number(weiAmount),
+      weiAmount.toString(),
     );
     notify({
-      title: `Funded ${amount} GEN`,
+      title: `Funded ${faucetAmount.value.trim()} GEN`,
       type: 'success',
     });
     showFaucet.value = false;

--- a/frontend/src/services/JsonRpcService.ts
+++ b/frontend/src/services/JsonRpcService.ts
@@ -93,7 +93,7 @@ export class JsonRpcService implements IJsonRpcService {
     ) as Promise<string>;
   }
 
-  async fundAccount(address: string, amount: number): Promise<any> {
+  async fundAccount(address: string, amount: string): Promise<any> {
     return this.callRpcMethod<any>(
       'sim_fundAccount',
       [address, amount],

--- a/frontend/src/utils/tokenAmount.ts
+++ b/frontend/src/utils/tokenAmount.ts
@@ -1,0 +1,13 @@
+const WEI_PER_GEN = 10n ** 18n;
+
+export const parseGenAmountToWei = (value: string): bigint | null => {
+  const normalized = value.trim();
+  if (!/^\d+(?:\.\d{1,18})?$/.test(normalized)) {
+    return null;
+  }
+
+  const parts = normalized.split('.');
+  const whole = parts[0] ?? '0';
+  const fraction = parts[1] ?? '';
+  return BigInt(whole) * WEI_PER_GEN + BigInt(fraction.padEnd(18, '0') || '0');
+};

--- a/frontend/test/unit/utils/tokenAmount.test.ts
+++ b/frontend/test/unit/utils/tokenAmount.test.ts
@@ -1,0 +1,19 @@
+import { parseGenAmountToWei } from '@/utils/tokenAmount';
+import { describe, expect, it } from 'vitest';
+
+describe('parseGenAmountToWei', () => {
+  it('preserves all 18 decimal places without Number precision loss', () => {
+    expect(parseGenAmountToWei('0.123456789012345678')).toBe(
+      123456789012345678n,
+    );
+    expect(parseGenAmountToWei('9007199254740993')).toBe(
+      9007199254740993000000000000000000n,
+    );
+  });
+
+  it('rejects values that cannot be represented exactly as wei', () => {
+    expect(parseGenAmountToWei('1.0000000000000000001')).toBeNull();
+    expect(parseGenAmountToWei('1e3')).toBeNull();
+    expect(parseGenAmountToWei('-1')).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- parse GEN decimal input directly to bigint without floating-point conversion
- send exact decimal wei strings over JSON-RPC
- reject unsupported precision and scientific notation

## Verification
- focused Vitest suite (2 passed)
- Vue TypeScript check
- pre-commit ESLint and Prettier hooks