### PR TITLE
feat(genvm): calls between different majors of genvm

### DIFF
--- a/backend/consensus/base.py
+++ b/backend/consensus/base.py
@@ -319,6 +319,15 @@ def node_factory(
     )
 
 
+def transaction_genvm_executor_selector(transaction: Transaction) -> str | None:
+    """Studio-only GenVM executor override carried by the transaction."""
+    return (
+        transaction.sim_config.genvm_executor_selector
+        if transaction.sim_config
+        else None
+    )
+
+
 def contract_snapshot_factory(
     contract_address: str,
     session: Session,
@@ -352,6 +361,9 @@ def contract_snapshot_factory(
         ret.contract_code = transaction.data["contract_code"]
         ret.balance = transaction.value or 0
         ret.states = {"accepted": {}, "finalized": {}}
+        # The contract row is still empty at deploy time, so the executor
+        # override can only come from the deploy transaction itself.
+        ret.genvm_executor_selector = transaction_genvm_executor_selector(transaction)
         return ret
 
     # Return a ContractSnapshot instance for an existing contract
@@ -2831,6 +2843,11 @@ class AcceptedState(TransactionState):
             ),
             to_address=context.transaction.to_address,
             leader_node_config=leader_receipt.node_config,
+            genvm_executor_selector=(
+                transaction_genvm_executor_selector(context.transaction)
+                if is_deploy
+                else None
+            ),
         )
 
         # Execute pre-effects (includes contract registration/update via executor)

--- a/backend/consensus/decisions.py
+++ b/backend/consensus/decisions.py
@@ -321,6 +321,7 @@ def decide_accepted(
     code_slot_b64: str | None,
     to_address: str,
     leader_node_config: dict,
+    genvm_executor_selector: str | None = None,
 ) -> tuple[list[Effect], list[Effect], ConsensusRound, ConsensusRound | None]:
     """Decide effects for AcceptedState.
 
@@ -419,6 +420,7 @@ def decide_accepted(
                             },
                         },
                     },
+                    "genvm_executor_selector": genvm_executor_selector,
                 }
                 pre_effects.append(RegisterContractEffect(contract_data=new_contract))
                 pre_effects.append(

--- a/backend/database_handler/contract_processor.py
+++ b/backend/database_handler/contract_processor.py
@@ -19,6 +19,10 @@ class ContractProcessor:
             self.session.query(CurrentState).filter_by(id=contract["id"]).one()
         )
         current_contract.data = contract["data"]
+        if "genvm_executor_selector" in contract:
+            current_contract.genvm_executor_selector = contract[
+                "genvm_executor_selector"
+            ]
         self.session.commit()
 
     def update_contract_state(

--- a/backend/database_handler/contract_snapshot.py
+++ b/backend/database_handler/contract_snapshot.py
@@ -17,6 +17,9 @@ class ContractSnapshot:
     contract_address: str
     balance: int
     states: Dict[str, Dict[str, str]]
+    # Executor version or `re:` selector this contract is pinned to, forwarded
+    # to the GenVM manager as `reroute_to`.
+    genvm_executor_selector: Optional[str] = None
 
     def __init__(self, contract_address: str | None, session: Session):
         if contract_address is not None:
@@ -25,6 +28,7 @@ class ContractSnapshot:
             contract_account = self._load_contract_account(session)
             self.contract_data = contract_account.data
             self.balance = contract_account.balance
+            self.genvm_executor_selector = contract_account.genvm_executor_selector
 
             if ("accepted" in self.contract_data["state"]) and (
                 isinstance(self.contract_data["state"]["accepted"], dict)
@@ -43,6 +47,7 @@ class ContractSnapshot:
             "balance": (
                 int(b) if (b := getattr(self, "balance", None)) is not None else None
             ),
+            "genvm_executor_selector": self.genvm_executor_selector,
         }
 
     @classmethod
@@ -53,6 +58,9 @@ class ContractSnapshot:
             instance.states = input.get("states", {"accepted": {}, "finalized": {}})
             raw_balance = input.get("balance")
             instance.balance = int(raw_balance) if raw_balance is not None else None
+            instance.genvm_executor_selector = input.get(
+                "genvm_executor_selector", None
+            )
             return instance
         else:
             return None

--- a/backend/database_handler/migration/versions/c1d2e3f4a5b6_add_reroute_to_to_current_state.py
+++ b/backend/database_handler/migration/versions/c1d2e3f4a5b6_add_reroute_to_to_current_state.py
@@ -1,0 +1,62 @@
+"""add reroute_to to current_state
+
+Revision ID: c1d2e3f4a5b6
+Revises: d0e1f2a3b4c5
+Create Date: 2026-07-24 12:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision: str = "c1d2e3f4a5b6"
+down_revision: Union[str, None] = "d0e1f2a3b4c5"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+LEGACY_EXECUTOR_SELECTOR = r"re:^v0\.2\."
+"""
+Backfilled onto every pre-existing contract row on upgrade.
+
+Studios being upgraded from before multi-version support only ever had a
+single GenVM line (v0.2.x) to deploy against, so every genuine contract row
+that isn't already pinned needs a legacy selector: without it, an unpinned
+row means "resolve from the manifest" (the current/latest line), which would
+silently move already-deployed v0.2 contracts onto an executor they were
+never deployed or tested against.
+"""
+
+
+def upgrade() -> None:
+    op.execute("SET LOCAL lock_timeout = '5s'")
+    op.execute("SET LOCAL statement_timeout = '30s'")
+
+    op.add_column(
+        "current_state",
+        sa.Column("reroute_to", sa.String(255), nullable=True),
+    )
+
+    # Only genuine contract rows: EOAs (and reset contracts) carry
+    # `data = '{}'`, deployed contracts carry `data->'state'`. Excluding rows
+    # that already have a `reroute_to` preserves anything set some other way
+    # (e.g. by a data migration or manual fixup run ahead of this one).
+    op.execute(
+        sa.text(
+            """
+            UPDATE current_state
+            SET reroute_to = :selector
+            WHERE reroute_to IS NULL
+              AND data ? 'state'
+            """
+        ).bindparams(selector=LEGACY_EXECUTOR_SELECTOR)
+    )
+
+
+def downgrade() -> None:
+    op.execute("SET LOCAL lock_timeout = '5s'")
+    op.drop_column("current_state", "reroute_to")

--- a/backend/database_handler/migration/versions/d2e3f4a5b6c7_rename_reroute_to_to_genvm_executor_selector.py
+++ b/backend/database_handler/migration/versions/d2e3f4a5b6c7_rename_reroute_to_to_genvm_executor_selector.py
@@ -1,0 +1,40 @@
+"""rename current_state.reroute_to to genvm_executor_selector
+
+`reroute_to` named the manager's internal/debug override field, not what the
+persisted value means: an exact executor version or a `re:` selector pinning
+a contract to a GenVM executor line. `genvm_executor_selector` says that
+directly. The external `sim_config.reroute_to` RPC field is unaffected.
+
+Revision ID: d2e3f4a5b6c7
+Revises: c1d2e3f4a5b6
+Create Date: 2026-07-30 12:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "d2e3f4a5b6c7"
+down_revision: Union[str, None] = "c1d2e3f4a5b6"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.execute("SET LOCAL lock_timeout = '5s'")
+    op.alter_column(
+        "current_state",
+        "reroute_to",
+        new_column_name="genvm_executor_selector",
+    )
+
+
+def downgrade() -> None:
+    op.execute("SET LOCAL lock_timeout = '5s'")
+    op.alter_column(
+        "current_state",
+        "genvm_executor_selector",
+        new_column_name="reroute_to",
+    )

--- a/backend/database_handler/models.py
+++ b/backend/database_handler/models.py
@@ -76,6 +76,12 @@ class CurrentState(Base):
     id: Mapped[str] = mapped_column(String(255), primary_key=True)
     data: Mapped[dict] = mapped_column(JSONB)
     balance: Mapped[int] = mapped_column(IntNumeric(), default=0, nullable=False)
+    # Executor version or `re:` selector this contract is pinned to, forwarded
+    # to the GenVM manager as `reroute_to`. NULL means "no override, resolve
+    # from the manifest".
+    genvm_executor_selector: Mapped[Optional[str]] = mapped_column(
+        String(255), default=None, nullable=True
+    )
     updated_at: Mapped[Optional[datetime.datetime]] = mapped_column(
         DateTime(True),
         init=False,

--- a/backend/database_handler/snapshot_manager.py
+++ b/backend/database_handler/snapshot_manager.py
@@ -33,6 +33,7 @@ class SnapshotManager:
             state.id: {
                 "data": state.data,
                 "balance": state.balance,
+                "genvm_executor_selector": state.genvm_executor_selector,
                 "updated_at": (
                     state.updated_at.isoformat() if state.updated_at else None
                 ),
@@ -110,7 +111,10 @@ class SnapshotManager:
         # Restore current states
         for state_id, state_info in state_data.items():
             new_state = CurrentState(
-                id=state_id, data=state_info["data"], balance=state_info["balance"]
+                id=state_id,
+                data=state_info["data"],
+                balance=state_info["balance"],
+                genvm_executor_selector=state_info.get("genvm_executor_selector"),
             )
             if state_info["updated_at"]:
                 new_state.updated_at = datetime.fromisoformat(state_info["updated_at"])

--- a/backend/domain/types.py
+++ b/backend/domain/types.py
@@ -46,6 +46,11 @@ class SimValidatorConfig:
 class SimConfig:
     validators: list[SimValidatorConfig]
     genvm_datetime: str | None = None
+    # Studio-only: GenVM executor version or `re:` selector to run instead of
+    # the manifest-resolved one. On a deploy it is used for the deployment
+    # execution itself and stored on the contract, so every later execution
+    # of that contract keeps using it.
+    genvm_executor_selector: str | None = None
 
     @property
     def genvm_datetime_as_datetime(self) -> datetime.datetime | None:
@@ -65,6 +70,7 @@ class SimConfig:
         return cls(
             validators=validators,
             genvm_datetime=d.get("genvm_datetime"),
+            genvm_executor_selector=d.get("genvm_executor_selector"),
         )
 
     def to_dict(self) -> dict:
@@ -73,6 +79,7 @@ class SimConfig:
                 v.to_dict() if hasattr(v, "to_dict") else v for v in self.validators
             ],
             "genvm_datetime": self.genvm_datetime,
+            "genvm_executor_selector": self.genvm_executor_selector,
         }
 
 

--- a/backend/node/base.py
+++ b/backend/node/base.py
@@ -371,6 +371,12 @@ class _SnapshotView(genvmbase.StateProxy):
         bal = getattr(snap, "balance", 0)
         return int(bal) if bal is not None else 0
 
+    def genvm_executor_selector_for(self, addr: Address) -> str | None:
+        # A nested call target picks up its own executor pin; loading its
+        # snapshot here is the same lookup its storage reads already trigger.
+        selector = getattr(self._get_snapshot(addr), "genvm_executor_selector", None)
+        return selector or None
+
 
 import aiohttp
 
@@ -1075,6 +1081,7 @@ class Node:
                     message_fee_allocation=message_fee_allocation,
                 ),
                 logger=logger,
+                genvm_executor_selector=self.contract_snapshot.genvm_executor_selector,
             )
         except FeeValidationError as e:
             result = genvmbase.ExecutionResult(

--- a/backend/node/genvm/base.py
+++ b/backend/node/genvm/base.py
@@ -17,6 +17,7 @@ __all__ = (
 
 import math
 import os
+import re
 import typing
 import tempfile
 from pathlib import Path
@@ -24,6 +25,7 @@ import shutil
 import json
 import base64
 import asyncio
+import contextlib
 import socket
 import backend.node.genvm.origin.base_host as genvmhost
 import collections.abc
@@ -43,6 +45,7 @@ from dataclasses import dataclass
 
 from .origin.public_abi import *
 from .origin import base_host
+from .origin import host_fns
 from .origin import logger as genvm_logger
 from .error_codes import (
     extract_error_code,
@@ -129,6 +132,17 @@ class StateProxy(metaclass=abc.ABCMeta):
     @abc.abstractmethod
     def get_balance(self, addr: Address) -> int: ...
 
+    def genvm_executor_selector_for(self, addr: Address) -> str | None:
+        """Executor selector this contract is pinned to, or None if unpinned.
+
+        Backs the nested cross-major `resolve_callcontract_executor` hook: the
+        genvm asks which executor a call target runs on, and a pinned contract
+        answers with its stored `genvm_executor_selector`. Proxies without a
+        contract store (e.g. deploy-time `_StateProxyNone`) inherit this None
+        default.
+        """
+        return None
+
 
 class StateProxyWritable(StateProxy, metaclass=abc.ABCMeta):
     @abc.abstractmethod
@@ -145,6 +159,53 @@ class StateProxyWritable(StateProxy, metaclass=abc.ABCMeta):
     ) -> None: ...
     @abc.abstractmethod
     def get_balance(self, addr: Address) -> int: ...
+
+
+EXECUTOR_VERSION_RE: typing.Final = re.compile(r"v?\d+(\.\d+)*(-[0-9A-Za-z.]+)?")
+"""
+Shape of an exact executor pin.
+
+The manager uses a pin verbatim as the executor directory name, so anything not
+shaped like a version must never reach it as a path component. Checked both at
+submit time and again where a stored pin is read back.
+"""
+
+_CLOSE_CONNECTIONS_TIMEOUT_S: typing.Final = 10.0
+"""
+Cap on how long `Host.close_connections` waits for a cancelled task to
+actually finish.
+
+Cancellation only requests a `CancelledError` at the next await point; a
+nested connection task stuck outside the event loop (e.g. in blocking I/O)
+would otherwise hang shutdown indefinitely instead of just losing that one
+task's cleanup.
+"""
+
+EXECUTOR_SELECTOR_REGEX_PREFIX: typing.Final = "re:"
+"""Prefix marking a selector as a regex pattern, matching the manager's
+`VERSION_REGEX_PREFIX` (genvm-manager crates/modules-interfaces/src/nested.rs)."""
+
+
+def is_valid_executor_selector(value: str) -> bool:
+    """
+    Same selector grammar the manager accepts for `reroute_to`: either an exact
+    executor version (see `EXECUTOR_VERSION_RE`), or a `re:`-prefixed pattern
+    matched by the manager against the directory names in its manifest.
+
+    Both submit-time validation
+    (`protocol_rpc.endpoints._validate_genvm_executor_selector`) and
+    nested-call resolution (`Host.resolve_callcontract_executor`) must use
+    this same grammar so a value that is accepted (or backfilled) on one
+    boundary never gets rejected at the other.
+    """
+    if value.startswith(EXECUTOR_SELECTOR_REGEX_PREFIX):
+        pattern = value[len(EXECUTOR_SELECTOR_REGEX_PREFIX) :]
+        try:
+            re.compile(pattern)
+        except re.error:
+            return False
+        return True
+    return bool(EXECUTOR_VERSION_RE.fullmatch(value))
 
 
 def apply_storage_changes(
@@ -210,50 +271,12 @@ class Context(base_host.Context):
     def add_stat(self, key: str, value: typing.Any, /):
         self.stats[key] = value
 
-    def get_timeout(
-        self,
-        action: base_host.TimeoutAction,
-        type: base_host.TimeoutType,
-        /,
-    ) -> float | None:
-        TA = base_host.TimeoutAction
-        TT = base_host.TimeoutType
-
-        if action == TA.GenVMRun:
-            total = _get_env_float("GENVM_MANAGER_RUN_HTTP_TIMEOUT_SECONDS", 10.0)
-            if type == TT.TOTAL_S:
-                return total
-            if type == TT.CONNECT_S:
-                return min(5.0, total)
-            if type == TT.SOCK_READ_S:
-                return total
-        elif action == TA.GenVMGet:
-            total = _get_env_float("GENVM_MANAGER_STATUS_HTTP_TIMEOUT_SECONDS", 10.0)
-            if type == TT.TOTAL_S:
-                return total
-            if type == TT.CONNECT_S:
-                return min(3.0, total)
-            if type == TT.SOCK_READ_S:
-                return total
-        elif action == TA.GenVMDelete:
-            if type == TT.TOTAL_S:
-                return _get_env_float("GENVM_MANAGER_DELETE_HTTP_TIMEOUT_SECONDS", 3.0)
-            if type == TT.CONNECT_S:
-                return 1.5
-            if type == TT.SOCK_READ_S:
-                return 1.5
-            if type == TT.DELETE_HTTP_GRACEFUL_TIMEOUT_MS:
-                return 20.0
-        return None
-
-    def retry_delay(
-        self, action: base_host.TimeoutAction, attempt_no: int, /
-    ) -> float | None:
-        max_retries = _get_int("GENVM_MANAGER_RUN_RETRIES", 3)
-        if attempt_no >= max_retries - 1:
-            return None
-        base_delay = _get_env_float("GENVM_MANAGER_RUN_RETRY_DELAY_SECONDS", 1.0)
-        return base_delay * (2**attempt_no)
+    def get_manager_connect_timeout(self) -> float | None:
+        # The manager socket is a local websocket; bound only the connect phase
+        # so a dead manager fails fast instead of hanging the run. Mirrors the
+        # old GenVMRun connect budget (min(5, run-timeout)).
+        total = _get_env_float("GENVM_MANAGER_RUN_HTTP_TIMEOUT_SECONDS", 10.0)
+        return min(5.0, total)
 
 
 @dataclass
@@ -425,6 +448,21 @@ def _extract_llm_token_metrics(
     return token_metrics
 
 
+def _close_watched(sock: socket.socket) -> None:
+    """
+    Closes a socket that an asyncio task may still be reading from.
+
+    `Task.cancel` only takes effect on the next loop iteration, so a task blocked
+    in `sock_recv` deregisters its reader *after* a synchronous `close` has freed
+    the file descriptor -- by which point the number may already belong to
+    someone else's socket, whose reader it then silently removes.
+    """
+    with contextlib.suppress(Exception):
+        asyncio.get_event_loop().remove_reader(sock.fileno())
+    with contextlib.suppress(OSError):
+        sock.close()
+
+
 class Host(genvmhost.IHost):
     """
     Handles all genvm host methods and accumulates results
@@ -450,6 +488,22 @@ class Host(genvmhost.IHost):
         self._state_proxy = state_proxy
         self.calldata_bytes = calldata_bytes
         self._leader_results = leader_results
+        # A run that delegates across a major boundary spawns nested executors,
+        # and each of them dials the same listener, so the first connection is
+        # not necessarily the only one.
+        self._ctx: Context | None = None
+        self._accept_task: asyncio.Task | None = None
+        self._connection_tasks: list[asyncio.Task] = []
+        self._accepted_sockets: list[socket.socket] = []
+
+    def bind_context(self, ctx: Context) -> None:
+        """
+        Gives the host the context its nested connections are served with.
+
+        `loop_enter` is the only seam the host protocol offers and it carries no
+        context, so the caller that owns both hands it over before the run.
+        """
+        self._ctx = ctx
 
     def provide_result(
         self,
@@ -612,24 +666,118 @@ class Host(genvmhost.IHost):
         )
 
     async def loop_enter(self, cancellation) -> socket.socket:
+        sock = await self._accept(cancellation)
+        if sock is None:
+            raise Exception("Program failed")
+        self.sock = sock
+        assert self._ctx is not None, "bind_context must run before the genvm connects"
+        if self._accept_task is None:
+            # Serve every later connection ourselves: accepting stops when the
+            # run ends, which is when `run_genvm` sets the cancellation event.
+            self._accept_task = asyncio.create_task(
+                self._accept_connections(cancellation)
+            )
+        return sock
+
+    async def _accept(self, cancellation) -> socket.socket | None:
+        """
+        Accepts one connection, or returns `None` once the run is over.
+        """
         async_loop = asyncio.get_event_loop()
         assert self.sock_listener is not None
 
-        interesting = asyncio.ensure_future(async_loop.sock_accept(self.sock_listener))
+        accepting = asyncio.ensure_future(async_loop.sock_accept(self.sock_listener))
         canc = asyncio.ensure_future(cancellation.wait())
 
-        done, pending = await asyncio.wait(
-            [canc, interesting], return_when=asyncio.FIRST_COMPLETED
-        )
-        if canc in done:
-            raise Exception("Program failed")
-        canc.cancel()
+        accepted: socket.socket | None = None
+        try:
+            await asyncio.wait([canc, accepting], return_when=asyncio.FIRST_COMPLETED)
+        finally:
+            # Also runs when this task is cancelled mid-accept, which is the
+            # normal way the background acceptor ends. The accept is awaited out
+            # even then: until it is gone the event loop still watches the
+            # listener, which the caller is about to close.
+            canc.cancel()
+            if not accepting.done():
+                accepting.cancel()
+            result = None
+            with contextlib.suppress(BaseException):
+                result = await accepting
+            if result is not None:
+                # Recorded here rather than after the `finally`, because this
+                # block also runs while a CancelledError is propagating: a
+                # connection that arrived just as we were cancelled is still
+                # ours to close, and nothing else knows about it.
+                accepted, _addr = result
+                accepted.setblocking(False)
+                self._accepted_sockets.append(accepted)
 
