### PR TITLE
fix(security): bind postgres to loopback

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -258,7 +258,7 @@ services:
     image: postgres:16-alpine
     command: sh -c "if [ \"$REMOTE_DATABASE\" = \"true\" ]; then echo 'Postgres disabled in hosted environment' && exec tail -f /dev/null; else exec docker-entrypoint.sh postgres; fi"
     ports:
-      - "${DBHOSTPORT:-5432}:5432"
+      - "127.0.0.1:${DBHOSTPORT:-5432}:5432"
     environment:
       - POSTGRES_USER=${DBUSER}
       - POSTGRES_PASSWORD=${DBPASSWORD}

--- a/tests/unit/test_docker_compose_security.py
+++ b/tests/unit/test_docker_compose_security.py
@@ -1,0 +1,16 @@
+from pathlib import Path
+
+import yaml
+
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_postgres_is_bound_to_loopback_by_default():
+    compose = yaml.safe_load(
+        (REPOSITORY_ROOT / "docker-compose.yml").read_text(encoding="utf-8")
+    )
+
+    assert compose["services"]["postgres"]["ports"] == [
+        "127.0.0.1:${DBHOSTPORT:-5432}:5432"
+    ]


### PR DESCRIPTION
Fixes #1603

# What

- bind the Docker Compose PostgreSQL host port to `127.0.0.1`
- keep `DBHOSTPORT` configurable for local tooling
- add a regression test that parses `docker-compose.yml` and enforces the loopback-only mapping

# Why

The previous `${DBHOSTPORT:-5432}:5432` mapping caused Docker to publish PostgreSQL on every host interface. Combined with the development credentials, this exposed the database to unauthenticated internet attacks on publicly reachable hosts. Issue #1603 reports a real compromise that used this path to deploy a cryptominer.

The new mapping preserves host access for local development while preventing remote connections by default.

# Testing done

- `python -m pytest tests/unit/test_docker_compose_security.py -q` — 1 passed
- `git diff --check`

# Decisions made

- hard-code the loopback bind rather than adding an environment override, so the secure default cannot be accidentally disabled through inherited environment configuration
- retain the existing configurable host port

# Checks

- [x] I have tested this code
- [x] I have reviewed my own PR
- [x] I have created an issue for this PR (existing issue #1603)
- [x] I have set a descriptive PR title compliant with conventional commits

# Reviewing tips

The functional change is the single port mapping in `docker-compose.yml`; the unit test protects that exact security invariant.

# User facing release notes

PostgreSQL exposed by GenLayer Studio now listens on the local machine only by default, preventing accidental public database exposure on VPS and cloud hosts.
