### PR TITLE
chore: fix source builds

### DIFF
--- a/.github/actions/genvm-runners-closure/action.yml
+++ b/.github/actions/genvm-runners-closure/action.yml
@@ -1,0 +1,65 @@
+name: Prebuild GenVM runners closure
+description: >
+  Builds genvm-manager's `runners-all` on the runner, where the Nix sandbox
+  works, and exports its store closure into the Docker build context so the
+  in-image source build can import it instead of rebuilding it.
+
+  The runner tree is assembled from fixed-output derivations that compile C to
+  wasm (`genvm-cpython-objs`, `genvm-ffi`, bz2/xz/zlib, numpy, PIL). Their
+  identity is their output hash, and the `nixos/nix` image cannot enable the
+  sandbox, so building them there picks up host state and misses the pinned
+  hashes. Everything else in the build is input-addressed and does not care.
+
+inputs:
+  ref:
+    description: GenVM source binding, `<branch>:<commit>` or a bare commit.
+    required: true
+  destination:
+    description: Directory in the build context to write the closure into.
+    required: false
+    default: .genvm-nix-closure
+
+runs:
+  using: composite
+  steps:
+    - name: Install Nix
+      uses: cachix/install-nix-action@v31
+      with:
+        extra_nix_config: |
+          experimental-features = nix-command flakes
+          sandbox = true
+          # Without this Nix quietly builds unsandboxed when it cannot set the
+          # sandbox up, which is the exact output this action must never export.
+          sandbox-fallback = false
+
+    - name: Build and export runners-all
+      shell: bash
+      env:
+        GENVM_CLOSURE_REF: ${{ inputs.ref }}
+        GENVM_CLOSURE_DEST: ${{ inputs.destination }}
+      run: |
+        set -euo pipefail
+        # `<branch>:<commit>` and a bare commit both resolve to the commit.
+        commit="${GENVM_CLOSURE_REF##*:}"
+        if [[ -z "$commit" ]]; then
+          echo "::error::empty GenVM ref passed to genvm-runners-closure"
+          exit 1
+        fi
+        # `sandbox-fallback = false` already fails the build when the sandbox
+        # cannot be set up. This only names the earlier mistake -- nix.conf not
+        # applied at all -- so the failure below reads as a cause, not a puzzle.
+        sandbox=$(nix config show sandbox)
+        if [[ "$sandbox" != "true" ]]; then
+          echo "::error::Nix sandbox is '$sandbox', expected 'true'; nix.conf did not apply, and runner derivations built without a sandbox miss their pinned hashes"
+        fi
+        src=$(mktemp -d)
+        git clone --recurse-submodules https://github.com/genlayerlabs/genvm-manager "$src"
+        git -C "$src" checkout "$commit"
+        git -C "$src" submodule update --init --recursive
+        out=$(cd "$src" && nix build --no-link --print-out-paths ".?submodules=1#runners-all")
+        mkdir -p "$GENVM_CLOSURE_DEST"
+        # shellcheck disable=SC2046 # store paths never contain whitespace
+        nix-store --export $(nix-store -qR "$out") \
+          | gzip > "$GENVM_CLOSURE_DEST/runners-all.nar.gz"
+        rm -rf "$src"
+        echo "Exported $out ($(du -h "$GENVM_CLOSURE_DEST/runners-all.nar.gz" | cut -f1))"

--- a/.github/actions/genvm-runners-closure/action.yml
+++ b/.github/actions/genvm-runners-closure/action.yml
@@ -38,28 +38,5 @@ runs:
         GENVM_CLOSURE_REF: ${{ inputs.ref }}
         GENVM_CLOSURE_DEST: ${{ inputs.destination }}
       run: |