-        self.sock, _addr = interesting.result()
-        self.sock.setblocking(False)
-        self.sock_listener.close()
-        self.sock_listener = None
-        return self.sock
+        return accepted
+
+    async def _accept_connections(self, cancellation) -> None:
+        assert self._ctx is not None
+        while True:
+            sock = await self._accept(cancellation)
+            if sock is None:
+                return
+            self._connection_tasks.append(
+                asyncio.create_task(genvmhost.host_loop_on(self, sock, ctx=self._ctx))
+            )
+
+    async def close_connections(self) -> None:
+        """
+        Winds down the nested-connection loops and drops every accepted socket.
+
+        A nested loop that died on its own is reported rather than dropped: the
+        run's own result comes from the manager and stays authoritative, but a
+        nested executor that lost its host is why it looks the way it does.
+
+        The listener is not closed here: it belongs to whoever created it.
+
+        Every drain below is capped at `_CLOSE_CONNECTIONS_TIMEOUT_S` via
+        `asyncio.wait` (not `wait_for`, which -- if the cancelled task keeps
+        swallowing `CancelledError` -- keeps re-awaiting it past its own
+        timeout instead of returning): a task that never actually stops must
+        not be able to hang shutdown forever.
+        """
+        if self._accept_task is not None:
+            task = self._accept_task
+            task.cancel()
+            done, pending = await asyncio.wait(
+                [task], timeout=_CLOSE_CONNECTIONS_TIMEOUT_S
+            )
+            if pending and self._ctx is not None:
+                self._ctx.logger.error(
+                    "accept task did not stop within close_connections timeout"
+                )
+            elif done and not task.cancelled():
+                exc = task.exception()
+                if exc is not None and self._ctx is not None:
+                    self._ctx.logger.error("accept task failed", error=exc)
+            self._accept_task = None
+        for task in self._connection_tasks:
+            if not task.done():
+                task.cancel()
+        if self._connection_tasks:
+            done, pending = await asyncio.wait(
+                self._connection_tasks, timeout=_CLOSE_CONNECTIONS_TIMEOUT_S
+            )
+            if pending and self._ctx is not None:
+                self._ctx.logger.error(
+                    f"{len(pending)} nested host connection(s) did not stop "
+                    "within close_connections timeout"
+                )
+            for task in done:
+                if task.cancelled():
+                    continue
+                exc = task.exception()
+                if exc is not None and self._ctx is not None:
+                    self._ctx.logger.error("nested host connection failed", error=exc)
+        self._connection_tasks.clear()
+        for accepted in self._accepted_sockets:
+            _close_watched(accepted)
+        self._accepted_sockets.clear()
+        self.sock = None
 
     async def storage_read(
         self, type: StorageType, account: bytes, slot: bytes, index: int, le: int, /
@@ -638,6 +786,37 @@ class Host(genvmhost.IHost):
         return await asyncio.to_thread(
             self._state_proxy.storage_read, Address(account), slot, index, le
         )
+
+    async def resolve_callcontract_executor(
+        self,
+        contract_address: Address,
+        state_mode: StorageType,
+        advisory_major: int,
+        /,
+    ) -> bytes | None:
+        # Cross-major nested calls: the genvm asks which executor a call target
+        # runs on. Answer with the target's own pin (genvm_executor_selector)
+        # so a contract deployed against an older line keeps executing there
+        # even when called from a newer one. Unpinned targets return None ->
+        # the caller's runner keeps advising the major (same-major behavior).
+        #
+        # The pin names the line outright rather than deriving a major from it:
+        # every line released so far is semver major 0, so a major resolves to
+        # the newest one whichever line the pin meant.
+        reroute = self._state_proxy.genvm_executor_selector_for(contract_address)
+        if not reroute:
+            return None
+        # A pin that is not a version is rejected at submit time, so reaching
+        # here means a stored one went bad. Fail this call as a host error:
+        # anything else escapes `host_loop_on`, kills the host task and turns a
+        # permanently broken callee into retries that only end when the
+        # transaction's time budget does.
+        if not is_valid_executor_selector(reroute):
+            raise base_host.HostException(
+                host_fns.Errors.FORBIDDEN,
+                f"contract {contract_address.as_hex} is pinned to an unusable executor version: {reroute!r}",
+            )
+        return gvm_calldata.encode({"kind": "version", "version": reroute})
 
     async def consume_gas(self, gas: int, /) -> None:
         pass
@@ -744,9 +923,24 @@ async def run_genvm_host(
     permissions: str = "rwscn",
     code: bytes | None = None,
     fee_context: GenVMFeeContext | None = None,
+    genvm_executor_selector: str | None = None,
 ) -> ExecutionResult:
     if logger is None:
         logger = genvm_logger.NoLogger()
+    # base_host.run_genvm no longer derives the level from capture_output, so
+    # resolve it here: capture_output implies safe-unbounded (host reads
+    # stdout/stderr artifacts), otherwise disabled.
+    effective_debug_mode: base_host.DebugMode = debug_mode or (
+        "safe-unbounded" if capture_output else "disabled"
+    )
+    if genvm_executor_selector and effective_debug_mode == "disabled":
+        # The manager honors the executor override only under debug_mode >= safe
+        # and ignores it silently otherwise, which would run the contract on the
+        # manifest-resolved executor instead of the requested one.
+        raise ValueError(
+            f"genvm_executor_selector={genvm_executor_selector!r} requires "
+            "debug_mode >= safe, got 'disabled'"
+        )
     ctx = Context(logger=logger)
     fee_context = fee_context or GenVMFeeContext()
     effective_bucket_totals = fee_context.bucket_totals or [
@@ -775,7 +969,16 @@ async def run_genvm_host(
         )
         fresh_args = {}
 
+        # Backoff owed to a failed attempt. It is served after that attempt's
+        # listener, sockets and nested connection tasks are gone, so a dead
+        # attempt cannot keep serving executors for the length of the sleep.
+        retry_delay = 0.0
+
         while True:
+            if retry_delay:
+                await asyncio.sleep(retry_delay)
+                retry_delay = 0.0
+
             remaining_time = timeout - (time.time() - start_time)
             if remaining_time <= 0:
                 # When the genvm keeps crashing we send a timeout error
@@ -801,7 +1004,9 @@ async def run_genvm_host(
                 sock_listener.setblocking(False)
                 sock_path = tmpdir.joinpath(f"sock_{retry_count}")
                 sock_listener.bind(str(sock_path))
-                sock_listener.listen(1)
+                # A run that delegates across a major boundary spawns nested
+                # executors, and each dials this same listener.
+                sock_listener.listen(8)
 
                 fresh_host_supplier = functools.partial(
                     (
@@ -812,6 +1017,7 @@ async def run_genvm_host(
                     **fresh_args,
                 )
                 host: Host = fresh_host_supplier(sock_listener)
+                host.bind_context(ctx)
 
                 leader_results = fresh_args.get(
                     "leader_results", host_args.get("leader_results")
@@ -819,27 +1025,45 @@ async def run_genvm_host(
                 leader_nondet_results = _leader_results_to_list(leader_results)
 
                 try:
-                    res = await base_host.run_genvm(
-                        host,
-                        manager_uri=manager_uri,
-                        message=message,
-                        timeout=timeout,
-                        capture_output=capture_output,
-                        debug_mode=debug_mode,
-                        is_sync=is_sync,
-                        host_data=host_data,
-                        ctx=ctx,
-                        host=f"unix://{sock_path}",
-                        extra_args=extra_args,
-                        code=code,
-                        bucket_totals=effective_bucket_totals,
-                        gas_data=effective_gas_data,
-                        message_fee_allocation=fee_context.message_fee_allocation or [],
-                        calldata=fresh_args.get(
-                            "calldata_bytes", host_args.get("calldata_bytes", b"")
-                        ),
-                        leader_nondet_results=leader_nondet_results,
-                    )
+                    # Fresh manager websocket per attempt: run_genvm never owns
+                    # the client's lifecycle, and a retry after a bounce wants a
+                    # clean connection rather than a poisoned one.
+                    async with base_host.ManagerClient(
+                        manager_uri,
+                        connect_timeout=ctx.get_manager_connect_timeout(),
+                    ) as manager_client:
+                        res = await base_host.run_genvm(
+                            host,
+                            manager_uri=manager_uri,
+                            manager_client=manager_client,
+                            message=message,
+                            timeout=timeout,
+                            debug_mode=effective_debug_mode,
+                            is_sync=is_sync,
+                            host_data=host_data,
+                            ctx=ctx,
+                            host=f"unix://{sock_path}",
+                            extra_args=extra_args,
+                            code=code,
+                            bucket_totals=effective_bucket_totals,
+                            gas_data=effective_gas_data,
+                            message_fee_allocation=fee_context.message_fee_allocation
+                            or [],
+                            calldata=fresh_args.get(
+                                "calldata_bytes", host_args.get("calldata_bytes", b"")
+                            ),
+                            leader_nondet_results=leader_nondet_results,
+                            unsafe_overrides=base_host.UnsafeOverrides(
+                                reroute_to=genvm_executor_selector or ""
+                            ),
+                            # Ask to be consulted on where a CallContract runs.
+                            # Opting out makes the manager answer the resolve
+                            # query itself with "stay in-process", which silently
+                            # runs a pinned callee's code on the caller's
+                            # executor -- the very thing the pin exists to stop.
+                            # A nested run inherits this from its parent.
+                            request_extra={"hook_cross_contract_calls": True},
+                        )
 
                     execution_result = host.provide_result(
                         res,
@@ -857,6 +1081,32 @@ async def run_genvm_host(
                     # Re-raise GenVMInternalError to propagate to worker for proper handling
                     # (stop worker, release transaction, report unhealthy)
                     raise
+                except base_host.TerminalResultUnavailable:
+                    # The genvm already executed exactly once and reached a
+                    # terminal state; only fetching/decoding its result failed.
+                    # Falling into the generic `except Exception` below would
+                    # start a brand new run here, executing the contract a
+                    # second time for a result that already exists -- so this
+                    # propagates as a permanent failure instead of retrying.
+                    raise
+                except base_host.ManagerRunNotStarted as e:
+                    # The genvm never executed. base_host already classified the
+                    # refusal, so no transport knowledge or string matching here:
+                    # a permanent refusal (bad request/runner) fails fast; a
+                    # transient one (manager still starting modules) retries
+                    # until the deadline budget runs out (top-of-loop check).
+                    if not e.retryable:
+                        raise
+                    logger.warning(
+                        "genvm run not started, retrying",
+                        reason=e.reason,
+                        retry_count=retry_count,
+                    )
+                    last_error = e
+                    retry_count += 1
+                    retry_delay = min(
+                        base_delay * (2 ** (retry_count - 1)), remaining_time
+                    )
                 except Exception as e:
                     logger.error(
                         "GenVM execution attempt failed",
@@ -874,13 +1124,14 @@ async def run_genvm_host(
                         )
 
                     retry_count += 1
-                    # Sleep for a longer time than the previous attempt to avoid executing it too many times
-                    delay = min(base_delay * (2 ** (retry_count - 1)), remaining_time)
-                    await asyncio.sleep(delay)
+                    # Back off longer than the previous attempt to avoid
+                    # executing it too many times.
+                    retry_delay = min(
+                        base_delay * (2 ** (retry_count - 1)), remaining_time
+                    )
 
                 finally:
-                    if host.sock is not None:
-                        host.sock.close()
+                    await host.close_connections()
                     sock_path.unlink(missing_ok=True)
     finally:
         shutil.rmtree(tmpdir, ignore_errors=True)

--- a/backend/node/genvm/origin/base_host.py
+++ b/backend/node/genvm/origin/base_host.py
@@ -1,10 +1,15 @@
 import abc
 import asyncio
-import enum
+import collections.abc
+import contextlib
+import json
+import math
 import socket
 import time
+import types
 import typing
-from dataclasses import dataclass
+import urllib.parse
+from dataclasses import dataclass, field
 
 import aiohttp
 
@@ -14,6 +19,7 @@ from . import (
 from . import (
     fees,
     host_fns,
+    manager_api,
     public_abi,
 )
 from .calldata import Address
@@ -21,6 +27,24 @@ from .logger import Logger
 
 ACCOUNT_ADDR_SIZE = 20
 SLOT_ID_SIZE = 32
+
+ZERO_SLOT = b"\x00" * SLOT_ID_SIZE
+"""The root `SlotID`, all zeroes."""
+
+ROOT_OFFSET_MAJOR = 0
+"""Offset of the single-octet public-ABI `major` within the root slot."""
+
+UNDEPLOYED_MAJOR = 0
+"""
+Major to declare when there is no deployed contract to read one from.
+
+Every line released so far has semver major `0`, and the manager matches `0`
+against all of them and picks the newest, so this is a de-facto "any line".
+A deploy is the honest case for it: the real value comes from the contract
+package, which this harness does not parse, and the harness pins its executor
+with `unsafe_overrides.reroute_to` regardless. It is also why the manager cannot
+yet reject `major == 0`.
+"""
 
 # Mirrors the executor's `DebugMode` enum (crates/common/src/debug_mode.rs).
 DebugMode = typing.Literal[
@@ -49,21 +73,6 @@ DEFAULT_GAS_DATA: dict[str, str] = {
     # 0 = no per-round execution-budget floor for balance-funded messages.
     "messageBudgetFloor": "0",
 }
-DEFAULT_INITIAL_TIME_UNITS_ALLOCATION = 10 * 60
-
-
-class TimeoutAction(enum.StrEnum):
-    VMErrorDescribe = "vm-error/describe"
-    GenVMGet = "/genvm/{id}"
-    GenVMRun = "/genvm/run"
-    GenVMDelete = "DELETE /genvm/{id}"
-
-
-class TimeoutType(enum.StrEnum):
-    TOTAL_S = "HTTP_TIMEOUT_TOTAL_S"
-    CONNECT_S = "HTTP_TIMEOUT_CONNECT_S"
-    SOCK_READ_S = "HTTP_TIMEOUT_SOCK_READ_S"
-    DELETE_HTTP_GRACEFUL_TIMEOUT_MS = "DELETE_HTTP_GRACEFUL_TIMEOUT_MS"
 
 
 class Context(typing.Protocol):
@@ -74,28 +83,12 @@ class Context(typing.Protocol):
 
     def add_stat(self, key: str, value: typing.Any, /): ...
 
-    def get_timeout(self, action: TimeoutAction, type: TimeoutType, /) -> float | None:
-        return None
-
-    def retry_delay(self, action: TimeoutAction, attempt_no: int, /) -> float | None:
-        """Returns delay before next retry, or None if no retries are left."""
+    def get_manager_connect_timeout(self) -> float | None:
         return None
 
 
-def _http_timeout(
-    ctx: Context,
-    action: TimeoutAction,
-) -> aiohttp.ClientTimeout:
-    """
-    Explicit aiohttp timeout to avoid wedging consensus when the local GenVM manager
-    accepts a connection but never responds.
-    """
-    total_s = ctx.get_timeout(action, TimeoutType.TOTAL_S)
-    connect_s = ctx.get_timeout(action, TimeoutType.CONNECT_S)
-    sock_read_s = ctx.get_timeout(action, TimeoutType.SOCK_READ_S)
-    return aiohttp.ClientTimeout(
-        total=total_s, connect=connect_s, sock_read=sock_read_s
-    )
+def _http_timeout(ctx: Context) -> aiohttp.ClientTimeout:
+    return aiohttp.ClientTimeout(connect=ctx.get_manager_connect_timeout())
 
 
 class HostException(Exception):
@@ -106,26 +99,23 @@ class HostException(Exception):
         super().__init__(message or f"GenVM error: {error_code}")
 
 
-# Studio-local retry shim for transient manager module restart races.
-class GenVMManagerRetryableError(Exception):
-    def __init__(self, status: int, body: typing.Any):
-        self.status = status
-        self.body = body
-        super().__init__(f"genvm manager /genvm/run failed: {status} {body}")
+@dataclass(frozen=True)
+class UnsafeOverrides:
+    """Request overrides that reach boundaries production traffic cannot.
 
+    Each member states the `debug_mode` the manager requires before it applies:
+    `reroute_to` from `safe`, `initial_recursion` from `unsafe`. With debugging
+    disabled none of them take effect.
+    """
 
-def _is_retryable_manager_run_error(status: int, body: typing.Any) -> bool:
-    if status != 500 or not isinstance(body, dict):
-        return False
+    reroute_to: str = ""
+    initial_recursion: int | None = None
 
-    error = body.get("error")
-    if not isinstance(error, str):
-        return False
-
-    return (
-        "modules are required but not running" in error
-        or "modules are required but not all are running" in error
-    )
+    def as_request_field(self) -> dict[str, typing.Any]:
+        return {
+            "reroute_to": self.reroute_to,
+            "initial_recursion": self.initial_recursion,
+        }
 
 
 class Message(typing.TypedDict):
@@ -220,6 +210,15 @@ class IHost(metaclass=abc.ABCMeta):
         /,
     ) -> bytes: ...
 
+    async def resolve_callcontract_executor(
+        self,
+        contract_address: Address,
+        state_mode: public_abi.StorageType,
+        advisory_major: int,
+        /,
+    ) -> bytes | None:
+        return None
+
     @abc.abstractmethod
     async def consume_gas(self, gas: int, /) -> None: ...
     @abc.abstractmethod
@@ -232,14 +231,40 @@ class IHost(metaclass=abc.ABCMeta):
     async def notify_nondet_disagreement(self, call_no: int, /) -> None: ...
 
 
+async def read_contract_major(handler: IHost, message: Message) -> int:
+    """
+    Reads the public-ABI major the run's contract was deployed against.
+
+    The major is octet `ROOT_OFFSET_MAJOR` of the root slot, written at deploy
+    time and read on every load. A deploy has nothing to read, so it declares
+    `UNDEPLOYED_MAJOR` instead.
+
+    The read uses the storage view a top-level run itself uses, so a run cannot
+    take its major from a state it would not otherwise observe. An address with
+    no contract reads back `0`, which is indistinguishable from major `0`; that
+    stays a fallback for now.
+    """
+    if message.get("is_init", False):
+        return UNDEPLOYED_MAJOR
+    octet = await handler.storage_read(
+        public_abi.StorageType.LATEST_NON_FINAL,
+        message["contract_address"].as_bytes,
+        ZERO_SLOT,
+        ROOT_OFFSET_MAJOR,
+        1,
+    )
+    return octet[0]
+
+
 async def host_loop(
     handler: IHost,
     cancellation: asyncio.Event,
     *,
     ctx: Context,
 ) -> None:
-    async_loop = asyncio.get_event_loop()
-
+    """
+    Accepts one connection through the handler, then serves it.
+    """
     logger = ctx.logger
 
     logger.trace("entering loop")
@@ -252,6 +277,26 @@ async def host_loop(
         round((host_loop_entered_s - loop_enter_wait_start) * 1000),
     )
     logger.trace("entered loop")
+
+    await host_loop_on(handler, sock, ctx=ctx)
+
+
+async def host_loop_on(
+    handler: IHost,
+    sock: socket.socket,
+    *,
+    ctx: Context,
+) -> None:
+    """
+    Serves an already accepted connection.
+
+    A run that spawns nested executors produces several connections to one
+    listener, so the accept step has to be separable from the protocol it feeds.
+    """
+    async_loop = asyncio.get_event_loop()
+
+    logger = ctx.logger
+
     accept_time = time.perf_counter()
     first_method_name: str | None = None
     first_method_received_s: float | None = None
@@ -311,6 +356,22 @@ async def host_loop(
     call_counts = {}
     meth_id: host_fns.Methods | None = None
 
+    def emit_host_loop_stats():
+        if first_method_name is not None:
+            ctx.add_stat("host_first_method", first_method_name)
+        ctx.add_stat("host_total_handling_time_ms", round(total_handling_time * 1000))
+        ctx.add_stat(
+            "host_time_per_method_ms",
+            {k: round(v * 1000) for k, v in time_per_method.items()},
+        )
+        ctx.add_stat("call_counts", call_counts)
+        logger.debug(
+            "handling time",
+            total=total_handling_time,
+            by_method=time_per_method,
+            call_counts=call_counts,
+        )
+
     handling_start = time.time()
     while True:
         cur_delta = time.time() - handling_start
@@ -322,7 +383,11 @@ async def host_loop(
 
         await flush_socket_buffer()
 
-        meth_id = host_fns.Methods(await recv_int(1))
+        try:
+            meth_id = host_fns.Methods(await recv_int(1))
+        except ConnectionResetError:
+            emit_host_loop_stats()
+            return None
         if first_method_name is None:
             first_method_name = meth_id.name
             first_method_received_s = time.perf_counter()
@@ -351,37 +416,28 @@ async def host_loop(
                 else:
                     await send_all(bytes([host_fns.Errors.OK]))
                     await send_all(res)
+            case host_fns.Methods.RESOLVE_CALLCONTRACT_EXECUTOR:
+                contract_address = Address(await read_exact(ACCOUNT_ADDR_SIZE))
+                state_mode = public_abi.StorageType((await read_exact(1))[0])
+                advisory_major = await recv_int(1)
+
+                try:
+                    res = await handler.resolve_callcontract_executor(
+                        contract_address,
+                        state_mode,
+                        advisory_major,
+                    )
+                except HostException as e:
+                    await send_all(bytes([e.error_code]))
+                else:
+                    encoded_res = gvm_calldata.encode(res)
+                    await send_all(bytes([host_fns.Errors.OK]))
+                    await send_int(len(encoded_res))
+                    await send_all(encoded_res)
             case host_fns.Methods.CONSUME_RESULT:
                 raise Exception(
                     "CONSUME_RESULT is not supported in this host loop implementation, use manager provided one"
                 )
-            case host_fns.Methods.NOTIFY_FINISHED:
-                logger.debug(
-                    "handling time",
-                    total=total_handling_time,
-                    by_method=time_per_method,
-                    call_counts=call_counts,
-                )
-                await send_all(bytes([0]))
-                await flush_socket_buffer()
-
-                if first_method_name is not None:
-                    ctx.add_stat("host_first_method", first_method_name)
-                ctx.add_stat(
-                    "host_total_handling_time_ms", round(total_handling_time * 1000)
-                )
-                ctx.add_stat(
-                    "host_time_per_method_ms",
-                    {k: round(v * 1000) for k, v in time_per_method.items()},
-                )
-                ctx.add_stat("call_counts", call_counts)
-                logger.debug(
-                    "handling time",
-                    total=total_handling_time,
-                    by_method=time_per_method,
-                    call_counts=call_counts,
-                )
-                return None
             case host_fns.Methods.CONSUME_FUEL:
                 gas = await recv_int(32)
                 await handler.consume_gas(gas)
@@ -423,6 +479,79 @@ async def host_loop(
                 raise Exception(f"unknown method {x}")
 
 
+class ConsumedResultDecodeError(Exception):
+    """`consumed_result` bytes did not parse into a `ConsumedResult` at all.
+
+    Distinct from `ConsumedResult.internal_error(...)`, which is itself a
+    valid (if unhappy) result value produced from bytes that *did* parse:
+    this means the bytes never parsed, so there is no result to hand back.
+    Callers must treat it the same as any other post-terminal failure -- see
+    `run_genvm`'s `TerminalResultUnavailable` wrapping -- never as grounds to
+    start a new run.
+    """
+
+
+@dataclass
+class ConsumedResult:
+    """The decoded `consumed_result` blob: a `ResultCode` byte plus calldata."""
+
+    execution_hash: bytes
+    result_kind: public_abi.ResultCode
+    result_data: gvm_calldata.Decoded
+    result_fingerprint: ResultFingerprint | None = None
+    result_storage_changes: list[tuple[bytes, bytes]] = field(default_factory=list)
+    result_emissions: list[ResultEmission] = field(default_factory=list)
+    result_nondet_results: list[bytes] = field(default_factory=list)
+    data_fees_remaining: list[int] = field(default_factory=list)
+
+    @classmethod
+    def internal_error(cls, message: str) -> "ConsumedResult":
+        return cls(
+            execution_hash=b"",
+            result_kind=public_abi.ResultCode.INTERNAL_ERROR,
+            result_data=message,
+        )
+
+    @classmethod
+    def decode(cls, raw: typing.Any) -> "ConsumedResult":
+        if raw is None:
+            # The manager never attempted to report a result at all.
+            return cls.internal_error("no_result")
+        empty = False
+        try:
+            as_bytes = bytes(raw)
+            empty = not as_bytes
+            if not empty:
+                result_kind = public_abi.ResultCode(as_bytes[0])
+                decoded = gvm_calldata.decode(as_bytes[1:])
+        except Exception as exc:
+            # `raw` wasn't even bytes-shaped, or its ResultCode byte/calldata
+            # failed to parse. Either way this is not a result the genvm
+            # reported, it's a protocol violation: raise instead of returning
+            # an `internal_error(...)` value so it can never be mistaken for a
+            # real (if unhappy) execution outcome.
+            raise ConsumedResultDecodeError(
+                f"malformed consumed_result ({raw!r}): {exc}"
+            ) from exc
+        if empty:
+            # Distinct from `None`: the manager did send a `consumed_result`,
+            # but it carries no `ResultCode` byte to read. Still "no usable
+            # result data" from the caller's point of view.
+            return cls.internal_error("empty_result")
+        if not isinstance(decoded, dict):
+            return cls.internal_error("result is not a mapping")
+        return cls(
+            execution_hash=decoded.get("execution_hash", b""),
+            result_kind=result_kind,
+            result_data=decoded.get("data"),
+            result_fingerprint=decoded.get("fingerprint"),
+            result_storage_changes=decoded.get("storage_changes", []),
+            result_emissions=decoded.get("emissions", []),
+            result_nondet_results=decoded.get("nondet_results", []),
+            data_fees_remaining=decoded.get("data_fees_remaining", []),
+        )
+
+
 @dataclass
 class RunHostAndProgramRes:
     stdout: str
@@ -444,485 +573,802 @@ class RunHostAndProgramRes:
     vm_error_description: str | None = None
 
 
-async def _send_timeout(
-    manager_uri: str,
-    genvm_id: str,
-    ctx: Context,
-):
-    try:
-        graceful_shutdown_wait_time_ms = ctx.get_timeout(
-            TimeoutAction.GenVMDelete, TimeoutType.DELETE_HTTP_GRACEFUL_TIMEOUT_MS
+class Frame(typing.NamedTuple):
+    """One manager socket message: a method, a request id and a calldata payload."""
+
+    method: manager_api.Methods
+    request_id: int
+    payload: typing.Any
+
+
+class ManagerSocketError(Exception):
+    def __init__(self, code: manager_api.Errors, message: str):
+        self.code = code
+        self.message = message
+        super().__init__(f"{code.name}: {message}")
+
+
+_MANAGER_RECONNECT_ATTEMPTS = 3
+_MANAGER_RECONNECT_BACKOFF_S = 0.05
+
+
+class ManagerConnectionLost(Exception):
+    """
+    The manager socket dropped.
+
+    `generation` is the connection this happened on, so a waiter that wakes up
+    after somebody else already reconnected can tell that its loss is stale
+    rather than reconnecting a second time.
+    """
+
+    def __init__(self, message: str, generation: int = -1):
+        super().__init__(message)
+        self.generation = generation
+
+
+class ManagerRunLost(Exception):
+    """
+    The manager process that owned a run is gone, so the run is unrecoverable.
+
+    Deliberately not a `ManagerConnectionLost`: that one means "reconnect and keep
+    waiting", and a waiter that treats this as one waits forever for a run no
+    reconnect can bring back.
+    """
+
+
+class ManagerRunNotStarted(Exception):
+    """A run never reached execution, so retrying it re-executes nothing.
+
+    Raised for the two ways the manager can refuse before the genvm runs -- a
+    rejected RUN request and a `failed_to_start` terminal. Retry policy belongs
+    to the caller; `retryable` tells it whether the refusal is transient (the
+    manager is still bringing modules up, or the socket bounced) rather than a
+    permanent rejection (malformed request, absent runner, bad calldata). This
+    is deliberately distinct from a returned `RETURN`/`*_ERROR` result, which
+    means the genvm did run and must never be blindly retried.
+    """
+
+    def __init__(self, message: str, *, retryable: bool, reason: str):
+        self.retryable = retryable
+        self.reason = reason
+        super().__init__(message)
+
+
+class TerminalResultUnavailable(Exception):
+    """A run reached a terminal `finished` state, but its result could not be
+    retrieved or decoded -- artifact transfer failed, or `consumed_result` was
+    empty/malformed.
+
+    The genvm already executed exactly once for this `genvm_id`; the caller
+    must never treat this the way it treats a plain `Exception` from
+    `run_genvm` (which starts a brand new run on retry). Always non-retryable
+    for that reason -- there is no `retryable` flag to override.
+    """
+
+    def __init__(self, message: str, *, genvm_id: int):
+        self.genvm_id = genvm_id
+        super().__init__(message)
+
+
+# Transient manager refusals worth retrying. The manager reports these with the
+# generic `Errors.INTERNAL` code (no dedicated variant yet), so the message is
+# the only discriminator -- kept here so callers never have to string-match.
+_RETRYABLE_RUN_REFUSAL_MARKERS: typing.Final = (
+    "modules are required but not running",
+    "modules are required but not all are running",
+)
+
+
+def _classify_run_refusal(message: str) -> tuple[bool, str]:
+    for marker in _RETRYABLE_RUN_REFUSAL_MARKERS:
+        if marker in message:
+            return True, "manager_modules_not_running"
+    return False, "manager_refused"
+
+
+@dataclass
+class RunState:
+    boot_id: int
+    genvm_id: int
+    host_genvm_id: str | None
+    events: asyncio.Queue[dict[str, typing.Any] | BaseException]
+    terminal: dict[str, typing.Any] | None = None
+    acked: bool = False
+
+
+class ManagerClient:
+    def __init__(
+        self,
+        manager_uri: str,
+        *,
+        connect_timeout: float | None = None,
+        max_msg_size: int = 64 * 1024 * 1024,
+    ):
+        self.manager_uri = manager_uri
+        self.connect_timeout = connect_timeout
+        self.max_msg_size = max_msg_size
+        self.boot_id: int | None = None
+        self._session: aiohttp.ClientSession | None = None
+        self._ws: aiohttp.ClientWebSocketResponse | None = None
+        self._reader_task: asyncio.Task | None = None
+        self._request_id = 1
+        self._pending: dict[int, asyncio.Future[Frame]] = {}
+        # The protocol identifies a run as (boot_id, genvm_id): ids restart at 1
+        # with the manager process, so genvm_id alone aliases across a restart.
+        self._runs: dict[tuple[int, int], RunState] = {}
+        self._orphan_events: dict[tuple[int, int], list[dict[str, typing.Any]]] = {}
+        self._connect_lock = asyncio.Lock()
+        self._send_lock = asyncio.Lock()
+        self._reconnect_lock = asyncio.Lock()
+        # Bumped on every successful connect, so a disconnect can be attributed
+        # to the connection it happened on.
+        self._generation = 0
+
+    @property
+    def run_states(self) -> dict[tuple[int, int], RunState]:
+        return self._runs
+
+    def _key(self, genvm_id: int) -> tuple[int, int]:
+        assert self.boot_id is not None, "no hello received yet"
+        return (self.boot_id, genvm_id)
+
+    async def __aenter__(self):
+        await self._ensure_connected()
+        return self
+
+    async def __aexit__(self, *_args):
+        await self._close()
+
+    async def disconnect(self) -> None:
+        await self._close()
+
+    async def run(self, payload: dict[str, typing.Any]) -> RunState:
+        response = await self._request(
+            manager_api.Methods.RUN,
+            {"run": payload},
+            retry_on_disconnect=True,
         )
-        if graceful_shutdown_wait_time_ms is None:
-            graceful_shutdown_wait_time_ms = 20
-        else:
-            graceful_shutdown_wait_time_ms = int(graceful_shutdown_wait_time_ms)
-        async with aiohttp.request(
-            "DELETE",
-            f"{manager_uri}/genvm/{genvm_id}?wait_timeout_ms={graceful_shutdown_wait_time_ms}",
-            timeout=_http_timeout(ctx, TimeoutAction.GenVMDelete),
-        ) as resp:
-            ctx.add_stat("delete_genvm_status", resp.status)
-            if resp.status != 200:
-                ctx.add_stat("delete_genvm_failed", True)
-                ctx.add_stat("delete_genvm_body", await resp.text())
-    except (aiohttp.ClientError, asyncio.TimeoutError) as exc:
-        ctx.add_stat("delete_genvm_request_failed", True)
-        ctx.add_stat("delete_genvm_request_error", str(exc))
+        genvm_id = int(response["genvm_id"])
+        key = self._key(genvm_id)
+        state = self._runs.get(key)
+        if state is None:
+            state = RunState(
+                boot_id=key[0],
+                genvm_id=genvm_id,
+                host_genvm_id=payload.get("host_genvm_id"),
+                events=asyncio.Queue(),
+            )
+            self._runs[key] = state
+            for event in self._orphan_events.pop(key, []):
+                self._queue_event(state, event)
+        return state
 
+    async def attach(self, boot_id: int, genvm_id: int) -> RunState:
+        response = await self._request(
+            manager_api.Methods.ATTACH,
+            {"attach": {"boot_id": boot_id, "genvm_id": genvm_id}},
+            retry_on_disconnect=True,
+        )
+        key = (boot_id, genvm_id)
+        state = self._runs.get(key)
+        if state is None:
+            state = RunState(
+                boot_id=boot_id,
+                genvm_id=genvm_id,
+                host_genvm_id=None,
+                events=asyncio.Queue(),
+            )
+            self._runs[key] = state
+        self._queue_event(state, response["snapshot"])
+        return state
 
-async def _await_first_cancel_others(*it):
-    _done, pending = await asyncio.wait(
-        [asyncio.ensure_future(x) for x in it],
-        return_when=asyncio.FIRST_COMPLETED,
-    )
-    for task in pending:
-        task.cancel()
-    for task in pending:
+    def _require_current_generation(
+        self, boot_id: int, genvm_id: int, *, op: str
+    ) -> None:
+        """Refuse to act on a run from a manager generation we have since left.
+
+        `CANCEL`/`ACK`/`GET_ARTIFACT` identify a run to the manager by
+        `genvm_id` alone -- the wire protocol has no `boot_id` field for them
+        (unlike `ATTACH`, which the manager itself rejects on a mismatch). If
+        the manager restarted and reused this `genvm_id` for an unrelated run,
+        sending one of these blind would act on that run instead of a stale
+        reference to the one this call actually means.
+        """
+        if self.boot_id is not None and boot_id != self.boot_id:
+            raise ManagerRunLost(
+                f"refusing to {op} genvm {genvm_id}: it belonged to manager "
+                f"boot {boot_id}, but the client is now talking to boot "
+                f"{self.boot_id} -- the id may have been reused by the new "
+                "process"
+            )
+
+    async def cancel(self, boot_id: int, genvm_id: int) -> None:
+        self._require_current_generation(boot_id, genvm_id, op="cancel")
+        await self._request(
+            manager_api.Methods.CANCEL,
+            {"cancel": {"genvm_id": genvm_id}},
+            retry_on_disconnect=True,
+        )
+
+    async def ack(self, boot_id: int, genvm_id: int) -> None:
+        self._require_current_generation(boot_id, genvm_id, op="ack")
+        await self._request(
+            manager_api.Methods.ACK,
+            {"ack": {"genvm_id": genvm_id}},
+            retry_on_disconnect=True,
+        )
+        key = (boot_id, genvm_id)
+        if state := self._runs.get(key):
+            state.acked = True
+        self._runs.pop(key, None)
+        self._orphan_events.pop(key, None)
+
+    async def get_artifact(self, boot_id: int, genvm_id: int, field: str) -> bytes:
+        self._require_current_generation(boot_id, genvm_id, op="get_artifact")
+        offset = 0
+        out = bytearray()
+        while True:
+            response = await self._request(
+                manager_api.Methods.GET_ARTIFACT,
+                {
+                    "get_artifact": {
+                        "genvm_id": genvm_id,
+                        "field": field,
+                        "offset": offset,
+                        "max_len": 256 * 1024,
+                    }
+                },
+                retry_on_disconnect=True,
+            )
+            data = bytes(response["data"])
+            out.extend(data)
+            offset += len(data)
+            if offset >= int(response["total_len"]):
+                return bytes(out)
+            if not data:
+                raise ManagerConnectionLost("artifact transfer made no progress")
+
+    async def wait_terminal(self, state: RunState) -> dict[str, typing.Any]:
+        if state.terminal is not None:
+            return state.terminal
+        while True:
+            event = await state.events.get()
+            if isinstance(event, ManagerConnectionLost):
+                await self._reconnect_live_runs(event.generation)
+                continue
+            if isinstance(event, BaseException):
+                raise event
+            for variant in ("failed_to_start", "finished"):
+                if variant in event:
+                    state.terminal = event
+                    return event
+
+    async def _request(
+        self,
+        method: manager_api.Methods,
+        payload: typing.Any,
+        *,
+        retry_on_disconnect: bool,
+    ) -> typing.Any:
+        last_error: BaseException | None = None
+        for attempt in range(_MANAGER_RECONNECT_ATTEMPTS if retry_on_disconnect else 1):
+            generation = self._generation
+            try:
+                return await self._request_once(method, payload)
+            except ManagerConnectionLost as exc:
+                last_error = exc
+                if attempt + 1 < _MANAGER_RECONNECT_ATTEMPTS and retry_on_disconnect:
+                    await asyncio.sleep(_MANAGER_RECONNECT_BACKOFF_S * (2**attempt))
+                    await self._reconnect_live_runs(generation)
+                    continue
+                raise
+        assert last_error is not None
+        raise last_error
+
+    async def _request_once(
+        self,
+        method: manager_api.Methods,
+        payload: typing.Any,
+    ) -> typing.Any:
+        await self._ensure_connected()
+        assert self._ws is not None
+        async with self._send_lock:
+            request_id = self._request_id
+            self._request_id += 1
+            future = asyncio.get_running_loop().create_future()
+            self._pending[request_id] = future
+            body = (
+                int(method).to_bytes(2, "big")
+                + request_id.to_bytes(8, "big")
+                + gvm_calldata.encode(payload)
+            )
+            try:
+                await self._ws.send_bytes(body)
+            except (
+                BrokenPipeError,
+                ConnectionError,
+                aiohttp.ClientConnectionError,
+            ) as exc:
+                self._pending.pop(request_id, None)
+                self._mark_disconnected(ManagerConnectionLost(str(exc)))
+                raise ManagerConnectionLost(str(exc)) from exc
         try:
-            await task
+            response = await future
+        finally:
+            self._pending.pop(request_id, None)
+        if response.method != method:
+            raise ManagerConnectionLost(
+                f"manager replied with {response.method} for {method}"
+            )
+        return response.payload
+
+    async def _ensure_connected(self) -> None:
+        if self._ws is not None and not self._ws.closed:
+            return
+        async with self._connect_lock:
+            await self._reconnect_locked(-1)
+
+    async def _connect(self) -> None:
+        timeout = aiohttp.ClientTimeout(connect=self.connect_timeout)
+        if self.manager_uri.startswith("unix://"):
+            connector = aiohttp.UnixConnector(
+                path=self.manager_uri.removeprefix("unix://")
+            )
+            self._session = aiohttp.ClientSession(connector=connector, timeout=timeout)
+            ws_url = "http://localhost/ws"
+        else:
+            self._session = aiohttp.ClientSession(timeout=timeout)
+            ws_url = urllib.parse.urljoin(self.manager_uri.rstrip("/") + "/", "ws")
+        try:
+            self._ws = await self._session.ws_connect(
+                ws_url,
+                max_msg_size=self.max_msg_size,
+            )
+            frame = await self._read_frame()
+        except BaseException:
+            await self._close()
+            raise
+        if frame.method != manager_api.Methods.HELLO or frame.request_id != 0:
+            await self._close()
+            raise ManagerConnectionLost("manager did not send hello")
+        hello = frame.payload["hello"]
+        if hello["protocol_major"] != manager_api.CURRENT_MAJOR:
+            await self._close()
+            raise ManagerConnectionLost(
+                f'unsupported manager socket protocol {hello["protocol_major"]}'
+            )
+        hello_boot_id = int(hello["boot_id"])
+        # Always adopt the generation we are actually talking to. Keeping the old
+        # one because a run is still around is what let stale state outlive a
+        # manager restart and alias a reused id.
+        if self.boot_id is not None and self.boot_id != hello_boot_id:
+            self._retire_generation(self.boot_id)
+        self.boot_id = hello_boot_id
+        self._generation += 1
+        self._reader_task = asyncio.create_task(self._reader_loop())
+
+    def _retire_generation(self, boot_id: int) -> None:
+        """
+        Drops every run belonging to a manager process that is gone.
+
+        Their ids are about to be handed out again by the new process, so a
+        waiter must learn its run died with its manager rather than silently
+        binding to an unrelated run of the same number.
+        """
+        for key in [k for k in self._runs if k[0] == boot_id]:
+            state = self._runs.pop(key)
+            if not state.acked and state.terminal is None:
+                state.events.put_nowait(
+                    ManagerRunLost(
+                        f"manager restarted; run {state.genvm_id} of boot {boot_id} is gone"
+                    )
+                )
+        for key in [k for k in self._orphan_events if k[0] == boot_id]:
+            del self._orphan_events[key]
+
+    async def _reader_loop(self) -> None:
+        try:
+            while True:
+                frame = await self._read_frame()
+                if frame.request_id == 0:
+                    self._handle_notification(frame.method, frame.payload)
+                    continue
+                future = self._pending.pop(frame.request_id, None)
+                if future is None or future.done():
+                    continue
+                if frame.method == manager_api.Methods.ERROR:
+                    code = manager_api.Errors(frame.payload["code"])
+                    future.set_exception(
+                        ManagerSocketError(code, frame.payload["message"])
+                    )
+                else:
+                    future.set_result(frame)
         except asyncio.CancelledError:
-            pass
+            raise
+        except BaseException as exc:
+            self._mark_disconnected(ManagerConnectionLost(str(exc)))
+
+    async def _read_frame(self) -> Frame:
+        assert self._ws is not None
+        msg = await self._ws.receive()
+        if msg.type == aiohttp.WSMsgType.BINARY:
+            body = bytes(msg.data)
+        elif msg.type in (
+            aiohttp.WSMsgType.CLOSE,
+            aiohttp.WSMsgType.CLOSED,
+            aiohttp.WSMsgType.ERROR,
+        ):
+            raise ManagerConnectionLost("manager websocket closed")
+        else:
+            raise ManagerConnectionLost(f"unexpected websocket message {msg.type}")
+        if len(body) < 10:
+            raise ManagerConnectionLost("manager sent a short message")
+        method = manager_api.Methods(int.from_bytes(body[:2], "big"))
+        request_id = int.from_bytes(body[2:10], "big")
+        payload = gvm_calldata.decode(body[10:])
+        return Frame(method, request_id, payload)
+
+    def _handle_notification(
+        self, method: manager_api.Methods, payload: typing.Any
+    ) -> None:
+        if method != manager_api.Methods.EVENT:
+            return
+        genvm_id = None
+        for event in payload.values():
+            if isinstance(event, dict) and "genvm_id" in event:
+                genvm_id = int(event["genvm_id"])
+                break
+        if genvm_id is None:
+            return
+        # Events arrive on the live connection, so they belong to its generation.
+        key = self._key(genvm_id)
+        state = self._runs.get(key)
+        if state is None:
+            self._orphan_events.setdefault(key, []).append(payload)
+            return
+        self._queue_event(state, payload)
+
+    def _queue_event(self, state: RunState, event: dict[str, typing.Any]) -> None:
+        if "failed_to_start" in event or "finished" in event:
+            state.terminal = event
+        state.events.put_nowait(event)
+
+    def _mark_disconnected(self, exc: ManagerConnectionLost) -> None:
+        exc.generation = self._generation
+        self._ws = None
+        for future in list(self._pending.values()):
+            if not future.done():
+                future.set_exception(exc)
+        for state in self._runs.values():
+            if not state.acked and state.terminal is None:
+                state.events.put_nowait(exc)
+
+    async def _reconnect_locked(self, generation: int) -> None:
+        """
+        Rebuilds the connection unless someone already did. Holds `_connect_lock`.
+
+        Every teardown-and-reconnect goes through here, so the two entry points
+        (`_ensure_connected` and `_reconnect_live_runs`) cannot run `_close()`
+        and `_connect()` against each other and orphan a reader task, a session
+        or a socket the other one is installing.
+
+        `generation < 0` means "any live connection will do"; a non-negative one
+        names the generation the caller saw die, so a connection newer than it
+        is already the replacement and is left alone.
+        """
+        assert self._connect_lock.locked()
+        if self._ws is not None and not self._ws.closed:
+            if generation < 0 or self._generation > generation:
+                return
+        await self._close()
+        await self._connect()
+
+    async def _reconnect_live_runs(self, generation: int) -> None:
+        """
+        Reconnects the connection generation `generation` was lost on.
+
+        Several waiters observe the same disconnect, so whoever gets the lock
+        second finds a newer generation already connected and has nothing to do.
+        Reconnecting again there would tear down the working socket the first
+        waiter just built.
+        """
+        async with self._reconnect_lock:
+            async with self._connect_lock:
+                await self._reconnect_locked(generation)
+            # Re-attaching runs its own requests, which take `_connect_lock`
+            # themselves, so it happens outside of it. `_reconnect_lock` still
+            # keeps a second waiter out until this generation is whole again.
+            #
+            # A restart already retired the previous generation's runs during
+            # hello, so whatever is left here belongs to the manager we are now
+            # talking to and re-attaches under its own boot id.
+            for state in list(self._runs.values()):
+                if state.acked:
+                    continue
+                try:
+                    response = await self._request(
+                        manager_api.Methods.ATTACH,
+                        {
+                            "attach": {
+                                "boot_id": state.boot_id,
+                                "genvm_id": state.genvm_id,
+                            }
+                        },
+                        retry_on_disconnect=False,
+                    )
+                except ManagerSocketError as exc:
+                    state.events.put_nowait(exc)
+                else:
+                    self._queue_event(state, response["snapshot"])
+
+    async def _close(self) -> None:
+        ws = self._ws
+        self._ws = None
+        if self._reader_task is not None:
+            self._reader_task.cancel()
+            with contextlib.suppress(BaseException):
+                await self._reader_task
+            self._reader_task = None
+        if ws is not None:
+            with contextlib.suppress(BaseException):
+                await ws.close()
+        if self._session is not None:
+            with contextlib.suppress(BaseException):
+                await self._session.close()
+            self._session = None
+
+
+def _duration_string(seconds: float | None) -> str | None:
+    if seconds is None:
+        return None
+    if seconds < 1:
+        millis = max(1, math.ceil(seconds * 1000))
+        return f"{millis}ms"
+    if float(seconds).is_integer():
+        return f"{int(seconds)}s"
+    return f"{seconds:g}s"
+
+
+def _decode_genvm_log(data: bytes) -> list[dict[str, typing.Any]]:
+    """Decodes the genvm log artifact, which is json lines.
+
+    Split on newline bytes only. `str.splitlines` also breaks on U+2028, U+2029
+    and U+0085, none of which json escapes and all of which therefore appear raw
+    inside a string value -- splitting there cuts a record in half and raises
+    `Unterminated string`. Model output reaches this log, so those codepoints do
+    turn up in practice.
+    """
+    if not data:
+        return []
+    return [json.loads(line) for line in data.split(b"\n") if line.strip()]
 
 
 async def run_genvm(
     handler: IHost,
     *,
-    timeout: float | None = None,  # noqa: ASYNC109 - drives a process timeout task
+    timeout: float | None = None,  # noqa: ASYNC109
     manager_uri: str = "http://127.0.0.1:3999",
+    manager_client: ManagerClient,
     ctx: Context,
     is_sync: bool,
-    capture_output: bool = True,
-    debug_mode: DebugMode | None = None,
+    debug_mode: DebugMode = "disabled",
     message: Message,
     host_data: str = "",
     gas_data: dict[str, str] | None = None,
     host: str,
-    extra_args: list[str] = [],
+    extra_args: collections.abc.Sequence[str] = (),
     # default config fee buckets use bucket_no 0 and 1
-    bucket_totals: list[int] | None = None,
+    bucket_totals: list[int],
     code: bytes | None = None,
     calldata: bytes,
     leader_nondet_results: list[bytes] | None = None,
-    message_fee_allocation: list[fees.MessageAllocationNode] | None = None,
-    reroute_to: str = "",
-    request_extra: dict[str, gvm_calldata.Encodable] = {},
+    message_fee_allocation: collections.abc.Sequence[fees.MessageAllocationNode] = (),
+    unsafe_overrides: UnsafeOverrides | None = None,
+    request_extra: collections.abc.Mapping[
+        str, gvm_calldata.Encodable
+    ] = types.MappingProxyType({}),
     shutdown_early: asyncio.Event | None = None,
+    host_hello_data: collections.abc.Sequence[bytes] = (),
+    major: int | None = None,
 ) -> RunHostAndProgramRes:
     logger = ctx.logger
 
-    # `node` fee constants are an ExecutionData field (no longer in host_data).
-    effective_debug_mode = debug_mode or (
-        "safe-unbounded" if capture_output else "disabled"
-    )
-    effective_bucket_totals = bucket_totals or [
-        10_000_000,
-        10_000_000,
-        10_000_000,
-        10_000_000,
-    ]
+    # `node` fee constants are an ExecutionData field.
     effective_gas_data = DEFAULT_GAS_DATA if gas_data is None else gas_data
-    effective_message_fee_allocation = message_fee_allocation or []
-
-    perf_timeline: dict[str, typing.Any] = {
-        "run_started_s": time.perf_counter(),
-    }
-    genvm_id_cell: list[str | None] = [None]
-    status_cell: list[dict | Exception | None] = [None]
-    timeout_task_cell: list[asyncio.Task | None] = [None]
     cancellation_event = asyncio.Event()
+    host_task = asyncio.create_task(host_loop(handler, cancellation_event, ctx=ctx))
 
-    started_at = [time.time()]
-
-    async def wrap_proc_body(attempt: int):
+    client = manager_client
+    genvm_id: int | None = None
+    boot_id: int | None = None
+    cancel_task: asyncio.Task | None = None
+    terminal_task: asyncio.Task | None = None
+    terminal_received = False
+    try:
         max_exec_mins = 20
         if timeout is not None:
             max_exec_mins = int(max(max_exec_mins, (timeout * 1.5 + 59) // 60))
-
         timestamp = message.get("datetime", "2024-11-26T06:42:42.424242Z")
+        deadline = _duration_string(timeout)
+        host_genvm_id = typing.cast(str | None, request_extra.get("host_genvm_id"))
+        if host_genvm_id is None:
+            host_genvm_id = f"{time.time_ns()}-{id(asyncio.current_task())}"
+        request_payload: dict[str, typing.Any] = {
+            "selector": {
+                "kind": "major",
+                "major": (
+                    await read_contract_major(handler, message)
+                    if major is None
+                    else major
+                ),
+            },
+            "message": message,
+            "is_sync": is_sync,
+            "debug_mode": debug_mode,
+            "host_data": host_data,
+            "max_execution_minutes": max_exec_mins,
+            "timestamp": timestamp,
+            "host": host,
+            "extra_args": list(extra_args),
+            "code": code,
+            "calldata": calldata,
+            "leader_nondet_results": leader_nondet_results,
+            "bucket_totals": bucket_totals,
+            "gas_data": effective_gas_data,
+            "message_fee_allocation": list(message_fee_allocation),
+            "initial_time_units_allocation": math.ceil(timeout or 10 * 60),
+            "unsafe_overrides": (
+                unsafe_overrides or UnsafeOverrides()
+            ).as_request_field(),
+            "host_genvm_id": host_genvm_id,
+            "host_hello_data": list(host_hello_data),
+            **request_extra,
+        }
+        if deadline is not None:
+            request_payload["deadline"] = deadline
 
-        async with aiohttp.request(
-            "POST",
-            f"{manager_uri}/genvm/run",
-            data=gvm_calldata.encode(
-                {
-                    "major": 0,  # FIXME
-                    "message": message,
-                    "is_sync": is_sync,
-                    "debug_mode": effective_debug_mode,
-                    "host_data": host_data,
-                    "max_execution_minutes": max_exec_mins,  # this parameter is needed to prevent zombie genvms
-                    "timestamp": timestamp,
-                    "host": host,
-                    "extra_args": extra_args,
-                    "code": code,
-                    "calldata": calldata,
-                    "leader_nondet_results": leader_nondet_results,
-                    "bucket_totals": effective_bucket_totals,
-                    "gas_data": effective_gas_data,
-                    "message_fee_allocation": effective_message_fee_allocation,
-                    "initial_time_units_allocation": DEFAULT_INITIAL_TIME_UNITS_ALLOCATION,
-                    # Debug-only executor-dir override; honored by the manager only
-                    # under debug_mode >= safe (tests run with safe/unsafe).
-                    "reroute_to": reroute_to,
-                    **request_extra,
-                }
-            ),
-            timeout=_http_timeout(ctx, TimeoutAction.GenVMRun),
-        ) as resp:
-            logger.debug("post /genvm/run", status=resp.status, attempt=attempt)
-            data = await resp.json()
-            logger.trace("post /genvm/run", body=data)
-            if resp.status != 200:
-                logger.error(
-                    "genvm manager /genvm/run failed", status=resp.status, body=data
-                )
-                if _is_retryable_manager_run_error(resp.status, data):
-                    raise GenVMManagerRetryableError(resp.status, data)
-                raise Exception(
-                    f"genvm manager /genvm/run failed: {resp.status} {data}"
-                )
+        attempt_start = time.perf_counter()
+        try:
+            state = await client.run(request_payload)
+        except Exception as exc:
+            if isinstance(exc, ManagerConnectionLost):
+                retryable, reason = True, "manager_connection_lost"
+            elif isinstance(exc, ManagerSocketError):
+                retryable, reason = _classify_run_refusal(exc.message)
             else:
-                genvm_id = data["id"]
-                logger.debug(
-                    "genvm manager /genvm", genvm_id=genvm_id, status=resp.status
-                )
-                genvm_id_cell[0] = genvm_id
-                perf_timeline["genvm_id_obtained_s"] = time.perf_counter()
-                timeout_task_cell[0] = asyncio.ensure_future(wrap_timeout(genvm_id))
-                ctx.on_genvm_success()
-
-    async def wrap_proc():
-        attempt = 0
-        while True:
-            attempt_start = time.perf_counter()
-            try:
-                await wrap_proc_body(attempt)
-                ctx.add_stat(
-                    "manager_run_attempt_success",
-                    {
-                        "attempt": attempt,
-                        "duration_ms": round(
-                            (time.perf_counter() - attempt_start) * 1000
-                        ),
-                    },
-                )
-                break
-            except (
-                aiohttp.ClientError,
-                asyncio.TimeoutError,
-                GenVMManagerRetryableError,
-            ) as exc:
-                delay = ctx.retry_delay(TimeoutAction.GenVMRun, attempt)
-                error_stat = {
-                    "attempt": attempt,
+                retryable, reason = False, "manager_run_error"
+            ctx.add_stat(
+                "manager_run_attempt_0_error",
+                {
+                    "attempt": 0,
                     "error_type": type(exc).__name__,
                     "duration_ms": round((time.perf_counter() - attempt_start) * 1000),
-                    "will_retry": delay is not None,
-                }
-                if isinstance(exc, GenVMManagerRetryableError):
-                    error_stat["status"] = exc.status
-                    error_stat["body"] = exc.body
-                    error_stat["retry_reason"] = "manager_modules_not_running"
-                ctx.add_stat(f"manager_run_attempt_{attempt}_error", error_stat)
-                if delay is None:
-                    logger.error(
-                        "genvm manager request failed after all retries",
-                        error=str(exc),
-                        attempt=attempt,
-                    )
-                    ctx.on_genvm_failure()
+                    "retryable": retryable,
+                    "reason": reason,
+                },
+            )
+            ctx.on_genvm_failure()
+            cancellation_event.set()
+            raise ManagerRunNotStarted(
+                str(exc), retryable=retryable, reason=reason
+            ) from exc
+        genvm_id = state.genvm_id
+        boot_id = state.boot_id
+        ctx.add_stat(
+            "manager_run_attempt_success",
+            {
+                "attempt": 0,
+                "duration_ms": round((time.perf_counter() - attempt_start) * 1000),
+            },
+        )
+        logger.debug("genvm manager socket run", genvm_id=genvm_id)
+        ctx.on_genvm_success()
+        started_at = time.time()
+
+        async def cancel_on_shutdown():
+            assert genvm_id is not None
+            if shutdown_early is None:
+                return
+            await shutdown_early.wait()
+            logger.debug("shutdown_early event set", genvm_id=genvm_id)
+            await client.cancel(boot_id, genvm_id)
+
+        if shutdown_early is not None:
+            cancel_task = asyncio.create_task(cancel_on_shutdown())
+
+        terminal_task = asyncio.create_task(client.wait_terminal(state))
+        while True:
+            done, _pending = await asyncio.wait(
+                [terminal_task, host_task],
+                return_when=asyncio.FIRST_COMPLETED,
+            )
+            if terminal_task in done:
+                terminal = terminal_task.result()
+                terminal_received = True
+                break
+            if host_task.done():
+                host_exc = host_task.exception()
+                if host_exc is not None:
+                    await client.cancel(boot_id, genvm_id)
                     cancellation_event.set()
-                    raise
-                logger.warning(
-                    "genvm manager request failed, retrying",
-                    error=str(exc),
-                    attempt=attempt,
-                    retry_delay_s=delay,
-                )
-                await asyncio.sleep(delay)
-            except Exception:
-                ctx.add_stat(
-                    f"manager_run_attempt_{attempt}_error",
-                    {
-                        "attempt": attempt,
-                        "outcome": "fatal_error",
-                        "duration_ms": round(
-                            (time.perf_counter() - attempt_start) * 1000
-                        ),
-                    },
-                )
-                raise
-            finally:
-                if genvm_id_cell[0] is not None:
-                    logger.debug("proc started", genvm_id=genvm_id_cell[0])
-            attempt += 1
-        started_at[0] = time.time()
+                    raise host_exc
+                terminal = await terminal_task
+                terminal_received = True
+                break
 
-    async def wrap_host():
-        r = await host_loop(handler, cancellation_event, ctx=ctx)
-        logger.debug("host loop finished")
-        return r
-
-    timeout_fired = asyncio.Event()
-
-    async def wrap_timeout(genvm_id: str):
-        reason = "unknown"
-        if timeout is None:
-            if shutdown_early is None:
-                return  # nothing to do
-            else:
-                await shutdown_early.wait()
-                reason = "shutdown_early event set"
-        else:
-            if shutdown_early is None:
-                await asyncio.sleep(timeout)
-                reason = "timeout reached"
-            else:
-                try:
-                    await asyncio.wait_for(shutdown_early.wait(), timeout=timeout)
-                    reason = "shutdown_early event set"
-                except asyncio.TimeoutError:
-                    reason = "timeout reached"
-        logger.debug("timeout reached", genvm_id=genvm_id, reason=reason)
-        timeout_fired.set()
-        await _send_timeout(
-            manager_uri,
-            genvm_id,
-            ctx=ctx,
-        )
-
-    poll_status_mutex = asyncio.Lock()
-
-    async def poll_status(genvm_id: str):
-        async with poll_status_mutex:
-            old_status = status_cell[0]
-            if old_status is not None:
-                return old_status
-            try:
-                async with aiohttp.request(
-                    "GET",
-                    f"{manager_uri}/genvm/{genvm_id}",
-                    timeout=_http_timeout(ctx, TimeoutAction.GenVMGet),
-                ) as resp:
-                    logger.debug("get /genvm", genvm_id=genvm_id, status=resp.status)
-                    body = await resp.json()
-                    logger.trace("get /genvm", genvm_id=genvm_id, body=body)
-                    if resp.status != 200:
-                        new_res = Exception(
-                            f"genvm manager /genvm failed: {resp.status} {body}"
-                        )
-                    elif body["status"] is None:
-                        return None
-                    else:
-                        new_res = typing.cast(dict, body["status"])
-            except (aiohttp.ClientError, asyncio.TimeoutError) as exc:
-                new_res = Exception(f"genvm manager /genvm request failed: {exc}")
-            status_cell[0] = new_res
-            return new_res
-
-    async def prob_died():
-        await _await_first_cancel_others(asyncio.sleep(1), cancellation_event.wait())
-
-        genvm_id = genvm_id_cell[0]
-        if genvm_id is None:
-            return
-        status = await poll_status(genvm_id)
-        if status is not None and not cancellation_event.is_set():
-            logger.error(
-                "genvm died without connecting", genvm_id=genvm_id, status=status
-            )
-            cancellation_event.set()
-
-    fut_host = asyncio.ensure_future(wrap_host())
-    fut_proc = asyncio.ensure_future(wrap_proc())
-    fut_prob = asyncio.ensure_future(prob_died())
-
-    # Map futures to names for debugging
-    task_names = {
-        id(fut_host): "host_loop",
-        id(fut_proc): "genvm_run",
-        id(fut_prob): "prob_died",
-    }
-
-    # IMPORTANT: if proc setup fails (e.g., manager accepts TCP but never replies),
-    # don't wait forever on host_loop.
-    try:
-        done, pending = await asyncio.wait(
-            [fut_host, fut_proc, fut_prob], return_when=asyncio.FIRST_EXCEPTION
-        )
-    except BaseException:
         cancellation_event.set()
-        tasks = [fut_host, fut_proc, fut_prob]
-        for task in tasks:
-            if not task.done():
-                task.cancel()
-        for task in tasks:
+        if cancel_task is not None:
+            cancel_task.cancel()
+            with contextlib.suppress(BaseException):
+                await cancel_task
+        with contextlib.suppress(BaseException):
+            await host_task
+
+        if "finished" in terminal:
+            status = terminal["finished"]
+            sizes = status.get("artifact_sizes") or {}
             try:
-                await task
-            except BaseException:
-                pass
-
-        timeout_task = timeout_task_cell[0]
-        if timeout_task is not None and not timeout_task.done():
-            timeout_task.cancel()
-            try:
-                await timeout_task
-            except BaseException:
-                pass
-
-        genvm_id = genvm_id_cell[0]
-        if genvm_id is not None:
-            await _send_timeout(manager_uri, genvm_id, ctx=ctx)
-        raise
-
-    # Log which tasks completed/failed for debugging
-    done_names = [task_names.get(id(t), "unknown") for t in done]
-    pending_names = [task_names.get(id(t), "unknown") for t in pending]
-    logger.debug(
-        "asyncio.wait returned",
-        done_tasks=done_names,
-        pending_tasks=pending_names,
-        genvm_id=genvm_id_cell[0],
-    )
-
-    # If anything errored, stop the host loop.
-    for task in done:
-        exc = task.exception()
-        if exc is not None:
-            task_name = task_names.get(id(task), "unknown")
-            logger.error(
-                "task raised exception",
-                task_name=task_name,
-                exception_type=type(exc).__name__,
-                exception_msg=str(exc),
-                genvm_id=genvm_id_cell[0],
+                stdout = (
+                    (await client.get_artifact(boot_id, genvm_id, "stdout")).decode()
+                    if sizes.get("stdout", 0)
+                    else ""
+                )
+                stderr = (
+                    (await client.get_artifact(boot_id, genvm_id, "stderr")).decode()
+                    if sizes.get("stderr", 0)
+                    else ""
+                )
+                genvm_log = (
+                    _decode_genvm_log(
+                        await client.get_artifact(boot_id, genvm_id, "genvm_log")
+                    )
+                    if sizes.get("genvm_log", 0)
+                    else []
+                )
+                consumed = ConsumedResult.decode(status.get("consumed_result"))
+            except Exception as exc:
+                # The run already executed and finished; a failure retrieving or
+                # decoding its result must never look like an attempt that
+                # never happened. That distinction is what keeps the outer
+                # retry loop (`run_genvm_host`) from starting a second
+                # execution for a result that already exists.
+                raise TerminalResultUnavailable(
+                    f"failed to retrieve/decode result for finished run: {exc}",
+                    genvm_id=genvm_id,
+                ) from exc
+            if (
+                status.get("cause") == "deadline"
+                and consumed.result_kind != public_abi.ResultCode.RETURN
+            ):
+                consumed.result_kind = public_abi.ResultCode.VM_ERROR
+                consumed.result_data = str(public_abi.VmError.timeout())
+        else:
+            # A failed_to_start terminal means the genvm was accepted but never
+            # ran, so surface it through the same not-started seam as a rejected
+            # RUN -- never as an INTERNAL_ERROR result the caller could mistake
+            # for a run that executed.
+            error = terminal["failed_to_start"]["error"]
+            retryable, reason = _classify_run_refusal(error)
+            ctx.add_stat(
+                "manager_run_start_failed",
+                {"reason": reason, "retryable": retryable},
             )
-            cancellation_event.set()
-
-    # Cancel any pending tasks to prevent leaks
-    for task in pending:
-        task.cancel()
-        try:
-            await task
-        except asyncio.CancelledError:
-            pass
-
-    # Cancel the timeout task if it's still pending
-    timeout_task = timeout_task_cell[0]
-    if timeout_task is not None and not timeout_task.done():
-        timeout_task.cancel()
-        try:
-            await timeout_task
-        except asyncio.CancelledError:
-            pass
-
-    # Collect exceptions from all tasks, including CancelledError
-    # Note: CancelledError inherits from BaseException, not Exception
-    exceptions: list[BaseException] = []
-    cancelled_tasks: list[str] = []
-
-    try:
-        fut_host.result()
-    except asyncio.CancelledError:
-        cancelled_tasks.append("host_loop")
-    except ConnectionResetError as e:
-        if not timeout_fired.is_set():
-            logger.warning("connection reset without timeout", error=e)
-    except BaseException as e:
-        if not timeout_fired.is_set():
-            exceptions.append(e)
-        else:
-            logger.warning("host handler failed after timeout", error=e)
-
-    try:
-        fut_proc.result()
-    except asyncio.CancelledError:
-        cancelled_tasks.append("genvm_run")
-    except BaseException as e:
-        exceptions.append(e)
-
-    # Log if tasks were cancelled (helps debug root cause)
-    if cancelled_tasks:
-        logger.debug(
-            "tasks were cancelled",
-            cancelled_tasks=cancelled_tasks,
-            exception_count=len(exceptions),
-            genvm_id=genvm_id_cell[0],
-        )
-
-    if len(exceptions) > 0:
-        # Include cancelled tasks info in the exception message for debugging
-        error_details = {
-            "exceptions": [f"{type(e).__name__}: {e}" for e in exceptions],
-            "cancelled_tasks": cancelled_tasks,
-            "genvm_id": genvm_id_cell[0],
-        }
-        logger.error("genvm execution failed", **error_details)
-        raise Exception(f"genvm execution failed: {error_details}") from exceptions[0]
-
-    # If all tasks were cancelled but no exceptions, something went wrong
-    if cancelled_tasks and len(exceptions) == 0:
-        error_msg = f"all genvm tasks cancelled without error: cancelled={cancelled_tasks}, genvm_id={genvm_id_cell[0]}"
-        logger.error(error_msg)
-        raise Exception(error_msg)
-
-    genvm_id = genvm_id_cell[0]
-    if genvm_id is not None:
-        await _send_timeout(
-            manager_uri,
-            genvm_id,
-            ctx=ctx,
-        )
-
-        status = await poll_status(genvm_id)
-        if status is None:
-            exceptions.append(Exception("execution failed: no status"))
-        elif isinstance(status, Exception):
-            exceptions.append(status)
-        if len(exceptions) > 0:
-            final_exception = Exception("execution failed", exceptions[1:])
-            raise final_exception from exceptions[0]
-
-        # Result was sent to manager via consume_result, get it from status
-        consumed_result_raw = (
-            status.get("consumed_result") if isinstance(status, dict) else None
-        )
-        if consumed_result_raw is not None:
-            consumed_result_bytes = bytes(consumed_result_raw)
-            result_kind = public_abi.ResultCode(consumed_result_bytes[0])
-            decoded = gvm_calldata.decode(consumed_result_bytes[1:])
-            execution_hash = decoded.get("execution_hash", b"")
-            result_data = decoded.get("data")
-            result_fingerprint = decoded.get("fingerprint")
-            result_storage_changes = decoded.get("storage_changes", [])
-            result_emissions = decoded.get("emissions", [])
-            nondet_results = decoded.get("nondet_results", [])
-            data_fees_remaining = decoded.get("data_fees_remaining", [])
-        else:
-            execution_hash = b""
-            result_kind = public_abi.ResultCode.INTERNAL_ERROR
-            result_data = "no_result"
-            result_fingerprint = None
-            result_storage_changes = []
-            result_emissions = []
-            nondet_results = []
-            data_fees_remaining = []
-
-        if timeout_fired.is_set() and result_kind != public_abi.ResultCode.RETURN:
-            result_kind = public_abi.ResultCode.VM_ERROR
-            result_data = str(public_abi.VmError.timeout())
+            # Symmetric with the client.run() rejection branch (and with the
+            # INTERNAL_ERROR result this used to return): a run that failed to
+            # start is a manager failure for health tracking.
+            ctx.on_genvm_failure()
+            raise ManagerRunNotStarted(error, retryable=retryable, reason=reason)
 
         vm_error_description: str | None = None
-        if result_kind == public_abi.ResultCode.VM_ERROR and isinstance(
-            result_data, str
+        if consumed.result_kind == public_abi.ResultCode.VM_ERROR and isinstance(
+            consumed.result_data, str
         ):
             try:
                 async with aiohttp.request(
                     "GET",
                     f"{manager_uri}/vm-error/describe",
-                    params={"error": result_data},
-                    timeout=_http_timeout(ctx, TimeoutAction.VMErrorDescribe),
+                    params={"error": consumed.result_data},
+                    timeout=_http_timeout(ctx),
                 ) as resp:
                     if resp.status == 200:
                         body = await resp.json()
@@ -931,20 +1377,49 @@ async def run_genvm(
                 logger.warning("failed to get vm error description", error=str(e))
 
         return RunHostAndProgramRes(
-            stdout=status["stdout"],
-            stderr=status["stderr"],
-            genvm_log=status.get("genvm_log") or [],
-            metrics=status.get("metrics") if isinstance(status, dict) else None,
-            execution_hash=execution_hash,
-            result_kind=result_kind,
-            result_data=result_data,
-            result_fingerprint=result_fingerprint,
-            result_storage_changes=result_storage_changes,
-            result_emissions=result_emissions,
-            result_nondet_results=nondet_results,
-            data_fees_remaining=data_fees_remaining,
+            stdout=stdout,
+            stderr=stderr,
+            genvm_log=genvm_log,
+            metrics=status.get("metrics"),
+            execution_hash=consumed.execution_hash,
+            result_kind=consumed.result_kind,
+            result_data=consumed.result_data,
+            result_fingerprint=consumed.result_fingerprint,
+            result_storage_changes=consumed.result_storage_changes,
+            result_emissions=consumed.result_emissions,
+            result_nondet_results=consumed.result_nondet_results,
+            data_fees_remaining=consumed.data_fees_remaining,
             vm_error_description=vm_error_description,
-            execution_time=time.time() - started_at[0],
+            execution_time=time.time() - started_at,
         )
-
-    raise Exception("Execution failed")
+    finally:
+        if cancel_task is not None and not cancel_task.done():
+            cancel_task.cancel()
+            with contextlib.suppress(BaseException):
+                await cancel_task
+        if terminal_task is not None and not terminal_task.done():
+            terminal_task.cancel()
+            with contextlib.suppress(BaseException):
+                await terminal_task
+        if genvm_id is not None and terminal_received:
+            # ack only releases the manager's retention of a run that already
+            # produced its result and artifacts. Letting it fail out of here
+            # would turn a finished execution into an attempt error and send
+            # the caller back through the retry loop to run the contract again.
+            try:
+                await client.ack(boot_id, genvm_id)
+            except Exception as exc:
+                logger.warning(
+                    "failed to ack a finished genvm run",
+                    genvm_id=genvm_id,
+                    error=str(exc),
+                )
+        elif genvm_id is not None:
+            with contextlib.suppress(BaseException):
+                await client.cancel(boot_id, genvm_id)
+        if not cancellation_event.is_set():
+            cancellation_event.set()
+        if not host_task.done():
+            host_task.cancel()
+            with contextlib.suppress(BaseException):
+                await host_task

--- a/backend/node/genvm/origin/base_host.py
+++ b/backend/node/genvm/origin/base_host.py
@@ -1,5 +1,6 @@
 import abc
 import asyncio
+import base64
 import collections.abc
 import contextlib
 import json
@@ -519,19 +520,22 @@ class ConsumedResult:
             return cls.internal_error("no_result")
         empty = False
         try:
-            as_bytes = bytes(raw)
+            # The socket sends bytes, the deprecated http shim sends base64.
+            as_bytes = (
+                base64.b64decode(raw, validate=True)
+                if isinstance(raw, str)
+                else bytes(raw)
+            )
             empty = not as_bytes
             if not empty:
                 result_kind = public_abi.ResultCode(as_bytes[0])
                 decoded = gvm_calldata.decode(as_bytes[1:])
         except Exception as exc:
-            # `raw` wasn't even bytes-shaped, or its ResultCode byte/calldata
-            # failed to parse. Either way this is not a result the genvm
-            # reported, it's a protocol violation: raise instead of returning
-            # an `internal_error(...)` value so it can never be mistaken for a
-            # real (if unhappy) execution outcome.
+            # Unreadable bytes are a protocol violation rather than a result, so
+            # raise instead of returning an `internal_error(...)` value that a
+            # caller could mistake for a real (if unhappy) execution outcome.
             raise ConsumedResultDecodeError(
-                f"malformed consumed_result ({raw!r}): {exc}"
+                f"malformed consumed_result ({raw!r:.80}): {exc}"
             ) from exc
         if empty:
             # Distinct from `None`: the manager did send a `consumed_result`,

--- a/backend/node/genvm/origin/host_fns.py
+++ b/backend/node/genvm/origin/host_fns.py
@@ -15,7 +15,8 @@ class Methods(IntEnum):
     REMAINING_FUEL_AS_GEN = 4
     NOTIFY_NONDET_DISAGREEMENT = 5
     CONSUME_RESULT = 6
-    NOTIFY_FINISHED = 7
+    RESOLVE_CALLCONTRACT_EXECUTOR = 7
+    RUN_NESTED = 8
 
 
 class Errors(IntEnum):
@@ -23,22 +24,26 @@ class Errors(IntEnum):
     EVM_REVERTED = 1
     FORBIDDEN = 2
 
+
 class VmErrorDetail:
-    __slots__ = ('value',)
+    __slots__ = ("value",)
+
     def __init__(self, value: str):
         self.value = value
+
     def __str__(self) -> str:
         return self.value
-    @staticmethod
-    def internal() -> 'VmErrorDetail':
-        return VmErrorDetail('internal')
-    @staticmethod
-    def external() -> 'VmErrorDetail':
-        return VmErrorDetail('external')
 
+    @staticmethod
+    def internal() -> "VmErrorDetail":
+        return VmErrorDetail("internal")
+
+    @staticmethod
+    def external() -> "VmErrorDetail":
+        return VmErrorDetail("external")
 
 
 CURRENT_MAJOR: typing.Final[int] = 0
 
 
-CURRENT_MAJOR_STR: typing.Final[str] = 'v0.0.0'
+CURRENT_MAJOR_STR: typing.Final[str] = "v0.0.0"

--- a/backend/node/genvm/origin/manager_api.py
+++ b/backend/node/genvm/origin/manager_api.py
@@ -1,0 +1,30 @@
+# This file is auto-generated. Do not edit!
+
+# fmt: off
+# ruff: noqa
+
+import typing
+from enum import IntEnum
+
+class Methods(IntEnum):
+    ERROR = 0
+    HELLO = 1
+    EVENT = 2
+    RUN = 3
+    ATTACH = 4
+    CANCEL = 5
+    ACK = 6
+    GET_ARTIFACT = 7
+
+
+class Errors(IntEnum):
+    INTERNAL = 0
+    MALFORMED_FRAME = 1
+    UNKNOWN_METHOD = 2
+    UNKNOWN_ID = 3
+    BOOT_ID_MISMATCH = 4
+    BAD_REQUEST_ID = 5
+    NOT_FINISHED = 6
+
+
+CURRENT_MAJOR: typing.Final[int] = 0

--- a/backend/node/genvm/origin/public_abi.py
+++ b/backend/node/genvm/origin/public_abi.py
@@ -37,6 +37,7 @@ class _MemoryLimiterConsts(typing.NamedTuple):
     RUNNER_LOAD_COST: int = 4096
     VM_SPAWN_COST: int = 134217728
 
+
 memory_limiter_consts: typing.Final = _MemoryLimiterConsts()
 
 
@@ -48,6 +49,7 @@ class _RootOffsets(typing.NamedTuple):
     UPGRADERS: int = 4
     CODE_SLOT: int = 5
     PERMISSIONS: int = 37
+
 
 root_offsets: typing.Final = _RootOffsets()
 
@@ -63,208 +65,267 @@ class _TopLimits(typing.NamedTuple):
     WASM_CALL_DEPTH: int = 1024
     WASM_STACK_VALUE_SLOTS: int = 65535
 
+
 top_limits: typing.Final = _TopLimits()
 
 
 class SpecialMethod(StrEnum):
-    GET_SCHEMA = '#get-schema'
-    ERRORED_MESSAGE = '#error'
+    GET_SCHEMA = "#get-schema"
+    ERRORED_MESSAGE = "#error"
+
 
 class _VmErrorWasmTrap:
     @staticmethod
-    def val() -> 'VmError':
-        return VmError('wasm_trap')
+    def val() -> "VmError":
+        return VmError("wasm_trap")
+
     @staticmethod
-    def unreachable() -> 'VmError':
-        return VmError('wasm_trap unreachable')
+    def unreachable() -> "VmError":
+        return VmError("wasm_trap unreachable")
+
     @staticmethod
-    def stack_overflow() -> 'VmError':
-        return VmError('wasm_trap stack_overflow')
+    def stack_overflow() -> "VmError":
+        return VmError("wasm_trap stack_overflow")
+
     @staticmethod
-    def memory_out_of_bounds() -> 'VmError':
-        return VmError('wasm_trap memory_out_of_bounds')
+    def memory_out_of_bounds() -> "VmError":
+        return VmError("wasm_trap memory_out_of_bounds")
+
     @staticmethod
-    def table_out_of_bounds() -> 'VmError':
-        return VmError('wasm_trap table_out_of_bounds')
+    def table_out_of_bounds() -> "VmError":
+        return VmError("wasm_trap table_out_of_bounds")
+
     @staticmethod
-    def indirect_call_to_null() -> 'VmError':
-        return VmError('wasm_trap indirect_call_to_null')
+    def indirect_call_to_null() -> "VmError":
+        return VmError("wasm_trap indirect_call_to_null")
+
     @staticmethod
-    def bad_signature() -> 'VmError':
-        return VmError('wasm_trap bad_signature')
+    def bad_signature() -> "VmError":
+        return VmError("wasm_trap bad_signature")
+
     @staticmethod
-    def integer_overflow() -> 'VmError':
-        return VmError('wasm_trap integer_overflow')
+    def integer_overflow() -> "VmError":
+        return VmError("wasm_trap integer_overflow")
+
     @staticmethod
-    def integer_divide_by_zero() -> 'VmError':
-        return VmError('wasm_trap integer_divide_by_zero')
+    def integer_divide_by_zero() -> "VmError":
+        return VmError("wasm_trap integer_divide_by_zero")
+
     @staticmethod
-    def bad_conversion_to_integer() -> 'VmError':
-        return VmError('wasm_trap bad_conversion_to_integer')
+    def bad_conversion_to_integer() -> "VmError":
+        return VmError("wasm_trap bad_conversion_to_integer")
+
     @staticmethod
-    def heap_misaligned() -> 'VmError':
-        return VmError('wasm_trap heap_misaligned')
+    def heap_misaligned() -> "VmError":
+        return VmError("wasm_trap heap_misaligned")
+
     @staticmethod
-    def atomic_wait_non_shared_memory() -> 'VmError':
-        return VmError('wasm_trap atomic_wait_non_shared_memory')
+    def atomic_wait_non_shared_memory() -> "VmError":
+        return VmError("wasm_trap atomic_wait_non_shared_memory")
+
     @staticmethod
-    def out_of_fuel() -> 'VmError':
-        return VmError('wasm_trap out_of_fuel')
+    def out_of_fuel() -> "VmError":
+        return VmError("wasm_trap out_of_fuel")
+
     @staticmethod
-    def interrupt() -> 'VmError':
-        return VmError('wasm_trap interrupt')
+    def interrupt() -> "VmError":
+        return VmError("wasm_trap interrupt")
+
     @staticmethod
-    def nondet_instruction() -> 'VmError':
-        return VmError('wasm_trap nondet_instruction')
+    def nondet_instruction() -> "VmError":
+        return VmError("wasm_trap nondet_instruction")
+
     @staticmethod
-    def fault() -> 'VmError':
-        return VmError('wasm_trap fault')
+    def fault() -> "VmError":
+        return VmError("wasm_trap fault")
+
 
 class _VmErrorOutOfMemory:
     @staticmethod
-    def val() -> 'VmError':
-        return VmError('out_of memory')
+    def val() -> "VmError":
+        return VmError("out_of memory")
+
     @staticmethod
-    def wasm_memory() -> 'VmError':
-        return VmError('out_of memory wasm_memory')
+    def wasm_memory() -> "VmError":
+        return VmError("out_of memory wasm_memory")
+
     @staticmethod
-    def wasm_table() -> 'VmError':
-        return VmError('out_of memory wasm_table')
+    def wasm_table() -> "VmError":
+        return VmError("out_of memory wasm_table")
+
 
 class _VmErrorOutOfReceipt:
     @staticmethod
-    def nondet_output() -> 'VmError':
-        return VmError('out_of receipt nondet_output')
+    def nondet_output() -> "VmError":
+        return VmError("out_of receipt nondet_output")
+
     @staticmethod
-    def message() -> 'VmError':
-        return VmError('out_of receipt message')
+    def message() -> "VmError":
+        return VmError("out_of receipt message")
+
     @staticmethod
-    def event() -> 'VmError':
-        return VmError('out_of receipt event')
+    def event() -> "VmError":
+        return VmError("out_of receipt event")
+
 
 class _VmErrorOutOfMessageFee:
     @staticmethod
-    def total() -> 'VmError':
-        return VmError('out_of message_fee total')
+    def total() -> "VmError":
+        return VmError("out_of message_fee total")
+
     @staticmethod
-    def node() -> 'VmError':
-        return VmError('out_of message_fee node')
+    def node() -> "VmError":
+        return VmError("out_of message_fee node")
+
 
 class _VmErrorOutOf:
     @staticmethod
-    def storage() -> 'VmError':
-        return VmError('out_of storage')
+    def storage() -> "VmError":
+        return VmError("out_of storage")
+
     @staticmethod
-    def vm_recursion() -> 'VmError':
-        return VmError('out_of vm_recursion')
+    def vm_recursion() -> "VmError":
+        return VmError("out_of vm_recursion")
+
     @staticmethod
-    def nondet_blocks() -> 'VmError':
-        return VmError('out_of nondet_blocks')
+    def nondet_blocks() -> "VmError":
+        return VmError("out_of nondet_blocks")
+
     @staticmethod
-    def locked_slots() -> 'VmError':
-        return VmError('out_of locked_slots')
+    def locked_slots() -> "VmError":
+        return VmError("out_of locked_slots")
+
     @staticmethod
-    def upgraders() -> 'VmError':
-        return VmError('out_of upgraders')
+    def upgraders() -> "VmError":
+        return VmError("out_of upgraders")
+
     @staticmethod
-    def fds() -> 'VmError':
-        return VmError('out_of fds')
+    def fds() -> "VmError":
+        return VmError("out_of fds")
+
     @staticmethod
-    def memory() -> '_VmErrorOutOfMemory':
+    def memory() -> "_VmErrorOutOfMemory":
         return _VmErrorOutOfMemory()
+
     @staticmethod
-    def receipt() -> '_VmErrorOutOfReceipt':
+    def receipt() -> "_VmErrorOutOfReceipt":
         return _VmErrorOutOfReceipt()
+
     @staticmethod
-    def message_fee() -> '_VmErrorOutOfMessageFee':
+    def message_fee() -> "_VmErrorOutOfMessageFee":
         return _VmErrorOutOfMessageFee()
+
 
 class _VmErrorFee:
     @staticmethod
-    def no_matching_node() -> 'VmError':
-        return VmError('fee no_matching_node')
+    def no_matching_node() -> "VmError":
+        return VmError("fee no_matching_node")
+
     @staticmethod
-    def below_minimum() -> 'VmError':
-        return VmError('fee below_minimum')
+    def below_minimum() -> "VmError":
+        return VmError("fee below_minimum")
+
     @staticmethod
-    def too_many_rounds() -> 'VmError':
-        return VmError('fee too_many_rounds')
+    def too_many_rounds() -> "VmError":
+        return VmError("fee too_many_rounds")
+
 
 class _VmErrorEvm:
     @staticmethod
-    def reverted() -> 'VmError':
-        return VmError('evm reverted')
+    def reverted() -> "VmError":
+        return VmError("evm reverted")
+
 
 class _VmErrorInvalidContractWasm:
     @staticmethod
-    def validating() -> 'VmError':
-        return VmError('invalid_contract wasm validating')
+    def validating() -> "VmError":
+        return VmError("invalid_contract wasm validating")
+
     @staticmethod
-    def linking() -> 'VmError':
-        return VmError('invalid_contract wasm linking')
+    def linking() -> "VmError":
+        return VmError("invalid_contract wasm linking")
+
     @staticmethod
-    def entrypoint() -> 'VmError':
-        return VmError('invalid_contract wasm entrypoint')
+    def entrypoint() -> "VmError":
+        return VmError("invalid_contract wasm entrypoint")
+
 
 class _VmErrorInvalidContract:
     @staticmethod
-    def val() -> 'VmError':
-        return VmError('invalid_contract')
+    def val() -> "VmError":
+        return VmError("invalid_contract")
+
     @staticmethod
-    def absent_runner_comment() -> 'VmError':
-        return VmError('invalid_contract absent_runner_comment')
+    def absent_runner_comment() -> "VmError":
+        return VmError("invalid_contract absent_runner_comment")
+
     @staticmethod
-    def not_utf8_text() -> 'VmError':
-        return VmError('invalid_contract not_utf8_text')
+    def not_utf8_text() -> "VmError":
+        return VmError("invalid_contract not_utf8_text")
+
     @staticmethod
-    def malformed_runner() -> 'VmError':
-        return VmError('invalid_contract malformed_runner')
+    def malformed_runner() -> "VmError":
+        return VmError("invalid_contract malformed_runner")
+
     @staticmethod
-    def major_mismatch() -> 'VmError':
-        return VmError('invalid_contract major_mismatch')
+    def major_mismatch() -> "VmError":
+        return VmError("invalid_contract major_mismatch")
+
     @staticmethod
-    def wasm() -> '_VmErrorInvalidContractWasm':
+    def wasm() -> "_VmErrorInvalidContractWasm":
         return _VmErrorInvalidContractWasm()
+
 
 class _VmErrorExitCode:
     @staticmethod
-    def val_i32(v: int) -> 'VmError':
-        return VmError(f'exit_code {v}')
+    def val_i32(v: int) -> "VmError":
+        return VmError(f"exit_code {v}")
+
 
 class VmError:
-    __slots__ = ('value',)
+    __slots__ = ("value",)
+
     def __init__(self, value: str):
         self.value = value
+
     def __str__(self) -> str:
         return self.value
-    @staticmethod
-    def timeout() -> 'VmError':
-        return VmError('timeout')
-    @staticmethod
-    def absent_leader_nondet_output() -> 'VmError':
-        return VmError('absent_leader_nondet_output')
-    @staticmethod
-    def host_forbidden() -> 'VmError':
-        return VmError('host_forbidden')
-    @staticmethod
-    def exit_code() -> '_VmErrorExitCode':
-        return _VmErrorExitCode()
-    @staticmethod
-    def wasm_trap() -> '_VmErrorWasmTrap':
-        return _VmErrorWasmTrap()
-    @staticmethod
-    def out_of() -> '_VmErrorOutOf':
-        return _VmErrorOutOf()
-    @staticmethod
-    def fee() -> '_VmErrorFee':
-        return _VmErrorFee()
-    @staticmethod
-    def evm() -> '_VmErrorEvm':
-        return _VmErrorEvm()
-    @staticmethod
-    def invalid_contract() -> '_VmErrorInvalidContract':
-        return _VmErrorInvalidContract()
 
+    @staticmethod
+    def timeout() -> "VmError":
+        return VmError("timeout")
+
+    @staticmethod
+    def absent_leader_nondet_output() -> "VmError":
+        return VmError("absent_leader_nondet_output")
+
+    @staticmethod
+    def host_forbidden() -> "VmError":
+        return VmError("host_forbidden")
+
+    @staticmethod
+    def exit_code() -> "_VmErrorExitCode":
+        return _VmErrorExitCode()
+
+    @staticmethod
+    def wasm_trap() -> "_VmErrorWasmTrap":
+        return _VmErrorWasmTrap()
+
+    @staticmethod
+    def out_of() -> "_VmErrorOutOf":
+        return _VmErrorOutOf()
+
+    @staticmethod
+    def fee() -> "_VmErrorFee":
+        return _VmErrorFee()
+
+    @staticmethod
+    def evm() -> "_VmErrorEvm":
+        return _VmErrorEvm()
+
+    @staticmethod
+    def invalid_contract() -> "_VmErrorInvalidContract":
+        return _VmErrorInvalidContract()
 
 
 EVENT_MAX_TOPICS: typing.Final[int] = 4

--- a/backend/protocol_rpc/endpoints.py
+++ b/backend/protocol_rpc/endpoints.py
@@ -7,7 +7,7 @@ import eth_utils
 import logging
 from contextlib import asynccontextmanager
 from functools import partial, wraps
-from typing import Any
+from typing import Any, Final, get_args
 from backend.protocol_rpc.exceptions import (
     JSONRPCError,
     NotFoundError,
@@ -66,7 +66,9 @@ from backend.database_handler.transactions_processor import (
 
 logger = logging.getLogger(__name__)
 TRANSACTION_NOT_FOUND_MESSAGE = "Transaction not found"
-from backend.node.base import Node, get_simulator_chain_id
+from backend.node.base import Node, _genvm_debug_mode, get_simulator_chain_id
+from backend.node.genvm.base import is_valid_executor_selector
+from backend.node.genvm.origin import base_host
 from backend.node.types import ExecutionMode, ExecutionResultStatus
 from backend.consensus.base import ConsensusAlgorithm
 from backend.protocol_rpc.call_interceptor import handle_consensus_data_call
@@ -1820,6 +1822,96 @@ def _fee_metadata(decoded_rollup_transaction: DecodedRollupTransaction) -> dict:
     return metadata
 
 
+# `DebugMode` is ordered least- to most-permissive, and the manager gates
+# `reroute_to` on `debug_mode >= Safe` (implementation/src/manager/run.rs).
+# Comparing positions states that rule directly instead of enumerating the
+# levels above it, which is how `safe-unbounded` -- the level studio's own run
+# path resolves to -- gets left out of a hand-written list.
+_DEBUG_MODE_ORDER: Final = get_args(base_host.DebugMode)
+_MIN_REROUTE_TO_DEBUG_MODE: Final = _DEBUG_MODE_ORDER.index("safe")
+
+
+def _genvm_executor_selector_is_present(sim_config: dict | None) -> bool:
+    """A missing key, `None`, or `""` all mean "unset" and are ignored.
+
+    Anything else -- including a non-string falsy value like `0`, `False`,
+    `[]`, or `{}` -- counts as present, so it reaches the type/grammar checks
+    below instead of silently being treated the same as "unset".
+    """
+    if not sim_config:
+        return False
+    value = sim_config.get("genvm_executor_selector")
+    if value is None:
+        return False
+    if isinstance(value, str) and not value:
+        return False
+    return True
+
+
+def _validate_genvm_executor_selector(sim_config: dict | None) -> None:
+    """`sim_config.genvm_executor_selector` pins the contract to a GenVM
+    executor version or `re:` selector.
+
+    The manager honors it only under `debug_mode >= safe` and ignores it
+    silently otherwise, so reject the transaction instead of running it on
+    an executor the caller did not ask for.
+    """
+    if not _genvm_executor_selector_is_present(sim_config):
+        return
+    genvm_executor_selector = sim_config["genvm_executor_selector"]
+    debug_mode = _genvm_debug_mode()
+    if (
+        debug_mode not in _DEBUG_MODE_ORDER
+        or _DEBUG_MODE_ORDER.index(debug_mode) < _MIN_REROUTE_TO_DEBUG_MODE
+    ):
+        raise JSONRPCError(
+            code=-32602,
+            message=(
+                "sim_config.genvm_executor_selector requires genvm debug mode "
+                "(GENVM_DEBUG_MODE)"
+            ),
+            data={"genvm_executor_selector": genvm_executor_selector},
+        )
+    # The pin is persisted on the contract and only read back much later, by
+    # `resolve_callcontract_executor` in the middle of a run. Validating it here
+    # turns an unusable pin into a rejected transaction instead of a contract
+    # that fails every call it takes part in.
+    # `fullmatch`, not `match`: `$` also matches in front of a final newline, so
+    # an anchored `match` would let `"v0.2.17\n"` through as a directory name.
+    if not isinstance(genvm_executor_selector, str) or not is_valid_executor_selector(
+        genvm_executor_selector
+    ):
+        raise JSONRPCError(
+            code=-32602,
+            message=(
+                "sim_config.genvm_executor_selector is not a valid executor "
+                "version or selector"
+            ),
+            data={"genvm_executor_selector": genvm_executor_selector},
+        )
+
+
+def _reject_genvm_executor_selector_unless_deploy(
+    sim_config: dict | None, *, is_deploy: bool
+) -> None:
+    """`sim_config.genvm_executor_selector` pins the *deployment's* executor;
+    the manager ignores it for every other transaction type. Silently
+    accepting it elsewhere would look like the pin took effect when it never
+    reached the manager at all, so reject it instead of dropping it on the
+    floor.
+    """
+    if is_deploy or not _genvm_executor_selector_is_present(sim_config):
+        return
+    raise JSONRPCError(
+        code=-32602,
+        message=(
+            "sim_config.genvm_executor_selector is only valid for contract "
+            "deployment transactions"
+        ),
+        data={"genvm_executor_selector": sim_config["genvm_executor_selector"]},
+    )
+
+
 def _validate_fee_envelope(
     decoded_rollup_transaction: DecodedRollupTransaction,
 ) -> None:
@@ -2078,6 +2170,8 @@ def send_raw_transaction(
     sim_config: dict | None = None,
 ) -> str:
     """Persist a raw transaction using a request-scoped session."""
+    _validate_genvm_executor_selector(sim_config)
+
     accounts_manager = AccountsManager(session)
     transactions_processor = TransactionsProcessor(session)
 
@@ -2111,6 +2205,7 @@ def send_raw_transaction(
         raise InvalidTransactionError("Transaction signature verification failed")
 
     if isinstance(decoded_rollup_transaction.data, DecodedsubmitAppealDataArgs):
+        _reject_genvm_executor_selector_unless_deploy(sim_config, is_deploy=False)
         return _handle_appeal_or_top_up_and_submit(
             accounts_manager=accounts_manager,
             transactions_processor=transactions_processor,
@@ -2118,6 +2213,7 @@ def send_raw_transaction(
             decoded_rollup_transaction=decoded_rollup_transaction,
         )
     elif isinstance(decoded_rollup_transaction.data, DecodedTopUpFeesDataArgs):
+        _reject_genvm_executor_selector_unless_deploy(sim_config, is_deploy=False)
         return _handle_top_up_fees(
             accounts_manager=accounts_manager,
             transactions_processor=transactions_processor,
@@ -2134,6 +2230,10 @@ def send_raw_transaction(
         total_spend = getattr(decoded_rollup_transaction, "total_spend", value)
         genlayer_transaction = transactions_parser.get_genlayer_transaction(
             decoded_rollup_transaction
+        )
+        _reject_genvm_executor_selector_unless_deploy(
+            sim_config,
+            is_deploy=genlayer_transaction.type == TransactionType.DEPLOY_CONTRACT,
         )
 
         transaction_data = {}

--- a/docker/scripts/download_genvm.sh
+++ b/docker/scripts/download_genvm.sh
@@ -176,8 +176,10 @@ if [[ -z "$EXECUTOR_BINARY" || ! -s "$EXECUTOR_BINARY" ]]; then
     error_exit "No GenVM executor binary was found after extracting $ASSET_NAME."
 fi
 
-# Studio embeds the py-genlayer hash in its intelligent contracts. Assert the
-# unique pin is present so an asset/pin mismatch fails during acquisition.
+# Studio embeds py-genlayer hashes in its intelligent contracts. Assert every
+# pin is present so an asset/pin mismatch fails during acquisition. Contracts
+# targeting an older executor line pin an older runner, which ships inside that
+# executor's legacy-runners/ tree rather than the shared runners/ tree.
 RUNNER_PINS=""
 if [[ -n "$RUNNER_PINS_FILE" ]]; then
     if [[ -f "$RUNNER_PINS_FILE" ]]; then
@@ -189,26 +191,40 @@ elif [[ -n "$REPO_ROOT" ]]; then
         | sed 's/^py-genlayer://' | sort -u || true)
 fi
 
+runner_tar_for_pin() {
+    local pin=$1 candidate
+    candidate="$INSTALL_DIR/runners/py-genlayer/${pin:0:2}/${pin:2}.tar"
+    if [[ -f "$candidate" ]]; then
+        printf '%s\n' "$candidate"
+        return 0
+    fi
+    for candidate in "$INSTALL_DIR"/executor/*/legacy-runners/py-genlayer/"${pin:0:2}"/"${pin:2}".tar; do
+        if [[ -f "$candidate" ]]; then
+            printf '%s\n' "$candidate"
+            return 0
+        fi
+    done
+    return 1
+}
+
 if [[ -n "$RUNNER_PINS_FILE" || -n "$REPO_ROOT" ]]; then
     RUNNER_PIN_COUNT=$(grep -c . <<<"$RUNNER_PINS" || true)
-    if [[ "$RUNNER_PIN_COUNT" -eq 1 ]]; then
-        RUNNER_PIN=$RUNNER_PINS
-        RUNNER_TAR="$INSTALL_DIR/runners/py-genlayer/${RUNNER_PIN:0:2}/${RUNNER_PIN:2}.tar"
-        if [[ ! -f "$RUNNER_TAR" ]]; then
-            if [[ ! -d "$INSTALL_DIR/runners" ]]; then
-                error_exit "No runners/ directory after extracting $BUNDLE_DESC at $VERSION; check the published release assets."
-            fi
-            error_exit "Pinned py-genlayer runner is missing: expected $RUNNER_TAR (pin: py-genlayer:$RUNNER_PIN)."
-        fi
-        echo "Runner pin OK: py-genlayer:$RUNNER_PIN"
-    elif [[ "$RUNNER_PIN_COUNT" -eq 0 ]]; then
+    if [[ "$RUNNER_PIN_COUNT" -eq 0 ]]; then
         # Studio always carries at least one pin, so zero means the context
         # filtering or the grep itself broke -- exactly what this assertion
         # exists to catch. Failing loudly beats silently skipping the check.
         error_exit "No py-genlayer pin found in Studio sources; the runner assertion cannot run. This usually means the pin inputs were not present in the build context."
-    else
-        echo "WARNING: expected exactly one py-genlayer pin in Studio, found $RUNNER_PIN_COUNT; skipping runner assertion."
     fi
+    if [[ ! -d "$INSTALL_DIR/runners" ]]; then
+        error_exit "No runners/ directory after extracting $BUNDLE_DESC at $VERSION; check the published release assets."
+    fi
+    while read -r RUNNER_PIN; do
+        [[ -n "$RUNNER_PIN" ]] || continue
+        if ! RUNNER_TAR=$(runner_tar_for_pin "$RUNNER_PIN"); then
+            error_exit "Pinned py-genlayer runner is missing: py-genlayer:$RUNNER_PIN (looked in $INSTALL_DIR/runners and $INSTALL_DIR/executor/*/legacy-runners)."
+        fi
+        echo "Runner pin OK: py-genlayer:$RUNNER_PIN -> ${RUNNER_TAR#"$INSTALL_DIR"/}"
+    done <<<"$RUNNER_PINS"
 fi
 
 # The executable was renamed in newer bundles. Both variants accept the same

--- a/tests/db-sqlalchemy/contract_reroute_to_test.py
+++ b/tests/db-sqlalchemy/contract_reroute_to_test.py
@@ -1,0 +1,67 @@
+"""`current_state.genvm_executor_selector` pins a contract to a GenVM
+executor version or `re:` selector.
+
+It is written once, when the deploy is registered, and every later execution
+picks it up through the contract snapshot.
+"""
+
+from sqlalchemy.orm import Session
+
+from backend.database_handler.contract_processor import ContractProcessor
+from backend.database_handler.contract_snapshot import ContractSnapshot
+from backend.database_handler.models import CurrentState
+
+
+def _empty_state() -> dict:
+    return {"state": {"accepted": {}, "finalized": {}}}
+
+
+def test_register_contract_persists_reroute_to(session: Session):
+    address = "0xreroute"
+    session.add(CurrentState(id=address, data={}))
+    session.commit()
+
+    ContractProcessor(session).register_contract(
+        {"id": address, "data": _empty_state(), "genvm_executor_selector": "v0.2.17"}
+    )
+
+    assert ContractSnapshot(address, session).genvm_executor_selector == "v0.2.17"
+
+
+def test_register_contract_without_reroute_to(session: Session):
+    address = "0xnoreroute"
+    session.add(CurrentState(id=address, data={}))
+    session.commit()
+
+    ContractProcessor(session).register_contract(
+        {"id": address, "data": _empty_state(), "genvm_executor_selector": None}
+    )
+
+    assert ContractSnapshot(address, session).genvm_executor_selector is None
+
+
+def test_reroute_to_survives_state_updates(session: Session):
+    address = "0xrerouteupdate"
+    session.add(
+        CurrentState(id=address, data=_empty_state(), genvm_executor_selector="v0.2.17")
+    )
+    session.commit()
+
+    ContractProcessor(session).update_contract_state(
+        address, accepted_state={"aaa": "bbb"}
+    )
+
+    assert ContractSnapshot(address, session).genvm_executor_selector == "v0.2.17"
+
+
+def test_snapshot_round_trip_keeps_reroute_to(session: Session):
+    address = "0xreroutesnapshot"
+    session.add(
+        CurrentState(id=address, data=_empty_state(), genvm_executor_selector="v0.2.17")
+    )
+    session.commit()
+
+    snapshot = ContractSnapshot(address, session)
+    restored = ContractSnapshot.from_dict(snapshot.to_dict())
+
+    assert restored.genvm_executor_selector == "v0.2.17"

--- a/tests/db-sqlalchemy/reroute_to_migration_backfill_test.py
+++ b/tests/db-sqlalchemy/reroute_to_migration_backfill_test.py
@@ -1,0 +1,149 @@
+"""Migration `c1d2e3f4a5b6` backfills the legacy executor selector for
+pre-existing contracts (later renamed to `genvm_executor_selector` by
+`d2e3f4a5b6c7`).
+
+Studios being upgraded from before multi-version GenVM support only ever had
+a single line (v0.2.x) to deploy against. A plain `ADD COLUMN reroute_to`
+would leave every already-deployed contract unpinned, which means "resolve
+from the manifest" (the current/latest line) -- silently moving contracts
+onto an executor they were never deployed or tested against. The migration
+must instead backfill a legacy selector onto genuine contract rows, while
+leaving EOAs (and any row that already carries an explicit pin) untouched.
+"""
+
+import asyncio
+import os
+
+from alembic import command
+from sqlalchemy import Engine, text
+from sqlalchemy.orm import Session
+
+import backend.node.genvm.origin.calldata as gvm_calldata
+from backend.database_handler.contract_snapshot import ContractSnapshot
+from backend.node.genvm.base import Host, is_valid_executor_selector
+from backend.node.genvm.origin.public_abi import StorageType
+from backend.node.types import Address
+
+from conftest import _alembic_config
+
+PRE_REROUTE_REVISION = "d0e1f2a3b4c5"
+LEGACY_EXECUTOR_SELECTOR = r"re:^v0\.2\."
+
+
+class _SingleContractStateProxy:
+    """Minimal `StateProxy` stand-in: answers `genvm_executor_selector_for`
+    for one address, the way `Host.resolve_callcontract_executor` reads it
+    mid-run."""
+
+    def __init__(self, address: str, genvm_executor_selector: str | None):
+        self._address = address.lower()
+        self._genvm_executor_selector = genvm_executor_selector
+
+    def genvm_executor_selector_for(self, addr: Address) -> str | None:
+        if addr.as_hex.lower() != self._address:
+            return None
+        return self._genvm_executor_selector
+
+
+def test_migration_backfills_legacy_selector_for_pre_existing_contracts(
+    migrated_engine: Engine,
+):
+    cfg = _alembic_config(os.environ["POSTGRES_URL"])
+    contract_address = "0x" + "11" * 20
+    pinned_contract_address = "0x" + "22" * 20
+    eoa_address = "0x" + "33" * 20
+
+    try:
+        # Roll back to just before the column existed at all, so `head` has to
+        # both add it and rename it -- matching a real Studio's pre-upgrade
+        # schema all the way through both migrations.
+        command.downgrade(cfg, PRE_REROUTE_REVISION)
+
+        with migrated_engine.connect() as conn:
+            # A genuine deployed contract: `data->'state'` present.
+            conn.execute(
+                text(
+                    "INSERT INTO current_state (id, data, balance) "
+                    "VALUES (:id, CAST(:data AS jsonb), 0)"
+                ),
+                {
+                    "id": contract_address,
+                    "data": '{"state": {"accepted": {}, "finalized": {}}}',
+                },
+            )
+            # An EOA: `data = '{}'`, must not be touched by the backfill.
+            conn.execute(
+                text(
+                    "INSERT INTO current_state (id, data, balance) "
+                    "VALUES (:id, CAST(:data AS jsonb), 0)"
+                ),
+                {"id": eoa_address, "data": "{}"},
+            )
+            conn.commit()
+
+        command.upgrade(cfg, "head")
+
+        # A contract that already had an explicit pin set some other way,
+        # after the column exists: the backfill must not clobber it.
+        with migrated_engine.connect() as conn:
+            conn.execute(
+                text(
+                    "INSERT INTO current_state "
+                    "(id, data, balance, genvm_executor_selector) "
+                    "VALUES (:id, CAST(:data AS jsonb), 0, :selector)"
+                ),
+                {
+                    "id": pinned_contract_address,
+                    "data": '{"state": {"accepted": {}, "finalized": {}}}',
+                    "selector": "v0.9.0",
+                },
+            )
+            conn.commit()
+
+        with migrated_engine.connect() as conn:
+            rows = dict(
+                conn.execute(
+                    text(
+                        "SELECT id, genvm_executor_selector FROM current_state "
+                        "WHERE id IN (:c, :e, :p)"
+                    ),
+                    {
+                        "c": contract_address,
+                        "e": eoa_address,
+                        "p": pinned_contract_address,
+                    },
+                ).all()
+            )
+
+        assert rows[contract_address] == LEGACY_EXECUTOR_SELECTOR
+        assert rows[eoa_address] is None
+        assert rows[pinned_contract_address] == "v0.9.0"
+
+        # The backfilled value must be usable end-to-end for a cross-version
+        # call, not merely present in the column: it has to pass the same
+        # selector grammar submit-time validation enforces, load back through
+        # `ContractSnapshot`, and let `resolve_callcontract_executor` answer a
+        # caller on another line with a routable selector instead of raising.
+        assert is_valid_executor_selector(LEGACY_EXECUTOR_SELECTOR)
+
+        with Session(migrated_engine) as session:
+            snapshot = ContractSnapshot(contract_address, session)
+        assert snapshot.genvm_executor_selector == LEGACY_EXECUTOR_SELECTOR
+
+        host = Host.__new__(Host)
+        host._state_proxy = _SingleContractStateProxy(
+            contract_address, snapshot.genvm_executor_selector
+        )
+        resolved = asyncio.run(
+            host.resolve_callcontract_executor(
+                Address(contract_address), StorageType.DEFAULT, 6
+            )
+        )
+        assert gvm_calldata.decode(resolved) == {
+            "kind": "version",
+            "version": LEGACY_EXECUTOR_SELECTOR,
+        }
+    finally:
+        with migrated_engine.connect() as conn:
+            conn.execute(text("TRUNCATE TABLE current_state RESTART IDENTITY CASCADE"))
+            conn.commit()

--- a/tests/integration/gltest_compat.py
+++ b/tests/integration/gltest_compat.py
@@ -29,7 +29,20 @@ def _is_genlayer_contract_base(base: ast.expr) -> bool:
 def search_path_by_class_name(contracts_dir: Path, contract_name: str) -> Path:
     """Search for a file by class name in the contracts directory."""
     matching_files = []
-    exclude_dirs = {".venv", "venv", "env", "build", "dist", "__pycache__", ".git"}
+    # `node_modules` holds third-party files this parser has no business
+    # reading: the documented `--contracts-dir .` walks the whole repo, and a
+    # single stray Python 2 script in there fails the run. CI never hits it
+    # because it does not install frontend deps.
+    exclude_dirs = {
+        ".venv",
+        "venv",
+        "env",
+        "build",
+        "dist",
+        "__pycache__",
+        ".git",
+        "node_modules",
+    }
 
     for file_path in contracts_dir.rglob("*"):
         if any(exclude_dir in file_path.parts for exclude_dir in exclude_dirs):

--- a/tests/integration/test_deploy_reroute_to.py
+++ b/tests/integration/test_deploy_reroute_to.py
@@ -1,0 +1,394 @@
+"""Integration test for the studio-only `sim_config.genvm_executor_selector`
+deploy parameter.
+
+`genvm_executor_selector` pins a contract to a specific GenVM executor version
+directory. It is applied to the deployment execution itself and stored on the
+contract row, so every later execution of that contract keeps using that
+executor.
+
+The test deploys two contracts that talk to each other:
+
+- contract A: current SDK / current executor (no reroute)
+- contract B: legacy SDK (pinned py-genlayer runner), deployed with
+  `genvm_executor_selector=v0.2.17` — it cannot run on the current executor at
+  all, so every successful step below is evidence that the override was
+  applied
+
+Both get each other's address, then each sends a message to the other. The
+cross-contract calls happen in *triggered* transactions, which carry no
+sim_config of their own — they only work if B's `genvm_executor_selector` was
+persisted to the DB at deploy time and reused on later executions.
+
+Run with containers up:
+    .venv/bin/pytest tests/integration/test_deploy_reroute_to.py -xvs
+"""
+
+import os
+import time
+
+import pytest
+import requests
+from genlayer_py import create_account, create_client, localnet
+from genlayer_py.abi import calldata
+from genlayer_py.abi.transactions import serialize
+from genlayer_py.contracts.actions import (
+    _encode_add_transaction_data,
+    _prepare_transaction,
+)
+from genlayer_py.contracts.utils import make_calldata_object
+from genlayer_py.types.transactions import TransactionHashVariant
+from web3.constants import ADDRESS_ZERO
+
+RPC_URL = "http://localhost:4000/api"
+
+# Executor version directory contract B is pinned to. Must exist under the
+# GenVM manager's executors path in the image under test.
+LEGACY_EXECUTOR = os.environ.get("TEST_REROUTE_EXECUTOR", "v0.2.17")
+
+# Executor version directory of the *current* line. Pinning a contract to it is
+# a no-op for how that contract runs on its own, but it gives the resolve hook
+# something to answer with when a caller on another line asks where this
+# contract lives.
+#
+# Hardcoded because the test has no way to ask for it, not because pinning it
+# here is desirable. The manager knows the answer --
+# `$GENVMROOT/data/manifest.yaml` lists `executor_versions` -- but it serves no
+# route that reads the manifest back (`/manifest/reload` only reloads it), and
+# `/contract/detect-version` answers with a `specified_major`, which is 0 for
+# every 0.x line and so cannot name a directory. Until something exposes it,
+# this constant has to be updated whenever the image's current line moves;
+# override the env var when it does.
+CURRENT_EXECUTOR = os.environ.get("TEST_CURRENT_EXECUTOR", "v0.3.0-rc7")
+
+# Shares the validator registry with the other integration suites, which wipe
+# validators while seeding mock responses.
+pytestmark = pytest.mark.xdist_group(name="mock_validators")
+
+
+# Current SDK, current executor.
+CONTRACT_A = """# v0.3.0
+# { "Depends": "py-genlayer:9b8kjyda2ycxyq4ea6g4yfpnydxhd52gqba5rb8dw7krkh5mn9p0" }
+
+import genlayer as gl
+from genlayer.types import *
+
+
+class RerouteModernPeer(gl.contract.Contract):
+    storage: str
+    peer: str
+
+    def __init__(self, initial_storage: str):
+        self.storage = initial_storage
+        self.peer = ""
+
+    @gl.public.view
+    def get_storage(self) -> str:
+        return self.storage
+
+    @gl.public.view
+    def get_peer(self) -> str:
+        return self.peer
+
+    @gl.public.write
+    def set_peer(self, peer: str) -> None:
+        self.peer = peer
+
+    @gl.public.write
+    def update_storage(self, new_storage: str) -> None:
+        self.storage = new_storage
+
+    @gl.public.write
+    def ping_peer(self, new_storage: str) -> None:
+        gl.contract.get_at(Address(self.peer)).emit().update_storage(new_storage)
+
+    @gl.public.view
+    def read_peer_storage(self) -> str:
+        # Synchronous cross-contract call from the current executor into a
+        # contract pinned to the legacy one. The manager runs the callee in a
+        # nested executor of its own, which it only knows to do because the
+        # host answers `resolve_callcontract_executor` for a callee that
+        # carries a `reroute_to`.
+        return gl.contract.get_at(Address(self.peer)).view().get_storage()
+"""
+
+# Legacy SDK, pinned runner — only runs on the legacy executor.
+CONTRACT_B = """# v0.2.16
+# { "Depends": "py-genlayer:1jb45aa8ynh2a9c9xn3b7qqh8sm5q93hwfp7jqmwsfhh8jpz09h6" }
+
+from genlayer import *
+
+
+class RerouteLegacyPeer(gl.Contract):
+    storage: str
+    peer: str
+
+    def __init__(self, initial_storage: str):
+        self.storage = initial_storage
+        self.peer = ""
+
+    @gl.public.view
+    def get_storage(self) -> str:
+        return self.storage
+
+    @gl.public.view
+    def get_peer(self) -> str:
+        return self.peer
+
+    @gl.public.write
+    def set_peer(self, peer: str) -> None:
+        self.peer = peer
+
+    @gl.public.write
+    def update_storage(self, new_storage: str) -> None:
+        self.storage = new_storage
+
+    @gl.public.write
+    def ping_peer(self, new_storage: str) -> None:
+        gl.get_contract_at(Address(self.peer)).emit().update_storage(new_storage)
+
+    @gl.public.view
+    def read_peer_storage(self) -> str:
+        # Synchronous cross-contract call from the legacy executor into a
+        # contract running on the current one.
+        return gl.get_contract_at(Address(self.peer)).view().get_storage()
+"""
+
+
+CLIENT = create_client(chain=localnet, endpoint=RPC_URL)
+ACCOUNT = create_account()
+CLIENT.local_account = ACCOUNT
+
+
+def rpc_call(method: str, params):
+    response = requests.post(
+        RPC_URL,
+        json={"jsonrpc": "2.0", "method": method, "params": params, "id": 1},
+        timeout=30,
+    )
+    result = response.json()
+    if "error" in result:
+        raise AssertionError(f"RPC error on {method}: {result['error']}")
+    return result.get("result")
+
+
+@pytest.fixture(scope="module", autouse=True)
+def ensure_validators_exist():
+    """Other integration suites delete all validators in teardown."""
+    validators = rpc_call("sim_getAllValidators", [])
+    if not validators:
+        provider = os.environ.get("TEST_PROVIDER", "openai")
+        model = os.environ.get("TEST_PROVIDER_MODEL", "gpt-4o")
+        rpc_call("sim_createRandomValidators", [5, 8, 12, [provider], [model]])
+    yield
+
+
+def _wait_for_tx(tx_hash: str, timeout: int = 240) -> dict:
+    """Wait until the transaction is finalized (triggered messages are only
+    emitted on finalization, which is what `emit()` defaults to)."""
+    start = time.time()
+    last = None
+    while time.time() - start < timeout:
+        tx = rpc_call("eth_getTransactionByHash", [tx_hash])
+        last = tx and tx.get("status")
+        if last == "FINALIZED":
+            return tx
+        if last in ("CANCELED", "UNDETERMINED", "LEADER_TIMEOUT", "VALIDATORS_TIMEOUT"):
+            raise AssertionError(f"Transaction {tx_hash} ended as {last}: {tx}")
+        time.sleep(2)
+    raise TimeoutError(
+        f"Transaction {tx_hash} not finalized in {timeout}s (last: {last})"
+    )
+
+
+def _deploy(code: str, args: list, reroute_to: str | None = None) -> str:
+    """Deploy a contract, optionally pinning its executor version.
+
+    genlayer-py sends `eth_sendRawTransaction` positionally and has no way to
+    attach `sim_config`, so the signed transaction is built here and sent with
+    named params instead.
+    """
+    data = serialize(
+        [
+            code,
+            calldata.encode(make_calldata_object(method=None, args=args, kwargs=None)),
+            False,  # leader_only
+        ]
+    )
+    encoded_data = _encode_add_transaction_data(
+        self=CLIENT,
+        sender_account=ACCOUNT,
+        recipient=ADDRESS_ZERO,
+        consensus_max_rotations=CLIENT.chain.default_consensus_max_rotations,
+        data=data,
+    )
+    transaction = _prepare_transaction(
+        self=CLIENT,
+        sender=ACCOUNT.address,
+        recipient=CLIENT.chain.consensus_main_contract["address"],
+        data=encoded_data,
+    )
+    signed = ACCOUNT.sign_transaction(transaction)
+
+    params = {"signed_rollup_transaction": CLIENT.w3.to_hex(signed.raw_transaction)}
+    if reroute_to is not None:
+        params["sim_config"] = {"genvm_executor_selector": reroute_to}
+
+    tx_hash = rpc_call("eth_sendRawTransaction", params)
+    tx = _wait_for_tx(tx_hash)
+    address = tx.get("contract_address") or tx.get("to_address")
+    assert address and address != ADDRESS_ZERO, f"no contract address in {tx}"
+    return address
+
+
+def _write(address: str, method: str, args: list) -> dict:
+    tx_hash = CLIENT.write_contract(address=address, function_name=method, args=args)
+    return _wait_for_tx(tx_hash)
+
+
+def _read(address: str, method: str, final: bool = True) -> str:
+    return CLIENT.read_contract(
+        address=address,
+        function_name=method,
+        args=[],
+        transaction_hash_variant=(
+            TransactionHashVariant.LATEST_FINAL
+            if final
+            else TransactionHashVariant.LATEST_NONFINAL
+        ),
+    )
+
+
+def _wait_for_storage(address: str, expected: str, timeout: int = 240) -> None:
+    """Triggered transactions are separate transactions; poll until the
+    message they carry has been applied."""
+    start = time.time()
+    last = None
+    while time.time() - start < timeout:
+        last = _read(address, "get_storage", final=False)
+        if last == expected:
+            return
+        time.sleep(2)
+    raise AssertionError(
+        f"Contract {address} storage is {last!r}, expected {expected!r}"
+    )
+
+
+@pytest.fixture(scope="module")
+def peers() -> tuple[str, str]:
+    """Deploy both contracts once and introduce them to each other.
+
+    A runs on the current executor, B on the legacy one — B's deployment
+    execution itself already requires the reroute to be honored, and the
+    `set_peer` write on B is a plain user transaction with no sim_config, so
+    it relies on the value persisted to the contract row.
+    """
+    address_a = _deploy(CONTRACT_A, args=["a_initial"])
+    address_b = _deploy(CONTRACT_B, args=["b_initial"], reroute_to=LEGACY_EXECUTOR)
+
+    assert _read(address_a, "get_storage") == "a_initial"
+    # Reading B works only if the stored `reroute_to` is reused after deploy.
+    assert _read(address_b, "get_storage") == "b_initial"
+
+    _write(address_a, "set_peer", [address_b])
+    _write(address_b, "set_peer", [address_a])
+    assert _read(address_a, "get_peer") == address_b
+    assert _read(address_b, "get_peer") == address_a
+
+    return address_a, address_b
+
+
+def test_message_from_current_to_legacy_executor(peers):
+    """v0.3 -> v0.2 message: the triggered transaction runs on the legacy
+    executor, which it can only pick up from the persisted `reroute_to`."""
+    address_a, address_b = peers
+
+    _write(address_a, "ping_peer", ["from_a"])
+    _wait_for_storage(address_b, "from_a")
+
+
+def test_message_from_legacy_to_current_executor(peers):
+    """v0.2 -> v0.3 message: the triggered transaction runs on the current
+    executor, because the target contract has no override."""
+    address_a, address_b = peers
+
+    _write(address_b, "ping_peer", ["from_b"])
+    _wait_for_storage(address_a, "from_b")
+
+
+def test_call_from_current_to_legacy_executor(peers):
+    """v0.3 -> v0.2 synchronous call (read): the cross-major path.
+
+    The caller's executor asks the host which executor the callee runs on, the
+    host answers with the major derived from the callee's persisted
+    `reroute_to`, and the manager runs the callee in a nested v0.2.17 executor
+    that dials the same host listener. Without any part of that the call would
+    fail the way the reverse direction below does.
+    """
+    address_a, address_b = peers
+
+    # Read B directly first: earlier tests in this module write to it through
+    # messages, so the only stable expectation is "whatever B actually holds".
+    expected = _read(address_b, "get_storage")
+    peer_storage = _read(address_a, "read_peer_storage", final=False)
+
+    assert peer_storage == expected
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason=(
+        "v0.2 -> v0.3 synchronous call to an *unpinned* callee. The limit is "
+        "ours, not the legacy executor's: v0.2.17 does issue "
+        "RESOLVE_CALLCONTRACT_EXECUTOR (confirmed in the host call counts), but "
+        "`Host.resolve_callcontract_executor` answers only for a callee that "
+        "carries a `reroute_to` and returns None for anything else. So the "
+        "answer here is 'stay in-process', the v0.2.17 executor loads A's v0.3 "
+        "code itself, and rejects it with `invalid_contract "
+        "absent_runner_comment`. Pinning A makes the same direction work -- see "
+        "test_call_from_legacy_to_pinned_current_executor below. Messages cross "
+        "either way, being separate transactions run by the target's own "
+        "executor."
+    ),
+)
+def test_call_from_legacy_to_current_executor(peers):
+    """v0.2 -> v0.3 synchronous call (read), as opposed to a message."""
+    _address_a, address_b = peers
+
+    peer_storage = _read(address_b, "read_peer_storage", final=False)
+
+    assert peer_storage is not None
+    assert peer_storage != ""
+
+
+@pytest.fixture(scope="module")
+def pinned_peers() -> tuple[str, str]:
+    """The same pair, except A is pinned to the current executor explicitly.
+
+    The pin changes nothing about how A runs — it is already on that line. It
+    changes what the *host* can say about A: `resolve_callcontract_executor`
+    answers from the callee's stored `reroute_to`, so an unpinned A leaves it
+    with nothing to answer and the caller keeps the callee in-process.
+    """
+    address_a = _deploy(CONTRACT_A, args=["a_pinned"], reroute_to=CURRENT_EXECUTOR)
+    address_b = _deploy(CONTRACT_B, args=["b_pinned"], reroute_to=LEGACY_EXECUTOR)
+
+    _write(address_a, "set_peer", [address_b])
+    _write(address_b, "set_peer", [address_a])
+
+    return address_a, address_b
+
+
+def test_call_from_legacy_to_pinned_current_executor(pinned_peers):
+    """v0.2 -> v0.3 synchronous call, with the callee pinned: this one works.
+
+    Same direction as the xfail above, and the same legacy caller. The only
+    difference is that A carries a `reroute_to`, so the host has something to
+    answer the caller's resolve query with instead of None, and the manager
+    runs A in a nested current-line executor rather than letting v0.2.17 try
+    to parse a v0.3 contract.
+    """
+    _address_a, address_b = pinned_peers
+
+    peer_storage = _read(address_b, "read_peer_storage", final=False)
+
+    assert peer_storage == "a_pinned"

--- a/tests/unit/consensus/test_contract_reroute_to.py
+++ b/tests/unit/consensus/test_contract_reroute_to.py
@@ -1,0 +1,57 @@
+"""The studio-only `sim_config.genvm_executor_selector` deploy parameter must
+reach the freshly created snapshot of the contract being deployed, and
+nothing else.
+"""
+
+from backend.consensus.base import (
+    contract_snapshot_factory,
+    transaction_genvm_executor_selector,
+)
+from backend.domain.types import (
+    SimConfig,
+    Transaction,
+    TransactionStatus,
+    TransactionType,
+)
+
+
+CONTRACT_ADDRESS = "0xcontract"
+
+
+def _deploy_transaction(sim_config: SimConfig | None) -> Transaction:
+    return Transaction(
+        hash="0xabc",
+        status=TransactionStatus.PENDING,
+        type=TransactionType.DEPLOY_CONTRACT,
+        from_address="0xsender",
+        to_address=CONTRACT_ADDRESS,
+        data={"contract_code": "contract code"},
+        value=0,
+        sim_config=sim_config,
+    )
+
+
+def test_transaction_reroute_to_without_sim_config():
+    assert transaction_genvm_executor_selector(_deploy_transaction(None)) is None
+
+
+def test_transaction_reroute_to_from_sim_config():
+    transaction = _deploy_transaction(
+        SimConfig(validators=[], genvm_executor_selector="v0.2.17"),
+    )
+    assert transaction_genvm_executor_selector(transaction) == "v0.2.17"
+
+
+def test_deploy_snapshot_carries_reroute_to():
+    transaction = _deploy_transaction(
+        SimConfig(validators=[], genvm_executor_selector="v0.2.17"),
+    )
+    snapshot = contract_snapshot_factory(CONTRACT_ADDRESS, None, transaction)
+    assert snapshot.genvm_executor_selector == "v0.2.17"
+
+
+def test_deploy_snapshot_without_reroute_to():
+    snapshot = contract_snapshot_factory(
+        CONTRACT_ADDRESS, None, _deploy_transaction(None)
+    )
+    assert snapshot.genvm_executor_selector is None

--- a/tests/unit/consensus/test_decisions_accepted.py
+++ b/tests/unit/consensus/test_decisions_accepted.py
@@ -202,6 +202,18 @@ class TestDecideAcceptedDeploy:
         pre, _, _, _ = decide_accepted(**self._deploy_kwargs())
         assert _find_effect(pre, UpdateContractStateEffect) is None
 
+    def test_registers_contract_without_reroute_by_default(self):
+        pre, _, _, _ = decide_accepted(**self._deploy_kwargs())
+        e = _find_effect(pre, RegisterContractEffect)
+        assert e.contract_data["genvm_executor_selector"] is None
+
+    def test_registers_contract_with_reroute_to(self):
+        pre, _, _, _ = decide_accepted(
+            **self._deploy_kwargs(genvm_executor_selector="v0.2.17")
+        )
+        e = _find_effect(pre, RegisterContractEffect)
+        assert e.contract_data["genvm_executor_selector"] == "v0.2.17"
+
 
 class TestDecideAcceptedRunContract:
     """Normal acceptance path for run-contract (non-deploy) transactions."""

--- a/tests/unit/test_consumed_result_decode.py
+++ b/tests/unit/test_consumed_result_decode.py
@@ -1,0 +1,79 @@
+"""`ConsumedResult.decode`: turning a manager-reported `consumed_result` blob
+into a `ConsumedResult`.
+
+`None`, empty bytes, and malformed bytes are three different situations and
+must not be conflated: `None` means the manager never reported a result;
+empty bytes means it reported one with nothing in it; malformed bytes is a
+protocol violation, not a result value at all, so it raises rather than
+quietly turning into an `internal_error(...)` result the caller could mistake
+for a real (if unhappy) execution outcome.
+"""
+
+import pytest
+
+import backend.node.genvm.origin.calldata as gvm_calldata
+from backend.node.genvm.origin import public_abi
+from backend.node.genvm.origin.base_host import (
+    ConsumedResult,
+    ConsumedResultDecodeError,
+)
+
+
+def _encode_valid(result_kind: public_abi.ResultCode, data: dict) -> bytes:
+    return bytes([int(result_kind)]) + gvm_calldata.encode(data)
+
+
+def test_decode_none_is_an_internal_error_result():
+    result = ConsumedResult.decode(None)
+    assert result.result_kind == public_abi.ResultCode.INTERNAL_ERROR
+    assert result.result_data == "no_result"
+
+
+def test_decode_empty_bytes_is_an_internal_error_result():
+    result = ConsumedResult.decode(b"")
+    assert result.result_kind == public_abi.ResultCode.INTERNAL_ERROR
+    assert result.result_data == "empty_result"
+
+
+def test_decode_valid_bytes_round_trips():
+    raw = _encode_valid(public_abi.ResultCode.RETURN, {"execution_hash": b"\x01\x02"})
+    result = ConsumedResult.decode(raw)
+    assert result.result_kind == public_abi.ResultCode.RETURN
+    assert result.execution_hash == b"\x01\x02"
+
+
+def test_decode_not_a_mapping_is_an_internal_error_result():
+    raw = bytes([int(public_abi.ResultCode.RETURN)]) + gvm_calldata.encode([1, 2, 3])
+    result = ConsumedResult.decode(raw)
+    assert result.result_kind == public_abi.ResultCode.INTERNAL_ERROR
+    assert result.result_data == "result is not a mapping"
+
+
+def test_decode_truncated_calldata_raises_a_protocol_error():
+    # A ResultCode byte with no calldata payload behind it at all.
+    with pytest.raises(ConsumedResultDecodeError):
+        ConsumedResult.decode(bytes([int(public_abi.ResultCode.RETURN)]))
+
+
+def test_decode_invalid_result_code_raises_a_protocol_error():
+    raw = bytes([255]) + gvm_calldata.encode({})
+    with pytest.raises(ConsumedResultDecodeError):
+        ConsumedResult.decode(raw)
+
+
+def test_decode_a_non_bytes_shaped_value_raises_a_protocol_error():
+    # `bytes(raw)` itself can fail (e.g. a string, or an int outside 0-255 in
+    # a list) before there is even a ResultCode byte to look at.
+    with pytest.raises(ConsumedResultDecodeError):
+        ConsumedResult.decode("not bytes")
+    with pytest.raises(ConsumedResultDecodeError):
+        ConsumedResult.decode([1, 2, 999])
+
+
+def test_decode_protocol_error_never_returns_an_internal_error_result():
+    # Malformed bytes must not silently look like a legitimate (if unhappy)
+    # execution outcome -- the caller has to be able to tell "the genvm ran
+    # and failed" apart from "we can't tell what the genvm reported".
+    with pytest.raises(ConsumedResultDecodeError) as exc_info:
+        ConsumedResult.decode(bytes([int(public_abi.ResultCode.RETURN)]))
+    assert not isinstance(exc_info.value, ConsumedResult)

--- a/tests/unit/test_consumed_result_decode.py
+++ b/tests/unit/test_consumed_result_decode.py
@@ -9,6 +9,8 @@ quietly turning into an `internal_error(...)` result the caller could mistake
 for a real (if unhappy) execution outcome.
 """
 
+import base64
+
 import pytest
 
 import backend.node.genvm.origin.calldata as gvm_calldata
@@ -61,9 +63,17 @@ def test_decode_invalid_result_code_raises_a_protocol_error():
         ConsumedResult.decode(raw)
 
 
+def test_decode_base64_string_round_trips():
+    # The socket reports bytes, the deprecated http shim reports base64.
+    raw = _encode_valid(public_abi.ResultCode.RETURN, {"execution_hash": b"\x01\x02"})
+    result = ConsumedResult.decode(base64.b64encode(raw).decode())
+    assert result.result_kind == public_abi.ResultCode.RETURN
+    assert result.execution_hash == b"\x01\x02"
+
+
 def test_decode_a_non_bytes_shaped_value_raises_a_protocol_error():
-    # `bytes(raw)` itself can fail (e.g. a string, or an int outside 0-255 in
-    # a list) before there is even a ResultCode byte to look at.
+    # Reading `raw` can fail (a string that is not base64, or an int outside
+    # 0-255 in a list) before there is even a ResultCode byte to look at.
     with pytest.raises(ConsumedResultDecodeError):
         ConsumedResult.decode("not bytes")
     with pytest.raises(ConsumedResultDecodeError):

--- a/tests/unit/test_genvm_initial_time_units.py
+++ b/tests/unit/test_genvm_initial_time_units.py
@@ -1,3 +1,5 @@
+import math
+
 import pytest
 
 from backend.node.genvm.origin import base_host
@@ -29,10 +31,7 @@ class _Ctx:
     def add_stat(self, _key, _value):
         pass
 
-    def get_timeout(self, _action, _timeout_type):
-        return None
-
-    def retry_delay(self, _action, _attempt_no):
+    def get_manager_connect_timeout(self):
         return None
 
 
@@ -40,46 +39,47 @@ class _Handler:
     pass
 
 
+class _FakeManagerClient:
+    """Captures the run payload and aborts before any real manager round-trip."""
+
+    def __init__(self):
+        self.payloads = []
+
+    async def run(self, payload):
+        self.payloads.append(payload)
+        raise RuntimeError("stop before manager request")
+
+
 @pytest.mark.asyncio
 @pytest.mark.parametrize("timeout", [None, 3.25, 1200])
-async def test_run_genvm_uses_fixed_initial_time_units_allocation(
+async def test_run_genvm_scales_initial_time_units_allocation(
     monkeypatch,
-    timeout,
+    timeout,  # noqa: ASYNC109 - pytest parametrize value, not a real timeout arg
 ):
-    captured_payloads = []
-
     async def fake_host_loop(_handler, cancellation, *, ctx):
         await cancellation.wait()
 
-    async def fake_await_first_cancel_others(*_awaitables):
-        for awaitable in _awaitables:
-            close = getattr(awaitable, "close", None)
-            if close is not None:
-                close()
-
-    def capture_payload(payload):
-        captured_payloads.append(payload)
-        raise RuntimeError("stop before manager request")
-
     monkeypatch.setattr(base_host, "host_loop", fake_host_loop)
-    monkeypatch.setattr(
-        base_host,
-        "_await_first_cancel_others",
-        fake_await_first_cancel_others,
-    )
-    monkeypatch.setattr(base_host.gvm_calldata, "encode", capture_payload)
 
-    with pytest.raises(Exception, match="genvm execution failed"):
+    client = _FakeManagerClient()
+    # run_genvm wraps a failed RUN in ManagerRunNotStarted (chaining the cause).
+    with pytest.raises(
+        base_host.ManagerRunNotStarted, match="stop before manager request"
+    ):
         await base_host.run_genvm(
             _Handler(),
             timeout=timeout,
+            manager_client=client,
             ctx=_Ctx(),
             is_sync=False,
-            message={},
+            message={"is_init": True},
             host="unix://test",
             calldata=b"",
+            bucket_totals=[10_000_000, 10_000_000, 10_000_000, 10_000_000],
         )
 
-    assert captured_payloads[0]["initial_time_units_allocation"] == (
-        base_host.DEFAULT_INITIAL_TIME_UNITS_ALLOCATION
+    # Upstream now scales the allocation with the run timeout (ceil), falling
+    # back to the 10-minute default when no timeout is given.
+    assert client.payloads[0]["initial_time_units_allocation"] == (
+        math.ceil(timeout or 10 * 60)
     )

--- a/tests/unit/test_genvm_retry_integration.py
+++ b/tests/unit/test_genvm_retry_integration.py
@@ -6,35 +6,13 @@ Note: Tests that import worker_service need to run in Docker (require fastapi).
 Those are in test_worker_health_degradation.py
 """
 
-from unittest.mock import patch
+import functools
+from unittest.mock import AsyncMock, patch
 import pytest
 
 import backend.node.genvm.base as base_host
 from backend.node.genvm.origin import base_host as origin_base_host
-
-
-class MockAsyncContextManager:
-    """Helper for mocking async context managers."""
-
-    def __init__(self, response):
-        self.response = response
-
-    async def __aenter__(self):
-        return self.response
-
-    async def __aexit__(self, *args):
-        pass
-
-
-class MockResponse:
-    """Helper for mocking aiohttp responses."""
-
-    def __init__(self, status, body):
-        self.status = status
-        self.body = body
-
-    async def json(self):
-        return self.body
+from backend.node.genvm.origin import manager_api
 
 
 class NoopLogger:
@@ -79,32 +57,128 @@ class NoopHandler:
     pass
 
 
-def _consumed_return_result():
-    return list(
-        bytes([origin_base_host.public_abi.ResultCode.RETURN])
-        + origin_base_host.gvm_calldata.encode(
-            {
-                "execution_hash": b"",
-                "data": b"ok",
-                "fingerprint": None,
-                "storage_changes": [],
-                "emissions": [],
-                "nondet_results": [],
-                "data_fees_remaining": [],
-            }
-        )
-    )
-
-
 async def _fake_host_loop(_handler, _cancellation, *, ctx):
     return None
 
 
-async def _fake_prob_died_wait(*awaitables):
-    for awaitable in awaitables:
-        close = getattr(awaitable, "close", None)
-        if close is not None:
-            close()
+class _RunRejectingManagerClient:
+    """A manager client whose RUN is rejected with a given socket error, so
+    run_genvm exercises its not-started classification without a real manager."""
+
+    def __init__(self, error: origin_base_host.ManagerSocketError):
+        self._error = error
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *_args):
+        return False
+
+    async def run(self, _payload):
+        raise self._error
+
+
+class _ArtifactFailingManagerClient:
+    """Reports a finished run, then fails to hand back one of its artifacts."""
+
+    class _State:
+        boot_id = 1
+        genvm_id = 42
+
+    def __init__(self):
+        self.ack_called = False
+        self.cancel_called = False
+
+    async def run(self, _payload):
+        return self._State()
+
+    async def wait_terminal(self, _state):
+        return {
+            "finished": {
+                "artifact_sizes": {"stdout": 5},
+                "consumed_result": None,
+            }
+        }
+
+    async def get_artifact(self, _boot_id, _genvm_id, _field):
+        raise RuntimeError("artifact transfer failed")
+
+    async def ack(self, _boot_id, _genvm_id):
+        self.ack_called = True
+
+    async def cancel(self, _boot_id, _genvm_id):
+        self.cancel_called = True
+
+
+class _FailedToStartManagerClient:
+    """Accepts the RUN, then reports a failed_to_start terminal so run_genvm
+    exercises the terminal-based not-started classification."""
+
+    class _State:
+        boot_id = 1
+        genvm_id = 1
+
+    def __init__(self, error: str):
+        self._error = error
+
+    async def run(self, _payload):
+        return self._State()
+
+    async def wait_terminal(self, _state):
+        return {"failed_to_start": {"error": self._error}}
+
+    async def ack(self, _boot_id, _genvm_id):
+        pass
+
+
+class _FakeManagerClientCM:
+    """Async-context stand-in so run_genvm_host does not open a real websocket
+    when base_host.run_genvm is mocked."""
+
+    def __init__(self, *_args, **_kwargs):
+        pass
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *_args):
+        return False
+
+
+class _DummyStateProxy(base_host.StateProxy):
+    def __init__(self):
+        self.snapshot_factory = lambda _addr: None
+
+    def storage_read(self, account, slot, index, le, /) -> bytes:
+        return b"\x00" * le
+
+    def get_balance(self, addr) -> int:
+        return 0
+
+
+class _ReturningHost:
+    def __init__(self, _sock_listener, **_kwargs):
+        self.sock = None
+
+    def bind_context(self, _ctx):
+        pass
+
+    async def close_connections(self):
+        pass
+
+    def provide_result(self, _res, state, _ctx=None):
+        return base_host.ExecutionResult(
+            result=base_host.ExecutionReturn(ret=b"\x00"),
+            eq_outputs={},
+            pending_transactions=[],
+            stdout="",
+            stderr="",
+            genvm_log=[],
+            state=state,
+            processing_time=0,
+            nondet_disagree=None,
+            execution_stats={},
+        )
 
 
 class TestRetryBehavior:
@@ -210,112 +284,299 @@ class TestRetryBehavior:
             "modules are required but not all are running",
         ],
     )
-    async def test_modules_not_running_500_is_retried_and_can_succeed(
-        self, monkeypatch, manager_error
-    ):
-        """Transient manager module restart 500 retries /genvm/run."""
+    async def test_transient_run_refusal_is_retryable(self, monkeypatch, manager_error):
+        """A modules-not-running RUN rejection surfaces as a retryable
+        ManagerRunNotStarted, classified inside base_host (no caller string
+        matching)."""
         ctx = RecordingCtx()
-        post_bodies = [
-            {"error": manager_error},
-            {"id": "genvm-1"},
-        ]
-        post_attempts = 0
-
-        def fake_request(method, url, **_kwargs):
-            nonlocal post_attempts
-            if method == "POST" and url.endswith("/genvm/run"):
-                body = post_bodies[post_attempts]
-                status = 500 if post_attempts == 0 else 200
-                post_attempts += 1
-                return MockAsyncContextManager(MockResponse(status, body))
-            if method == "DELETE":
-                return MockAsyncContextManager(MockResponse(200, {}))
-            if method == "GET" and url.endswith("/genvm/genvm-1"):
-                return MockAsyncContextManager(
-                    MockResponse(
-                        200,
-                        {
-                            "status": {
-                                "consumed_result": _consumed_return_result(),
-                                "stdout": "",
-                                "stderr": "",
-                                "genvm_log": [],
-                            }
-                        },
-                    )
-                )
-            raise AssertionError(f"unexpected request: {method} {url}")
-
         monkeypatch.setattr(origin_base_host, "host_loop", _fake_host_loop)
-        monkeypatch.setattr(
-            origin_base_host, "_await_first_cancel_others", _fake_prob_died_wait
-        )
-        monkeypatch.setattr(origin_base_host.aiohttp, "request", fake_request)
-
-        result = await origin_base_host.run_genvm(
-            NoopHandler(),
-            ctx=ctx,
-            is_sync=False,
-            message={},
-            host="unix://test",
-            calldata=b"",
+        client = _RunRejectingManagerClient(
+            origin_base_host.ManagerSocketError(
+                manager_api.Errors.INTERNAL, manager_error
+            )
         )
 
-        assert post_attempts == 2
-        assert result.result_data == b"ok"
-        assert ctx.successes == 1
-        assert ctx.failures == 0
-        assert ctx.stats["manager_run_attempt_0_error"]["will_retry"] is True
-        assert (
-            ctx.stats["manager_run_attempt_0_error"]["error_type"]
-            == "GenVMManagerRetryableError"
-        )
-        assert (
-            ctx.stats["manager_run_attempt_0_error"]["retry_reason"]
-            == "manager_modules_not_running"
-        )
-        assert ctx.stats["manager_run_attempt_success"]["attempt"] == 1
-
-    @pytest.mark.asyncio
-    async def test_other_500_is_not_retried(self, monkeypatch):
-        """Non-transient manager 500s still fail fast."""
-        ctx = RecordingCtx()
-        post_attempts = 0
-
-        def fake_request(method, url, **_kwargs):
-            nonlocal post_attempts
-            if method == "POST" and url.endswith("/genvm/run"):
-                post_attempts += 1
-                return MockAsyncContextManager(
-                    MockResponse(
-                        500,
-                        {
-                            "error": "unknown variant `foo`, expected one of `bar`, `baz`"
-                        },
-                    )
-                )
-            raise AssertionError(f"unexpected request: {method} {url}")
-
-        monkeypatch.setattr(origin_base_host, "host_loop", _fake_host_loop)
-        monkeypatch.setattr(
-            origin_base_host, "_await_first_cancel_others", _fake_prob_died_wait
-        )
-        monkeypatch.setattr(origin_base_host.aiohttp, "request", fake_request)
-
-        with pytest.raises(Exception, match="genvm execution failed"):
+        with pytest.raises(origin_base_host.ManagerRunNotStarted) as exc_info:
             await origin_base_host.run_genvm(
                 NoopHandler(),
+                manager_client=client,
                 ctx=ctx,
                 is_sync=False,
-                message={},
+                message={"is_init": True},
                 host="unix://test",
                 calldata=b"",
+                bucket_totals=[10_000_000, 10_000_000, 10_000_000, 10_000_000],
             )
 
-        assert post_attempts == 1
-        assert ctx.successes == 0
-        assert ctx.failures == 0
-        assert ctx.stats["manager_run_attempt_0_error"]["outcome"] == "fatal_error"
+        assert exc_info.value.retryable is True
+        assert exc_info.value.reason == "manager_modules_not_running"
+        assert ctx.failures == 1
+        assert ctx.stats["manager_run_attempt_0_error"]["retryable"] is True
+        assert (
+            ctx.stats["manager_run_attempt_0_error"]["reason"]
+            == "manager_modules_not_running"
+        )
+
+    @pytest.mark.asyncio
+    async def test_unknown_run_refusal_is_not_retryable(self, monkeypatch):
+        """An unrecognised RUN rejection is a permanent ManagerRunNotStarted."""
+        ctx = RecordingCtx()
+        monkeypatch.setattr(origin_base_host, "host_loop", _fake_host_loop)
+        client = _RunRejectingManagerClient(
+            origin_base_host.ManagerSocketError(
+                manager_api.Errors.INTERNAL,
+                "unknown variant `foo`, expected one of `bar`, `baz`",
+            )
+        )
+
+        with pytest.raises(origin_base_host.ManagerRunNotStarted) as exc_info:
+            await origin_base_host.run_genvm(
+                NoopHandler(),
+                manager_client=client,
+                ctx=ctx,
+                is_sync=False,
+                message={"is_init": True},
+                host="unix://test",
+                calldata=b"",
+                bucket_totals=[10_000_000, 10_000_000, 10_000_000, 10_000_000],
+            )
+
+        assert exc_info.value.retryable is False
+        assert exc_info.value.reason == "manager_refused"
+        assert ctx.stats["manager_run_attempt_0_error"]["retryable"] is False
+
+    @pytest.mark.asyncio
+    async def test_run_genvm_raises_terminal_result_unavailable_on_artifact_failure(
+        self, monkeypatch
+    ):
+        """A finished run whose artifact retrieval fails must surface as
+        `TerminalResultUnavailable`, not a plain exception -- the run already
+        executed, so the caller must not mistake this for an attempt that
+        never happened and retry it."""
+        monkeypatch.setattr(origin_base_host, "host_loop", _fake_host_loop)
+        client = _ArtifactFailingManagerClient()
+        ctx = RecordingCtx()
+
+        with pytest.raises(origin_base_host.TerminalResultUnavailable) as exc_info:
+            await origin_base_host.run_genvm(
+                NoopHandler(),
+                manager_client=client,
+                ctx=ctx,
+                is_sync=False,
+                message={"is_init": True},
+                host="unix://test",
+                calldata=b"",
+                bucket_totals=[10_000_000, 10_000_000, 10_000_000, 10_000_000],
+            )
+
+        assert exc_info.value.genvm_id == 42
+        # Releasing the manager's retention of the finished run must still
+        # happen -- only its result is unavailable, not the run itself.
+        assert client.ack_called
+        assert not client.cancel_called
+
+    @pytest.mark.asyncio
+    async def test_run_genvm_host_retries_retryable_not_started(self):
+        """run_genvm_host retries a retryable ManagerRunNotStarted and succeeds,
+        with no transport knowledge of its own."""
+        state = _DummyStateProxy()
+        host_supplier = functools.partial(
+            _ReturningHost,
+            state_proxy=state,
+            calldata_bytes=b"",
+            leader_results=None,
+        )
+        transient = origin_base_host.ManagerRunNotStarted(
+            "modules are required but not running",
+            retryable=True,
+            reason="manager_modules_not_running",
+        )
+
+        with patch(
+            "backend.node.genvm.base.base_host.run_genvm",
+            new_callable=AsyncMock,
+            side_effect=[transient, object()],
+        ) as run_mock, patch(
+            "backend.node.genvm.base.base_host.ManagerClient",
+            _FakeManagerClientCM,
+        ), patch(
+            "backend.node.genvm.base.asyncio.sleep",
+            new_callable=AsyncMock,
+            return_value=None,
+        ):
+            result = await base_host.run_genvm_host(
+                host_supplier,
+                timeout=15,
+                is_sync=False,
+                message={"is_init": True},
+                capture_output=False,
+            )
+
+        assert run_mock.await_count == 2
+        assert isinstance(result.result, base_host.ExecutionReturn)
+
+    @pytest.mark.asyncio
+    async def test_run_genvm_host_fails_fast_on_permanent_not_started(self):
+        """A non-retryable ManagerRunNotStarted is raised immediately, not
+        retried until the deadline."""
+        state = _DummyStateProxy()
+        host_supplier = functools.partial(
+            _ReturningHost,
+            state_proxy=state,
+            calldata_bytes=b"",
+            leader_results=None,
+        )
+        permanent = origin_base_host.ManagerRunNotStarted(
+            "unknown variant `foo`",
+            retryable=False,
+            reason="manager_refused",
+        )
+
+        with patch(
+            "backend.node.genvm.base.base_host.run_genvm",
+            new_callable=AsyncMock,
+            side_effect=[permanent, object()],
+        ) as run_mock, patch(
+            "backend.node.genvm.base.base_host.ManagerClient",
+            _FakeManagerClientCM,
+        ), patch(
+            "backend.node.genvm.base.asyncio.sleep",
+            new_callable=AsyncMock,
+            return_value=None,
+        ):
+            with pytest.raises(origin_base_host.ManagerRunNotStarted) as exc_info:
+                await base_host.run_genvm_host(
+                    host_supplier,
+                    timeout=15,
+                    is_sync=False,
+                    message={"is_init": True},
+                    capture_output=False,
+                )
+
+        assert exc_info.value.retryable is False
+        assert run_mock.await_count == 1
+
+    @pytest.mark.asyncio
+    async def test_run_genvm_host_does_not_start_a_second_run_after_terminal_result_unavailable(
+        self,
+    ):
+        """`TerminalResultUnavailable` must propagate immediately, never fall
+        into the generic retry branch that would start a brand new run for a
+        genvm that already executed and finished."""
+        state = _DummyStateProxy()
+        host_supplier = functools.partial(
+            _ReturningHost,
+            state_proxy=state,
+            calldata_bytes=b"",
+            leader_results=None,
+        )
+        failure = origin_base_host.TerminalResultUnavailable(
+            "failed to retrieve/decode result for finished run: boom",
+            genvm_id=42,
+        )
+
+        with patch(
+            "backend.node.genvm.base.base_host.run_genvm",
+            new_callable=AsyncMock,
+            side_effect=[failure, object()],
+        ) as run_mock, patch(
+            "backend.node.genvm.base.base_host.ManagerClient",
+            _FakeManagerClientCM,
+        ), patch(
+            "backend.node.genvm.base.asyncio.sleep",
+            new_callable=AsyncMock,
+            return_value=None,
+        ):
+            with pytest.raises(origin_base_host.TerminalResultUnavailable):
+                await base_host.run_genvm_host(
+                    host_supplier,
+                    timeout=15,
+                    is_sync=False,
+                    message={"is_init": True},
+                    capture_output=False,
+                )
+
+        # Only the one, already-consumed attempt -- no second call to
+        # `run_genvm` that would start a new genvm execution.
+        assert run_mock.await_count == 1
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "error,expected_retryable,expected_reason",
+        [
+            (
+                "modules are required but not running",
+                True,
+                "manager_modules_not_running",
+            ),
+            ("absent runner for py-genlayer", False, "manager_refused"),
+        ],
+    )
+    async def test_failed_to_start_terminal_is_classified(
+        self, monkeypatch, error, expected_retryable, expected_reason
+    ):
+        """A failed_to_start terminal surfaces as ManagerRunNotStarted (not an
+        INTERNAL_ERROR result) and counts as a manager failure."""
+        ctx = RecordingCtx()
+        monkeypatch.setattr(origin_base_host, "host_loop", _fake_host_loop)
+
+        with pytest.raises(origin_base_host.ManagerRunNotStarted) as exc_info:
+            await origin_base_host.run_genvm(
+                NoopHandler(),
+                manager_client=_FailedToStartManagerClient(error),
+                ctx=ctx,
+                is_sync=False,
+                message={"is_init": True},
+                host="unix://test",
+                calldata=b"",
+                bucket_totals=[10_000_000, 10_000_000, 10_000_000, 10_000_000],
+            )
+
+        assert exc_info.value.retryable is expected_retryable
+        assert exc_info.value.reason == expected_reason
+        # The RUN was accepted (success), then failed to start (failure).
+        assert ctx.failures == 1
+        assert ctx.stats["manager_run_start_failed"]["retryable"] is expected_retryable
+
+    @pytest.mark.asyncio
+    async def test_run_genvm_host_retryable_exhausts_timeout_budget(self):
+        """A persistently retryable ManagerRunNotStarted stops at the deadline
+        (timeout result) instead of looping forever or raising."""
+        state = _DummyStateProxy()
+        host_supplier = functools.partial(
+            _ReturningHost,
+            state_proxy=state,
+            calldata_bytes=b"",
+            leader_results=None,
+        )
+        transient = origin_base_host.ManagerRunNotStarted(
+            "modules are required but not running",
+            retryable=True,
+            reason="manager_modules_not_running",
+        )
+
+        # A short real deadline (no sleep mock): the first backoff is clamped to
+        # the remaining budget, so the next top-of-loop check exits via timeout.
+        with patch(
+            "backend.node.genvm.base.base_host.run_genvm",
+            new_callable=AsyncMock,
+            side_effect=transient,
+        ) as run_mock, patch(
+            "backend.node.genvm.base.base_host.ManagerClient",
+            _FakeManagerClientCM,
+        ):
+            result = await base_host.run_genvm_host(
+                host_supplier,
+                timeout=0.3,
+                is_sync=False,
+                message={"is_init": True},
+                capture_output=False,
+            )
+
+        assert result is not None
+        assert run_mock.await_count >= 1
+        # It exhausted the budget rather than propagating the exception.
+        assert isinstance(result.result, base_host.ExecutionError)
 
 
 class TestRetryConfiguration:

--- a/tests/unit/test_host_loop_fuel_widths.py
+++ b/tests/unit/test_host_loop_fuel_widths.py
@@ -54,16 +54,15 @@ async def test_consume_fuel_reads_32_byte_little_endian_u256():
     try:
         gas = (1 << 100) + 7
         client.sendall(
-            bytes([host_fns.Methods.CONSUME_FUEL])
-            + gas.to_bytes(32, "little")
-            + bytes([host_fns.Methods.NOTIFY_FINISHED])
+            bytes([host_fns.Methods.CONSUME_FUEL]) + gas.to_bytes(32, "little")
         )
+        # CONSUME_FUEL sends no reply; EOF ends the loop after it is consumed.
+        client.shutdown(socket.SHUT_WR)
 
         handler = FuelHandler(server, remaining_fuel=12345)
         await base_host.host_loop(handler, asyncio.Event(), ctx=RecordingCtx())
 
         assert handler.consumed_gas == [gas]
-        assert await _recv_exact(client, 1) == b"\x00"
     finally:
         client.close()
         server.close()
@@ -76,22 +75,14 @@ async def test_remaining_fuel_as_gen_replies_with_32_byte_little_endian_u256():
     client.setblocking(False)
     try:
         remaining_fuel = 12345
-        client.sendall(
-            bytes(
-                [
-                    host_fns.Methods.REMAINING_FUEL_AS_GEN,
-                    host_fns.Methods.NOTIFY_FINISHED,
-                ]
-            )
-        )
+        client.sendall(bytes([host_fns.Methods.REMAINING_FUEL_AS_GEN]))
+        client.shutdown(socket.SHUT_WR)
 
         handler = FuelHandler(server, remaining_fuel=remaining_fuel)
         await base_host.host_loop(handler, asyncio.Event(), ctx=RecordingCtx())
 
-        assert await _recv_exact(client, 34) == (
-            bytes([host_fns.Errors.OK])
-            + remaining_fuel.to_bytes(32, "little")
-            + b"\x00"
+        assert await _recv_exact(client, 33) == (
+            bytes([host_fns.Errors.OK]) + remaining_fuel.to_bytes(32, "little")
         )
     finally:
         client.close()

--- a/tests/unit/test_host_nested_connections.py
+++ b/tests/unit/test_host_nested_connections.py
@@ -1,0 +1,234 @@
+"""A cross-major run dials the host listener once per executor.
+
+The genvm reroutes a nested call to another major by starting a second executor,
+and that executor connects to the same unix socket the top-level run uses. The
+host therefore has to keep accepting after `loop_enter` handed the first
+connection to the protocol loop, and it has to serve every later connection with
+the same handler state.
+"""
+
+import asyncio
+import contextlib
+import functools
+import socket
+import tempfile
+from pathlib import Path
+
+import pytest
+
+import backend.node.genvm.base as genvm_base
+import backend.node.genvm.origin.base_host as genvmhost
+from backend.node.genvm.base import Context, Host
+
+
+class _FakeStateProxy:
+    def storage_read(self, _addr, _slot, _index, le):  # pragma: no cover - unused
+        return b"\x00" * le
+
+
+def _host(sock_listener: socket.socket) -> tuple[Host, Context]:
+    host = Host(
+        sock_listener,
+        calldata_bytes=b"",
+        state_proxy=_FakeStateProxy(),
+        leader_results=None,
+    )
+    ctx = Context()
+    host.bind_context(ctx)
+    return host, ctx
+
+
+async def _connect(path: Path) -> socket.socket:
+    sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    sock.setblocking(False)
+    await asyncio.get_event_loop().sock_connect(sock, str(path))
+    return sock
+
+
+@pytest.mark.asyncio
+async def test_later_connections_are_served_with_the_same_handler(monkeypatch):
+    served: list[tuple[object, socket.socket, object]] = []
+
+    async def fake_host_loop_on(handler, sock, *, ctx):
+        served.append((handler, sock, ctx))
+        await asyncio.Event().wait()
+
+    monkeypatch.setattr(genvmhost, "host_loop_on", fake_host_loop_on)
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        path = Path(tmpdir) / "sock"
+        with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as sock_listener:
+            sock_listener.setblocking(False)
+            sock_listener.bind(str(path))
+            sock_listener.listen(8)
+
+            host, ctx = _host(sock_listener)
+            cancellation = asyncio.Event()
+
+            first = await _connect(path)
+            accepted = await host.loop_enter(cancellation)
+            assert accepted is host.sock
+
+            nested = await _connect(path)
+            for _ in range(100):
+                if served:
+                    break
+                await asyncio.sleep(0.01)
+
+            # The nested executor's connection is served; the top-level one is
+            # not, because `run_genvm` drives it through `host_loop` itself.
+            assert len(served) == 1
+            served_handler, served_sock, served_ctx = served[0]
+            # Nested calls read and write the state of the run they belong to,
+            # so they are served by that run's handler, not a fresh one.
+            assert served_handler is host
+            assert served_ctx is ctx
+            assert served_sock is not accepted
+
+            cancellation.set()
+            await host.close_connections()
+            first.close()
+            nested.close()
+
+    assert host.sock is None
+
+
+@pytest.mark.asyncio
+async def test_accepting_stops_when_the_run_ends():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        path = Path(tmpdir) / "sock"
+        with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as sock_listener:
+            sock_listener.setblocking(False)
+            sock_listener.bind(str(path))
+            sock_listener.listen(8)
+
+            host, _ctx = _host(sock_listener)
+            cancellation = asyncio.Event()
+
+            first = await _connect(path)
+            await host.loop_enter(cancellation)
+            accept_task = host._accept_task
+            assert accept_task is not None
+
+            cancellation.set()
+            await asyncio.wait_for(accept_task, timeout=5)
+            assert not accept_task.cancelled()
+
+            await host.close_connections()
+            first.close()
+
+
+@pytest.mark.asyncio
+async def test_loop_enter_reports_a_run_that_never_connected():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        path = Path(tmpdir) / "sock"
+        with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as sock_listener:
+            sock_listener.setblocking(False)
+            sock_listener.bind(str(path))
+            sock_listener.listen(8)
+
+            host, _ctx = _host(sock_listener)
+            cancellation = asyncio.Event()
+            cancellation.set()
+
+            with pytest.raises(Exception, match="Program failed"):
+                await host.loop_enter(cancellation)
+            assert host._accept_task is None
+
+
+@pytest.mark.asyncio
+async def test_close_connections_times_out_on_a_task_that_ignores_cancellation(
+    monkeypatch,
+):
+    # Cancellation only requests a CancelledError at the task's next await
+    # point; a task that keeps swallowing it (e.g. stuck outside the event
+    # loop, or shielded) must not be able to hang shutdown forever.
+    monkeypatch.setattr(genvm_base, "_CLOSE_CONNECTIONS_TIMEOUT_S", 0.05)
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        path = Path(tmpdir) / "sock"
+        with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as sock_listener:
+            sock_listener.setblocking(False)
+            sock_listener.bind(str(path))
+            sock_listener.listen(8)
+
+            host, ctx = _host(sock_listener)
+
+            async def _uncancellable():
+                while True:
+                    with contextlib.suppress(asyncio.CancelledError):
+                        await asyncio.sleep(10)
+
+            stuck_task = asyncio.create_task(_uncancellable())
+            host._connection_tasks.append(stuck_task)
+
+            await asyncio.wait_for(host.close_connections(), timeout=5)
+
+            assert host.sock is None
+            stuck_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await stuck_task
+
+
+class _NoopManagerClient:
+    def __init__(self, *_args, **_kwargs):
+        pass
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *_args):
+        return False
+
+
+class _AttemptRecordingHost:
+    """Records its teardown into the shared event log."""
+
+    events: list[str] = []
+
+    def __init__(self, _sock_listener, **_kwargs):
+        self.sock = None
+
+    def bind_context(self, _ctx):
+        pass
+
+    async def close_connections(self):
+        self.events.append("closed")
+
+
+@pytest.mark.asyncio
+async def test_a_failed_attempt_is_torn_down_before_the_backoff(monkeypatch):
+    """Cleanup belongs before the sleep, not after it.
+
+    A failed attempt's listener and its nested connection tasks stay live for
+    as long as the backoff runs if teardown waits for the `finally` that
+    follows the sleep -- so a dead attempt would keep serving executors with a
+    state proxy the next attempt is about to replace.
+    """
+    events = _AttemptRecordingHost.events
+    events.clear()
+
+    async def fake_run_genvm(_handler, **_kwargs):
+        events.append("attempt")
+        raise RuntimeError("attempt failed")
+
+    async def fake_sleep(_delay):
+        events.append("backoff")
+
+    monkeypatch.setattr(genvmhost, "run_genvm", fake_run_genvm)
+    monkeypatch.setattr(genvmhost, "ManagerClient", _NoopManagerClient)
+    monkeypatch.setattr(asyncio, "sleep", fake_sleep)
+
+    await genvm_base.run_genvm_host(
+        functools.partial(
+            _AttemptRecordingHost,
+            state_proxy=_FakeStateProxy(),
+            calldata_bytes=b"",
+            leader_results=None,
+        ),
+        timeout=0.1,
+        is_sync=False,
+        message={"is_init": True},
+    )
+
+    assert events.index("closed") < events.index("backoff")

--- a/tests/unit/test_manager_client_lifecycle.py
+++ b/tests/unit/test_manager_client_lifecycle.py
@@ -1,0 +1,225 @@
+"""Connection lifecycle of `ManagerClient`, and what a failed `ack` may cost.
+
+Every other test of the manager seam substitutes a fake client, so the real
+connect/reconnect code and the finally-block cleanup around a finished run are
+only exercised here.
+"""
+
+import asyncio
+
+import pytest
+
+from backend.node.genvm.origin import base_host
+from backend.node.genvm.origin import manager_api
+
+
+class _FakeWs:
+    def __init__(self):
+        self.closed = False
+
+
+class _CountingClient(base_host.ManagerClient):
+    """Records how many connect/close sections overlap.
+
+    `_close()` and `_connect()` rebuild `_ws`, `_session` and `_reader_task`
+    together, so two of them running at once leave a half-built connection
+    behind whichever one finishes last.
+    """
+
+    def __init__(self):
+        super().__init__("http://127.0.0.1:0")
+        self.in_flight = 0
+        self.max_in_flight = 0
+        self.connects = 0
+
+    async def _enter(self):
+        self.in_flight += 1
+        self.max_in_flight = max(self.max_in_flight, self.in_flight)
+        # Yields, so a caller that is not excluded by a lock gets in here.
+        await asyncio.sleep(0)
+
+    async def _connect(self):
+        await self._enter()
+        self._ws = _FakeWs()
+        self._generation += 1
+        self.connects += 1
+        self.in_flight -= 1
+
+    async def _close(self):
+        await self._enter()
+        self._ws = None
+        self.in_flight -= 1
+
+
+@pytest.mark.asyncio
+async def test_concurrent_reconnect_paths_do_not_overlap():
+    client = _CountingClient()
+    client._generation = 1
+
+    # The two entry points a lost connection wakes up at once: a request-side
+    # `_ensure_connected` and a waiter reacting to the disconnect event.
+    await asyncio.gather(
+        client._ensure_connected(),
+        client._reconnect_live_runs(1),
+    )
+
+    assert client.max_in_flight == 1, "connect/close sections overlapped"
+    assert client.connects == 1, "the live connection was torn down and rebuilt"
+
+
+@pytest.mark.asyncio
+async def test_ensure_connected_reuses_a_live_connection():
+    client = _CountingClient()
+    await client._ensure_connected()
+    await client._ensure_connected()
+    assert client.connects == 1
+
+
+class _WireCallRecordingClient(base_host.ManagerClient):
+    """Records whether a request actually reached the wire, so a guard that
+    refuses before sending can be told apart from one that sends and fails."""
+
+    def __init__(self, boot_id: int):
+        super().__init__("http://127.0.0.1:0")
+        self.boot_id = boot_id
+        self.requests_sent = 0
+
+    async def _request(self, method, _payload, *, retry_on_disconnect):
+        self.requests_sent += 1
+        if method == manager_api.Methods.GET_ARTIFACT:
+            return {"data": b"", "total_len": 0}
+        return {}
+
+
+@pytest.mark.asyncio
+async def test_cancel_refuses_a_stale_boot_id_without_touching_the_wire():
+    # The manager restarted (client reconnected under a new boot_id) since
+    # this genvm_id was handed out. Sending CANCEL with only the genvm_id
+    # could hit a same-numbered but unrelated run on the new process.
+    client = _WireCallRecordingClient(boot_id=2)
+    with pytest.raises(base_host.ManagerRunLost):
+        await client.cancel(1, 7)
+    assert client.requests_sent == 0
+
+
+@pytest.mark.asyncio
+async def test_ack_refuses_a_stale_boot_id_without_touching_the_wire():
+    client = _WireCallRecordingClient(boot_id=2)
+    with pytest.raises(base_host.ManagerRunLost):
+        await client.ack(1, 7)
+    assert client.requests_sent == 0
+
+
+@pytest.mark.asyncio
+async def test_get_artifact_refuses_a_stale_boot_id_without_touching_the_wire():
+    client = _WireCallRecordingClient(boot_id=2)
+    with pytest.raises(base_host.ManagerRunLost):
+        await client.get_artifact(1, 7, "stdout")
+    assert client.requests_sent == 0
+
+
+@pytest.mark.asyncio
+async def test_cancel_ack_get_artifact_proceed_for_the_current_boot_id():
+    client = _WireCallRecordingClient(boot_id=1)
+    await client.cancel(1, 7)
+    await client.get_artifact(1, 7, "stdout")
+    assert client.requests_sent == 2
+    # ack also needs a `total_len`-shaped-independent response; its own
+    # request stub returns `{}`, which is fine since ack only reads the
+    # response for its side effect of succeeding.
+    await client.ack(1, 7)
+    assert client.requests_sent == 3
+
+
+class _AckFailingClient:
+    """Reports a finished run, then fails the ack that releases it."""
+
+    class _State:
+        boot_id = 1
+        genvm_id = 7
+
+    def __init__(self, error: BaseException):
+        self._error = error
+        self.acked = False
+
+    async def run(self, _payload):
+        return self._State()
+
+    async def wait_terminal(self, _state):
+        return {"finished": {"artifact_sizes": {}}}
+
+    async def ack(self, _boot_id, _genvm_id):
+        self.acked = True
+        raise self._error
+
+    async def cancel(self, _boot_id, _genvm_id):
+        pass
+
+
+class _NoopHandler:
+    async def get_contract_major(self, *_args, **_kwargs):
+        return 0
+
+
+class _RecordingCtx:
+    class _Logger:
+        def __getattr__(self, _name):
+            return lambda *args, **kwargs: None
+
+    logger = _Logger()
+
+    def on_genvm_success(self):
+        pass
+
+    def on_genvm_failure(self):
+        pass
+
+    def add_stat(self, *_args, **_kwargs):
+        pass
+
+    def get_timeout(self, *_args, **_kwargs):
+        return None
+
+
+async def _run_with_ack_error(monkeypatch, error: BaseException):
+    client = _AckFailingClient(error)
+
+    async def _no_host_loop(_handler, cancellation, *, ctx):
+        # No executor connects in this test, so the loop just waits for the
+        # run to end, exactly as the real one does.
+        await cancellation.wait()
+
+    monkeypatch.setattr(base_host, "host_loop", _no_host_loop)
+    res = await base_host.run_genvm(
+        _NoopHandler(),
+        manager_client=client,
+        ctx=_RecordingCtx(),
+        is_sync=True,
+        message={},
+        host="unix:///dev/null",
+        bucket_totals=[0, 0, 0, 0],
+        calldata=b"",
+        major=0,
+    )
+    assert client.acked
+    return res
+
+
+@pytest.mark.asyncio
+async def test_ack_socket_error_does_not_discard_a_finished_run(monkeypatch):
+    # ack only releases the manager's retention of a run whose result is
+    # already in hand; failing it must not turn that into an attempt error
+    # that the retry loop answers by executing the contract again.
+    res = await _run_with_ack_error(
+        monkeypatch,
+        base_host.ManagerSocketError(manager_api.Errors.INTERNAL, "boom"),
+    )
+    assert res.result_kind is not None
+
+
+@pytest.mark.asyncio
+async def test_ack_connection_loss_does_not_discard_a_finished_run(monkeypatch):
+    res = await _run_with_ack_error(
+        monkeypatch, base_host.ManagerConnectionLost("socket died")
+    )
+    assert res.result_kind is not None

--- a/tests/unit/test_reroute_to_debug_mode.py
+++ b/tests/unit/test_reroute_to_debug_mode.py
@@ -1,0 +1,166 @@
+"""`genvm_executor_selector` is only honored by the genvm manager under
+`debug_mode >= safe`.
+
+Below that the manager ignores it *silently* and runs the manifest-resolved
+executor instead, so both the RPC entry point and the run path refuse the
+request rather than executing on the wrong executor.
+"""
+
+import asyncio
+
+import pytest
+
+from backend.node.genvm.base import run_genvm_host
+from backend.protocol_rpc.endpoints import (
+    _reject_genvm_executor_selector_unless_deploy,
+    _validate_genvm_executor_selector,
+)
+from backend.protocol_rpc.exceptions import JSONRPCError
+
+
+def _run_with(genvm_executor_selector, **kwargs):
+    return asyncio.run(
+        run_genvm_host(
+            lambda sock: None,
+            timeout=1,
+            is_sync=True,
+            message={},
+            genvm_executor_selector=genvm_executor_selector,
+            **kwargs,
+        )
+    )
+
+
+def test_run_genvm_host_rejects_reroute_to_with_debug_mode_disabled():
+    with pytest.raises(ValueError, match="requires debug_mode >= safe"):
+        _run_with("v0.2.17", debug_mode="disabled")
+
+
+def test_run_genvm_host_rejects_reroute_to_when_capture_off_implies_disabled():
+    # debug_mode unset + capture_output=False resolves to "disabled" in base_host
+    with pytest.raises(ValueError, match="requires debug_mode >= safe"):
+        _run_with("v0.2.17", capture_output=False)
+
+
+def test_validate_reroute_to_allows_missing_value(monkeypatch):
+    monkeypatch.setenv("GENVM_DEBUG_MODE", "false")
+    _validate_genvm_executor_selector(None)
+    _validate_genvm_executor_selector({})
+    _validate_genvm_executor_selector({"genvm_executor_selector": None})
+
+
+def test_validate_reroute_to_allows_value_in_debug_mode(monkeypatch):
+    monkeypatch.setenv("GENVM_DEBUG_MODE", "true")
+    _validate_genvm_executor_selector({"genvm_executor_selector": "v0.2.17"})
+
+
+def test_validate_reroute_to_rejects_value_without_debug_mode(monkeypatch):
+    monkeypatch.setattr(
+        "backend.protocol_rpc.endpoints._genvm_debug_mode", lambda: "disabled"
+    )
+    with pytest.raises(JSONRPCError) as exc:
+        _validate_genvm_executor_selector({"genvm_executor_selector": "v0.2.17"})
+    assert exc.value.code == -32602
+
+
+@pytest.mark.parametrize("mode", ["safe", "safe-unbounded", "unsafe", "unsafe-tracing"])
+def test_validate_reroute_to_allows_every_level_the_manager_honors(monkeypatch, mode):
+    # The manager gates the pin on `debug_mode >= Safe`, so every level above it
+    # must pass -- `safe-unbounded` in particular is what studio's own run path
+    # resolves to whenever output is captured.
+    monkeypatch.setattr(
+        "backend.protocol_rpc.endpoints._genvm_debug_mode", lambda: mode
+    )
+    _validate_genvm_executor_selector({"genvm_executor_selector": "v0.2.17"})
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "banana",
+        "",
+        "v",
+        "../../../etc",
+        "v0.2.17/../../elsewhere",
+        "v0.2.17 ",
+        "v0.2.17\n",
+        42,
+    ],
+)
+def test_validate_reroute_to_rejects_values_that_are_not_versions(monkeypatch, value):
+    # The pin is persisted and only read back mid-run, and the manager uses it
+    # verbatim as the executor directory name. A value that is not a version is
+    # a rejected transaction, not a contract that fails every call it takes part
+    # in and not a path below the executors root.
+    monkeypatch.setenv("GENVM_DEBUG_MODE", "true")
+    sim_config = {"genvm_executor_selector": value}
+    if not value:
+        # Falsy values mean "unpinned" and are simply ignored.
+        _validate_genvm_executor_selector(sim_config)
+        return
+    with pytest.raises(JSONRPCError) as exc:
+        _validate_genvm_executor_selector(sim_config)
+    assert exc.value.code == -32602
+
+
+@pytest.mark.parametrize("value", [0, False, [], {}])
+def test_validate_reroute_to_rejects_non_string_falsy_values(monkeypatch, value):
+    # Only a missing key, None, or "" mean "unset". A non-string falsy value
+    # like 0/False/[]/{} must not be silently treated the same way -- it has
+    # to reach the type check and get rejected.
+    monkeypatch.setenv("GENVM_DEBUG_MODE", "true")
+    with pytest.raises(JSONRPCError) as exc:
+        _validate_genvm_executor_selector({"genvm_executor_selector": value})
+    assert exc.value.code == -32602
+
+
+@pytest.mark.parametrize("value", [0, False, [], {}])
+def test_reject_reroute_to_unless_deploy_rejects_non_string_falsy_values(value):
+    with pytest.raises(JSONRPCError) as exc:
+        _reject_genvm_executor_selector_unless_deploy(
+            {"genvm_executor_selector": value}, is_deploy=False
+        )
+    assert exc.value.code == -32602
+
+
+def test_validate_reroute_to_accepts_prerelease_versions(monkeypatch):
+    monkeypatch.setenv("GENVM_DEBUG_MODE", "true")
+    _validate_genvm_executor_selector({"genvm_executor_selector": "v0.6.0-rc2"})
+
+
+def test_validate_reroute_to_accepts_a_regex_selector(monkeypatch):
+    # Same grammar the manager accepts (`re:`-prefixed pattern), and what the
+    # migration backfill writes for pre-existing v0.2 contracts.
+    monkeypatch.setenv("GENVM_DEBUG_MODE", "true")
+    _validate_genvm_executor_selector({"genvm_executor_selector": r"re:^v0\.2\."})
+
+
+def test_validate_reroute_to_rejects_an_invalid_regex_selector(monkeypatch):
+    monkeypatch.setenv("GENVM_DEBUG_MODE", "true")
+    with pytest.raises(JSONRPCError) as exc:
+        _validate_genvm_executor_selector({"genvm_executor_selector": "re:("})
+    assert exc.value.code == -32602
+
+
+def test_reject_reroute_to_unless_deploy_allows_it_on_deploy():
+    _reject_genvm_executor_selector_unless_deploy(
+        {"genvm_executor_selector": "v0.2.17"}, is_deploy=True
+    )
+
+
+def test_reject_reroute_to_unless_deploy_allows_missing_value_anywhere():
+    _reject_genvm_executor_selector_unless_deploy(None, is_deploy=False)
+    _reject_genvm_executor_selector_unless_deploy({}, is_deploy=False)
+    _reject_genvm_executor_selector_unless_deploy(
+        {"genvm_executor_selector": None}, is_deploy=False
+    )
+
+
+def test_reject_reroute_to_unless_deploy_rejects_it_on_non_deploy():
+    # Accepting it here and silently dropping it would look like the pin
+    # took effect when it never reached the manager at all.
+    with pytest.raises(JSONRPCError) as exc:
+        _reject_genvm_executor_selector_unless_deploy(
+            {"genvm_executor_selector": "v0.2.17"}, is_deploy=False
+        )
+    assert exc.value.code == -32602

--- a/tests/unit/test_resolve_callcontract_executor.py
+++ b/tests/unit/test_resolve_callcontract_executor.py
@@ -1,0 +1,95 @@
+"""Nested cross-major call routing: `Host.resolve_callcontract_executor`.
+
+A call target that is pinned to an executor version (its snapshot carries a
+`reroute_to`) answers the genvm's resolve query with that version, so the callee
+keeps running on its own line. Unpinned targets answer None.
+"""
+
+import pytest
+
+import backend.node.genvm.origin.calldata as gvm_calldata
+from backend.node.genvm.base import Host
+from backend.node.genvm.origin import base_host, host_fns
+from backend.node.genvm.origin.public_abi import StorageType
+from backend.node.types import Address
+
+
+class _FakeStateProxy:
+    def __init__(self, pins: dict[str, str | None]):
+        self._pins = pins
+
+    def storage_read(self, *_args):  # pragma: no cover - unused here
+        raise AssertionError("storage_read should not be called")
+
+    def get_balance(self, _addr):  # pragma: no cover - unused here
+        raise AssertionError("get_balance should not be called")
+
+    def genvm_executor_selector_for(self, addr: Address) -> str | None:
+        return self._pins.get(addr.as_hex.lower())
+
+
+ADDR_PINNED = Address("0x" + "11" * 20)
+ADDR_UNPINNED = Address("0x" + "22" * 20)
+
+
+def _host(pins):
+    host = Host.__new__(Host)
+    host._state_proxy = _FakeStateProxy(pins)
+    return host
+
+
+@pytest.mark.asyncio
+async def test_resolve_names_the_pinned_line_itself():
+    # Not a major: every line released so far is semver major 0, so a major
+    # would resolve to the newest line whichever one the pin meant.
+    host = _host({ADDR_PINNED.as_hex.lower(): "v0.2.17"})
+    res = await host.resolve_callcontract_executor(ADDR_PINNED, StorageType.DEFAULT, 6)
+    assert res is not None
+    assert gvm_calldata.decode(res) == {"kind": "version", "version": "v0.2.17"}
+
+
+@pytest.mark.asyncio
+async def test_resolve_returns_none_for_unpinned_target():
+    host = _host({ADDR_PINNED.as_hex.lower(): "v0.2.17"})
+    res = await host.resolve_callcontract_executor(
+        ADDR_UNPINNED, StorageType.DEFAULT, 6
+    )
+    assert res is None
+
+
+@pytest.mark.asyncio
+async def test_resolve_reports_an_unusable_stored_pin_as_a_host_error():
+    # Submit-time validation keeps these out of the database, so reaching here
+    # means a stored pin went bad. It has to come back as a host error the
+    # genvm can fail the call on: a bare exception escapes `host_loop_on`, kills
+    # the host task, and the retry loop then re-runs the contract until the
+    # transaction's time budget is gone.
+    host = _host({ADDR_PINNED.as_hex.lower(): "banana"})
+    with pytest.raises(base_host.HostException) as exc:
+        await host.resolve_callcontract_executor(ADDR_PINNED, StorageType.DEFAULT, 6)
+    assert exc.value.error_code != host_fns.Errors.OK
+
+
+@pytest.mark.asyncio
+async def test_resolve_treats_empty_pin_as_unpinned():
+    host = _host({ADDR_PINNED.as_hex.lower(): ""})
+    res = await host.resolve_callcontract_executor(ADDR_PINNED, StorageType.DEFAULT, 6)
+    assert res is None
+
+
+@pytest.mark.asyncio
+async def test_resolve_accepts_a_regex_selector():
+    # Same grammar the migration backfill writes for pre-existing v0.2
+    # contracts: a `re:`-prefixed pattern, not an exact version.
+    host = _host({ADDR_PINNED.as_hex.lower(): r"re:^v0\.2\."})
+    res = await host.resolve_callcontract_executor(ADDR_PINNED, StorageType.DEFAULT, 6)
+    assert res is not None
+    assert gvm_calldata.decode(res) == {"kind": "version", "version": r"re:^v0\.2\."}
+
+
+@pytest.mark.asyncio
+async def test_resolve_rejects_a_stored_pin_with_an_invalid_regex():
+    host = _host({ADDR_PINNED.as_hex.lower(): "re:("})
+    with pytest.raises(base_host.HostException) as exc:
+        await host.resolve_callcontract_executor(ADDR_PINNED, StorageType.DEFAULT, 6)
+    assert exc.value.error_code != host_fns.Errors.OK

--- a/tests/unit/test_run_genvm_host_state_copy.py
+++ b/tests/unit/test_run_genvm_host_state_copy.py
@@ -24,10 +24,31 @@ class _DummyStateProxy(StateProxy):
         return 0
 
 
+class _FakeManagerClient:
+    """Stands in for base_host.ManagerClient's async-context lifecycle so
+    run_genvm_host does not open a real manager websocket when run_genvm itself
+    is mocked."""
+
+    def __init__(self, *_args, **_kwargs):
+        pass
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *_args):
+        return False
+
+
 class _FakeHost:
     def __init__(self, _sock_listener, **kwargs):
         self.sock = None
         self._kwargs = kwargs
+
+    def bind_context(self, _ctx):
+        pass
+
+    async def close_connections(self):
+        pass
 
     def provide_result(self, _res, state, _ctx=None):
         return ExecutionResult(
@@ -59,6 +80,9 @@ async def test_run_genvm_host_skips_state_copy_on_first_attempt():
         new_callable=AsyncMock,
         return_value=object(),
     ) as run_mock, patch(
+        "backend.node.genvm.base.base_host.ManagerClient",
+        _FakeManagerClient,
+    ), patch(
         "backend.node.genvm.base._copy_state_proxy",
         new_callable=AsyncMock,
         side_effect=lambda s: s,
@@ -91,6 +115,9 @@ async def test_run_genvm_host_copies_state_on_retry():
         "backend.node.genvm.base.base_host.run_genvm",
         new_callable=AsyncMock,
         side_effect=[RuntimeError("boom"), object()],
+    ), patch(
+        "backend.node.genvm.base.base_host.ManagerClient",
+        _FakeManagerClient,
     ), patch(
         "backend.node.genvm.base._copy_state_proxy",
         new_callable=AsyncMock,

--- a/tests/unit/test_run_request_major.py
+++ b/tests/unit/test_run_request_major.py
@@ -1,0 +1,187 @@
+"""What the run request tells the manager about which executor to use.
+
+The manager picks an executor line from the request selector's `major`, so a
+contract deployed against an older line must keep reaching that line on every
+later call. The major lives in octet 0 of the root slot, which the host reads
+through the same state proxy the run itself uses; a deploy has nothing to read
+and declares `UNDEPLOYED_MAJOR` instead.
+
+The request also has to opt into being asked where a `CallContract` runs, which
+is what lets a pinned callee keep its own executor across a nested call.
+"""
+
+import functools
+
+import pytest
+
+import backend.node.genvm.base as genvm_base
+import backend.node.genvm.origin.base_host as base_host
+from backend.node.genvm.base import Context, Host
+from backend.node.genvm.error_codes import GenVMInternalError
+from backend.node.types import Address
+
+ADDR = Address("0x" + "11" * 20)
+
+
+class _RecordingStateProxy:
+    """Serves one root slot and records what was asked of it."""
+
+    def __init__(self, root: bytes):
+        self._root = root
+        self.reads: list[tuple[Address, bytes, int, int]] = []
+
+    def storage_read(self, account: Address, slot: bytes, index: int, le: int, /):
+        self.reads.append((account, slot, index, le))
+        return self._root[index : index + le].ljust(le, b"\x00")
+
+    def get_balance(self, _addr):  # pragma: no cover - unused here
+        raise AssertionError("get_balance should not be called")
+
+
+class _FakeManagerClient:
+    """Captures the run payload and aborts before any real manager round-trip."""
+
+    def __init__(self):
+        self.payloads = []
+
+    async def run(self, payload):
+        self.payloads.append(payload)
+        raise RuntimeError("stop before manager request")
+
+
+def _host(state_proxy) -> Host:
+    host = Host.__new__(Host)
+    host._state_proxy = state_proxy
+    return host
+
+
+async def _run(monkeypatch, host: Host, message, **kwargs) -> _FakeManagerClient:
+    """Starts a run that stops at the manager request, keeping its payload."""
+    client = _FakeManagerClient()
+
+    async def fake_host_loop(_handler, cancellation, *, ctx):
+        await cancellation.wait()
+
+    monkeypatch.setattr(base_host, "host_loop", fake_host_loop)
+
+    with pytest.raises(
+        base_host.ManagerRunNotStarted, match="stop before manager request"
+    ):
+        await base_host.run_genvm(
+            host,
+            timeout=None,
+            manager_client=client,
+            ctx=Context(),
+            is_sync=False,
+            message=message,
+            host="unix://test",
+            calldata=b"",
+            bucket_totals=[10_000_000] * 4,
+            **kwargs,
+        )
+    assert len(client.payloads) == 1
+    return client
+
+
+@pytest.mark.asyncio
+async def test_call_declares_the_deployed_major(monkeypatch):
+    state = _RecordingStateProxy(bytes([2]))
+    client = await _run(
+        monkeypatch, _host(state), {"is_init": False, "contract_address": ADDR}
+    )
+
+    assert client.payloads[0]["selector"] == {"kind": "major", "major": 2}
+    assert state.reads == [(ADDR, b"\x00" * 32, 0, 1)]
+
+
+@pytest.mark.asyncio
+async def test_deploy_declares_the_undeployed_major(monkeypatch):
+    state = _RecordingStateProxy(bytes([2]))
+    client = await _run(
+        monkeypatch, _host(state), {"is_init": True, "contract_address": ADDR}
+    )
+
+    assert client.payloads[0]["selector"] == {
+        "kind": "major",
+        "major": base_host.UNDEPLOYED_MAJOR,
+    }
+    # A deploy has no prior state to read a major out of.
+    assert state.reads == []
+
+
+@pytest.mark.asyncio
+async def test_an_explicit_major_skips_the_storage_read(monkeypatch):
+    state = _RecordingStateProxy(bytes([2]))
+    client = await _run(
+        monkeypatch,
+        _host(state),
+        {"is_init": False, "contract_address": ADDR},
+        major=6,
+    )
+
+    assert client.payloads[0]["selector"] == {"kind": "major", "major": 6}
+    assert state.reads == []
+
+
+class _NoopHost:
+    """Stands in for the real host: `run_genvm` never gets to use it here."""
+
+    def __init__(self, _sock_listener, **_kwargs):
+        self.sock = None
+
+    def bind_context(self, _ctx):
+        pass
+
+    async def close_connections(self):
+        pass
+
+
+class _NoopManagerClient:
+    def __init__(self, *_args, **_kwargs):
+        pass
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *_args):
+        return False
+
+
+@pytest.mark.asyncio
+async def test_run_genvm_host_opts_into_cross_contract_resolution(monkeypatch):
+    """Opting out is a silent downgrade, not a missing feature.
+
+    Without this flag the manager answers `resolve_callcontract_executor`
+    itself with "stay in-process", so a pinned callee's code runs on the
+    caller's executor and the pin quietly stops meaning anything.
+    """
+    captured: dict = {}
+
+    async def fake_run_genvm(_handler, **kwargs):
+        captured.update(kwargs)
+        # Cuts the run short: `run_genvm_host` re-raises this one untouched
+        # instead of entering its retry backoff.
+        raise GenVMInternalError(
+            "stop after the run request was built",
+            error_code=None,
+            causes=[],
+            is_fatal=False,
+        )
+
+    monkeypatch.setattr(base_host, "run_genvm", fake_run_genvm)
+    monkeypatch.setattr(base_host, "ManagerClient", _NoopManagerClient)
+
+    with pytest.raises(GenVMInternalError):
+        await genvm_base.run_genvm_host(
+            functools.partial(
+                _NoopHost,
+                state_proxy=_RecordingStateProxy(bytes([2])),
+                calldata_bytes=b"",
+                leader_results=None,
+            ),
+            timeout=5,
+            is_sync=False,
+            message={"is_init": False, "contract_address": ADDR},
+        )
+
+    assert captured["request_extra"] == {"hook_cross_contract_calls": True}

--- a/third_party/genvm/version
+++ b/third_party/genvm/version
@@ -1,1 +1,1 @@
-v0.6.0-rc0
+feat/rework-manager-api:7b7f2c4947ced7f968a16e02c80a4e321344d4f0


### PR DESCRIPTION
This PR adds support for

1. Pinning a version for a contract (commit 1)
  a. Messages between "majors" work out of the box with it
2. Calls between contracts (commit 2) via rewrite of the manager interface to support multiple host <-> executor connections
  a. Nondet and some other stuff is forbidden on it, there are sharp edges
  b. Referral contract should work
3. Docker build of GenVM (commit 3: sandbox, priveleges, etc; that slack message)

## How to Get Rally Work

NOT tested on real rally, follow up may be needed, but on migrating real DB set new param to `"re:^v0\.2\."` for existing contracts)

## Disclaimer

Vendored genvm communication got diverged from origin, I ported retries and other stuff back to genvm, but this needs agent re-review (I did many iterations already, but...)

Diff is much less scary:

```sh
❯ git diff (git merge-base HEAD v0.123-dev) --stat -- ':(exclude)*test_*.py' ':(exclude)backend/node/genvm/origin/*'
 .genvm-nix-closure/.gitkeep                                                                 |   0
 .github/actions/genvm-runners-closure/action.yml                                            |  65 ++++++++++++++++
 .github/workflows/backend_integration_tests_pr.yml                                          |  26 +++++++
 .github/workflows/load-test-oha.yml                                                         |  13 ++++
 .gitignore                                                                                  |   4 +
 backend/consensus/base.py                                                                   |  11 +++
 backend/consensus/decisions.py                                                              |   2 +
 backend/database_handler/contract_processor.py                                              |   2 +
 backend/database_handler/contract_snapshot.py                                               |   5 ++
 backend/database_handler/migration/versions/c1d2e3f4a5b6_add_reroute_to_to_current_state.py |  30 ++++++++
 backend/database_handler/models.py                                                          |   5 ++
 backend/database_handler/snapshot_manager.py                                                |   6 +-
 backend/domain/types.py                                                                     |   7 ++
 backend/node/base.py                                                                        |   7 ++
 backend/node/genvm/base.py                                                                  | 347 ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++---------------------
 backend/protocol_rpc/endpoints.py                                                           |  51 ++++++++++++-
 docker/Dockerfile.backend                                                                   |  12 +++
 docker/Dockerfile.consensus-worker                                                          |  12 +++
 docker/scripts/download_genvm.sh                                                            |  46 ++++++++----
 tests/db-sqlalchemy/contract_reroute_to_test.py                                             |  62 ++++++++++++++++
 third_party/genvm/version                                                                   |   2 +-
 21 files changed, 613 insertions(+), 102 deletions(-)
```

## Changeset

Depends-On: genlayerlabs/genlayer-node#1647
Depends-On: genlayerlabs/genlayer-studio#1716
Depends-On: genlayerlabs/genvm-manager#9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Studio-only executor version pinning for contract deployments.
  * Preserved executor routing settings across contract state, snapshots, and restarts.
  * Enabled cross-contract calls between contracts running on different executor versions.
  * Added validation to ensure routing pins use supported version formats and debug modes.

* **Bug Fixes**
  * Improved executor connection recovery, retries, cleanup, and completion handling.
  * Updated GenVM assets to version v0.6.0-rc1.

* **Tests**
  * Added comprehensive coverage for routing, persistence, nested execution, retries, and connection lifecycles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->