-        set -euo pipefail
-        # `<branch>:<commit>` and a bare commit both resolve to the commit.
-        commit="${GENVM_CLOSURE_REF##*:}"
-        if [[ -z "$commit" ]]; then
-          echo "::error::empty GenVM ref passed to genvm-runners-closure"
-          exit 1
-        fi
-        # `sandbox-fallback = false` already fails the build when the sandbox
-        # cannot be set up. This only names the earlier mistake -- nix.conf not
-        # applied at all -- so the failure below reads as a cause, not a puzzle.
-        sandbox=$(nix config show sandbox)
-        if [[ "$sandbox" != "true" ]]; then
-          echo "::error::Nix sandbox is '$sandbox', expected 'true'; nix.conf did not apply, and runner derivations built without a sandbox miss their pinned hashes"
-        fi
-        src=$(mktemp -d)
-        git clone --recurse-submodules https://github.com/genlayerlabs/genvm-manager "$src"
-        git -C "$src" checkout "$commit"
-        git -C "$src" submodule update --init --recursive
-        out=$(cd "$src" && nix build --no-link --print-out-paths ".?submodules=1#runners-all")
-        mkdir -p "$GENVM_CLOSURE_DEST"
-        # shellcheck disable=SC2046 # store paths never contain whitespace
-        nix-store --export $(nix-store -qR "$out") \
-          | gzip > "$GENVM_CLOSURE_DEST/runners-all.nar.gz"
-        rm -rf "$src"
-        echo "Exported $out ($(du -h "$GENVM_CLOSURE_DEST/runners-all.nar.gz" | cut -f1))"
+        ./scripts/genvm-runners-closure.sh \
+          "$GENVM_CLOSURE_REF" "$GENVM_CLOSURE_DEST"

--- a/.github/actions/genvm-runners-closure/action.yml
+++ b/.github/actions/genvm-runners-closure/action.yml
@@ -23,7 +23,7 @@ runs:
   using: composite
   steps:
     - name: Install Nix
-      uses: cachix/install-nix-action@v31
+      uses: cachix/install-nix-action@b4b293eae0b79aac8a161bb32925a5508c9cca93 # v31
       with:
         extra_nix_config: |
           experimental-features = nix-command flakes

--- a/.github/workflows/backend_integration_tests_pr.yml
+++ b/.github/workflows/backend_integration_tests_pr.yml
@@ -206,6 +206,14 @@ jobs:
           sudo mkdir -p "$GENVM_CACHE_DIR/pc"
           sudo chown -R 999:999 "$GENVM_CACHE_DIR"
 
+      # Source builds need the GenVM runner fixed-output derivations built under
+      # a real Nix sandbox, which the nixos/nix build stage cannot provide.
+      - name: Prebuild GenVM runners closure
+        if: env.GENVM_SOURCE_MODE == 'source'
+        uses: ./.github/actions/genvm-runners-closure
+        with:
+          ref: ${{ env.GENVM_REF }}
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -213,6 +221,11 @@ jobs:
       - name: Build backend images with cache (buildx bake)
         uses: docker/bake-action@v6
         with:
+          # Bake defaults to the Git context, which ignores anything earlier
+          # steps wrote into the workspace. Source builds need the prebuilt
+          # runners closure from there; release builds keep the Git context,
+          # where an empty value is the same as not passing the input.
+          source: ${{ env.GENVM_SOURCE_MODE == 'source' && '.' || '' }}
           files: |
             ./docker-compose.yml
           targets: |
@@ -449,6 +462,14 @@ jobs:
           sudo mkdir -p "$GENVM_CACHE_DIR/pc"
           sudo chown -R 999:999 "$GENVM_CACHE_DIR"
 
+      # Source builds need the GenVM runner fixed-output derivations built under
+      # a real Nix sandbox, which the nixos/nix build stage cannot provide.
+      - name: Prebuild GenVM runners closure
+        if: env.GENVM_SOURCE_MODE == 'source'
+        uses: ./.github/actions/genvm-runners-closure
+        with:
+          ref: ${{ env.GENVM_REF }}
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
@@ -456,6 +477,11 @@ jobs:
       - name: Build backend images with cache (buildx bake)
         uses: docker/bake-action@5be5f02ff8819ecd3092ea6b2e6261c31774f2b4 # v6
         with:
+          # Bake defaults to the Git context, which ignores anything earlier
+          # steps wrote into the workspace. Source builds need the prebuilt
+          # runners closure from there; release builds keep the Git context,
+          # where an empty value is the same as not passing the input.
+          source: ${{ env.GENVM_SOURCE_MODE == 'source' && '.' || '' }}
           files: |
             ./docker-compose.yml
           targets: |

--- a/.github/workflows/load-test-oha.yml
+++ b/.github/workflows/load-test-oha.yml
@@ -195,12 +195,25 @@ jobs:
           sudo mkdir -p "$GENVM_CACHE_DIR/pc"
           sudo chown -R 999:999 "$GENVM_CACHE_DIR"
 
+      # Source builds need the GenVM runner fixed-output derivations built under
+      # a real Nix sandbox, which the nixos/nix build stage cannot provide.
+      - name: Prebuild GenVM runners closure
+        if: env.GENVM_SOURCE_MODE == 'source'
+        uses: ./.github/actions/genvm-runners-closure
+        with:
+          ref: ${{ env.GENVM_REF }}
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
       - name: Build images with cache (buildx bake)
         uses: docker/bake-action@v6
         with:
+          # Bake defaults to the Git context, which ignores anything earlier
+          # steps wrote into the workspace. Source builds need the prebuilt
+          # runners closure from there; release builds keep the Git context,
+          # where an empty value is the same as not passing the input.
+          source: ${{ env.GENVM_SOURCE_MODE == 'source' && '.' || '' }}
           files: |
             ./docker-compose.yml
           targets: |

--- a/.gitignore
+++ b/.gitignore
@@ -181,3 +181,7 @@ frontend/test-results/
 # E2E injects a shared GenVM runtime here for Docker builds.
 .e2e-genvm-prebuilt/*
 !.e2e-genvm-prebuilt/.gitkeep
+
+# CI exports the sandboxed GenVM runners store closure here for source builds.
+.genvm-nix-closure/*
+!.genvm-nix-closure/.gitkeep

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,6 +40,20 @@ Have ideas for new features or use cases? We're eager to hear them! But first:
    $ docker compose up
    ```
 
+   When building GenVM from source, install Nix locally and configure
+   `sandbox = true` in `nix.conf`. After exporting `GENVM_SOURCE_MODE=source`
+   and `GENVM_REF` (or using a `<branch>:<commit>` ref for automatic source
+   mode), prepare the runner closure before `docker compose build` or
+   `docker compose up`:
+
+   ```sh
+   $ ./scripts/prepare-genvm-source-build.sh
+   ```
+
+   The runner tree contains fixed-output derivations that need a real Nix
+   sandbox to retain their pinned hashes. The Docker build imports this
+   prepared closure because its `nixos/nix` stage cannot provide that sandbox.
+
 - **1.4. Running Tests**:
 
    ```sh

--- a/docker/Dockerfile.backend
+++ b/docker/Dockerfile.backend
@@ -32,9 +32,8 @@ ARG GENVM_BUILD_CORES=0
 # nixos/nix ships bash only inside the default nix profile (no /bin/bash).
 SHELL ["/nix/var/nix/profiles/default/bin/bash", "-x", "-c"]
 
-# CI exports genvm-manager's `runners-all` closure here from a sandboxed Nix on
-# the runner (.github/actions/genvm-runners-closure). Empty in a plain local
-# build, which then builds the runners here instead -- see the import below.
+# CI or scripts/prepare-genvm-source-build.sh exports genvm-manager's
+# `runners-all` closure here from a sandboxed Nix.
 COPY .genvm-nix-closure/ /genvm-nix-closure/
 
 # Source builds bind Studio to a genvm-manager branch/SHA. The flake target
@@ -52,6 +51,14 @@ RUN set -euo pipefail ; \
         if [[ -z "$GENVM_REF" ]]; then \
             echo "ERROR: GENVM_SOURCE_MODE=source requires GENVM_REF" ; exit 1 ; \
         fi ; \
+        # The runner tree is built from fixed-output derivations that compile C
+        # to wasm; without a sandbox they pick up host state and miss their
+        # pinned hashes. Import the closure built under a real sandbox so they
+        # are not rebuilt here.
+        if [[ ! -f /genvm-nix-closure/runners-all.nar.gz ]]; then \
+            echo "ERROR: GenVM source builds require the sandboxed runners closure; run ./scripts/prepare-genvm-source-build.sh before building" ; exit 1 ; \
+        fi ; \
+        gzip -dc /genvm-nix-closure/runners-all.nar.gz | nix-store --import > /dev/null ; \
         SOURCE_REF="$GENVM_REF" ; \
         if [[ "$SOURCE_REF" =~ ^.+:([0-9a-fA-F]{7,40})$ ]]; then \
             SOURCE_REF="${BASH_REMATCH[1]}" ; \
@@ -62,13 +69,6 @@ RUN set -euo pipefail ; \
         cd /src/genvm ; \
         git checkout "$SOURCE_REF" ; \
         git submodule update --init --recursive ; \
-        # The runner tree is built from fixed-output derivations that compile C
-        # to wasm; without a sandbox they pick up host state and miss their
-        # pinned hashes. Import the closure CI built under a real sandbox
-        # (.github/actions/genvm-runners-closure) so they are not rebuilt here.
-        if [[ -f /genvm-nix-closure/runners-all.nar.gz ]]; then \
-            gzip -dc /genvm-nix-closure/runners-all.nar.gz | nix-store --import > /dev/null ; \
-        fi ; \
         if [[ "$TARGETARCH" == "amd64" ]] || [[ -z "$TARGETARCH" ]]; then \
             GT="amd64-linux" ; \
         elif [[ "$TARGETARCH" == "arm64" ]]; then \

--- a/docker/Dockerfile.backend
+++ b/docker/Dockerfile.backend
@@ -51,19 +51,22 @@ RUN set -euo pipefail ; \
         if [[ -z "$GENVM_REF" ]]; then \
             echo "ERROR: GENVM_SOURCE_MODE=source requires GENVM_REF" ; exit 1 ; \
         fi ; \
-        # The runner tree is built from fixed-output derivations that compile C
-        # to wasm; without a sandbox they pick up host state and miss their
-        # pinned hashes. Import the closure built under a real sandbox so they
-        # are not rebuilt here.
-        if [[ ! -f /genvm-nix-closure/runners-all.nar.gz ]]; then \
-            echo "ERROR: GenVM source builds require the sandboxed runners closure; run ./scripts/prepare-genvm-source-build.sh before building" ; exit 1 ; \
-        fi ; \
-        gzip -dc /genvm-nix-closure/runners-all.nar.gz | nix-store --import > /dev/null ; \
         SOURCE_REF="$GENVM_REF" ; \
         if [[ "$SOURCE_REF" =~ ^.+:([0-9a-fA-F]{7,40})$ ]]; then \
             SOURCE_REF="${BASH_REMATCH[1]}" ; \
         fi ; \
-        # nix's seccomp filter cannot load under qemu/Rosetta emulation.
+        # The runner tree is built from fixed-output derivations that compile C
+        # to wasm; without a sandbox they pick up host state and miss their
+        # pinned hashes. Import the closure built under a real sandbox so they
+        # are not rebuilt here.
+        CLOSURE_FILE="/genvm-nix-closure/runners-all-$SOURCE_REF.nar.gz" ; \
+        if [[ ! -f "$CLOSURE_FILE" ]]; then \
+            echo "ERROR: GenVM source builds require the sandboxed runners closure; run ./scripts/prepare-genvm-source-build.sh before building" ; exit 1 ; \
+        fi ; \
+        gzip -dc "$CLOSURE_FILE" | nix-store --import > /dev/null ; \
+        # filter-syscalls=false: nix's seccomp filter cannot load under
+        # qemu/Rosetta emulation (cross-platform local builds); harmless on
+        # native hosts since the image already runs with sandbox disabled.
         printf 'experimental-features = nix-command flakes\nfilter-syscalls = false\ncores = %s\n' "$GENVM_BUILD_CORES" >> /etc/nix/nix.conf ; \
         git clone --recurse-submodules https://github.com/genlayerlabs/genvm-manager /src/genvm ; \
         cd /src/genvm ; \

--- a/docker/Dockerfile.backend
+++ b/docker/Dockerfile.backend
@@ -32,6 +32,11 @@ ARG GENVM_BUILD_CORES=0
 # nixos/nix ships bash only inside the default nix profile (no /bin/bash).
 SHELL ["/nix/var/nix/profiles/default/bin/bash", "-x", "-c"]
 
+# CI exports genvm-manager's `runners-all` closure here from a sandboxed Nix on
+# the runner (.github/actions/genvm-runners-closure). Empty in a plain local
+# build, which then builds the runners here instead -- see the import below.
+COPY .genvm-nix-closure/ /genvm-nix-closure/
+
 # Source builds bind Studio to a genvm-manager branch/SHA. The flake target
 # follows TARGETARCH (amd64-linux / arm64-linux); runners are included by
 # genvm-manager's combined genvm package.
@@ -57,6 +62,13 @@ RUN set -euo pipefail ; \
         cd /src/genvm ; \
         git checkout "$SOURCE_REF" ; \
         git submodule update --init --recursive ; \
+        # The runner tree is built from fixed-output derivations that compile C
+        # to wasm; without a sandbox they pick up host state and miss their
+        # pinned hashes. Import the closure CI built under a real sandbox
+        # (.github/actions/genvm-runners-closure) so they are not rebuilt here.
+        if [[ -f /genvm-nix-closure/runners-all.nar.gz ]]; then \
+            gzip -dc /genvm-nix-closure/runners-all.nar.gz | nix-store --import > /dev/null ; \
+        fi ; \
         if [[ "$TARGETARCH" == "amd64" ]] || [[ -z "$TARGETARCH" ]]; then \
             GT="amd64-linux" ; \
         elif [[ "$TARGETARCH" == "arm64" ]]; then \

--- a/scripts/genvm-runners-closure.sh
+++ b/scripts/genvm-runners-closure.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -ne 2 ]]; then
+    echo "Usage: $0 <branch:commit|commit> <destination>" >&2
+    exit 1
+fi
+
+GENVM_CLOSURE_REF=$1
+GENVM_CLOSURE_DEST=$2
+
+if [[ -z "$GENVM_CLOSURE_DEST" ]]; then
+    echo "ERROR: destination directory must not be empty" >&2
+    exit 1
+fi
+
+# `<branch>:<commit>` and a bare commit both resolve to the commit.
+commit="${GENVM_CLOSURE_REF##*:}"
+if [[ -z "$commit" ]]; then
+    echo "ERROR: empty GenVM ref passed to genvm-runners-closure" >&2
+    exit 1
+fi
+
+# A caller may disable sandbox fallback separately. Checking the effective
+# config here also catches nix.conf not being applied at all.
+sandbox=$(nix config show sandbox)
+if [[ "$sandbox" != "true" ]]; then
+    echo "ERROR: Nix sandbox is '$sandbox', expected 'true'; runner derivations built without a sandbox miss their pinned hashes" >&2
+    exit 1
+fi
+
+# Nix's own git fetcher clones (and caches) the repo and its submodules; no
+# need to `git clone` it ourselves first.
+out=$(nix build --no-link --print-out-paths \
+    "git+https://github.com/genlayerlabs/genvm-manager?rev=$commit&submodules=1#runners-all")
+mkdir -p "$GENVM_CLOSURE_DEST"
+# shellcheck disable=SC2046 # store paths never contain whitespace
+nix-store --export $(nix-store -qR "$out") \
+    | gzip > "$GENVM_CLOSURE_DEST/runners-all.nar.gz"
+echo "Exported $out ($(du -h "$GENVM_CLOSURE_DEST/runners-all.nar.gz" | cut -f1))"

--- a/scripts/genvm-runners-closure.sh
+++ b/scripts/genvm-runners-closure.sh
@@ -15,11 +15,11 @@ if [[ -z "$GENVM_CLOSURE_DEST" ]]; then
 fi
 
 # `<branch>:<commit>` and a bare commit both resolve to the commit.
-commit="${GENVM_CLOSURE_REF##*:}"
-if [[ -z "$commit" ]]; then
-    echo "ERROR: empty GenVM ref passed to genvm-runners-closure" >&2
+if [[ ! "$GENVM_CLOSURE_REF" =~ ^([^:]+:)?[0-9a-fA-F]{7,40}$ ]]; then
+    echo "ERROR: GenVM ref must be '<branch>:<commit>' or a bare commit SHA, got '$GENVM_CLOSURE_REF'" >&2
     exit 1
 fi
+commit="${GENVM_CLOSURE_REF##*:}"
 
 # A caller may disable sandbox fallback separately. Checking the effective
 # config here also catches nix.conf not being applied at all.
@@ -34,7 +34,12 @@ fi
 out=$(nix build --no-link --print-out-paths \
     "git+https://github.com/genlayerlabs/genvm-manager?rev=$commit&submodules=1#runners-all")
 mkdir -p "$GENVM_CLOSURE_DEST"
+dest="$GENVM_CLOSURE_DEST/runners-all-$commit.nar.gz"
+tmp="$dest.tmp"
 # shellcheck disable=SC2046 # store paths never contain whitespace
 nix-store --export $(nix-store -qR "$out") \
-    | gzip > "$GENVM_CLOSURE_DEST/runners-all.nar.gz"
-echo "Exported $out ($(du -h "$GENVM_CLOSURE_DEST/runners-all.nar.gz" | cut -f1))"
+    | gzip > "$tmp"
+# Export via a temp file + rename so a Ctrl+C mid-write can't leave a
+# truncated .nar.gz that a later build silently imports as if it were valid.
+mv "$tmp" "$dest"
+echo "Exported $out ($(du -h "$dest" | cut -f1))"

--- a/scripts/prepare-genvm-source-build.sh
+++ b/scripts/prepare-genvm-source-build.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+GENVM_REF=${GENVM_REF:-}
+GENVM_SOURCE_MODE=${GENVM_SOURCE_MODE:-}
+
+source_selected=0
+if [[ "$GENVM_SOURCE_MODE" == "source" || ( -z "$GENVM_SOURCE_MODE" && "$GENVM_REF" =~ ^.+:[0-9a-fA-F]{7,40}$ ) ]]; then
+    source_selected=1
+fi
+
+if [[ "$source_selected" != "1" ]]; then
+    echo "ERROR: GenVM source mode is not selected; set GENVM_SOURCE_MODE=source and GENVM_REF, or use a <branch>:<commit> GENVM_REF" >&2
+    exit 1
+fi
+if [[ -z "$GENVM_REF" ]]; then
+    echo "ERROR: GENVM_SOURCE_MODE=source requires GENVM_REF" >&2
+    exit 1
+fi
+
+"$SCRIPT_DIR/genvm-runners-closure.sh" \
+    "$GENVM_REF" "$REPO_ROOT/.genvm-nix-closure"

--- a/third_party/genvm/version
+++ b/third_party/genvm/version
@@ -1,1 +1,1 @@
-v0.6.0-rc0
+main:64de46028afba5f36dcb62401c4c052ebf6456a1

--- a/third_party/genvm/version
+++ b/third_party/genvm/version
@@ -1,1 +1,1 @@
-main:64de46028afba5f36dcb62401c4c052ebf6456a1
+v0.6.0-rc0


### PR DESCRIPTION
Split from #1716 that makes source build work, instead of erroring on absent sandbox for building runners, which causes hash mismatch

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for preparing GenVM source builds with reproducible runner artifacts.
  - CI workflows now support GenVM source-mode builds consistently.

- **Documentation**
  - Added contributor instructions for configuring Nix and preparing GenVM source builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->