### PR TITLE
fix(consensus): keep worker alive on transient GenVM transport failures

### DIFF
--- a/backend/consensus/worker.py
+++ b/backend/consensus/worker.py
@@ -25,6 +25,14 @@ from loguru import logger
 from backend.node.base import Manager as GenVMManager
 from backend.services.usage_metrics_service import UsageMetricsService
 
+# Causes the GenVM module reports as fatal that Studio treats as transient.
+# GenVM's shared HTTP helper flags every transport-level failure fatal, so a
+# webdriver or LLM endpoint that is briefly unreachable surfaces here. That
+# means "an upstream call failed", not "this worker's state is broken" — the
+# transaction is still reset for another worker, but killing the worker turns
+# one restarting dependency into a fleet-wide restart loop.
+_TRANSIENT_LEADER_FATAL_CAUSES = frozenset({"SENDING_REQUEST", "READING_BODY"})
+
 
 class ConsensusWorker:
     """
@@ -802,11 +810,25 @@ class ConsensusWorker:
 
                     # For fatal leader errors, stop the worker to trigger K8s restart via health check
                     if e.is_fatal:
-                        logger.warning(
-                            f"[Worker {self.worker_id}] Fatal GenVM error in leader - stopping worker. "
-                            f"{tx_type.capitalize()} {tx_hash} will be reset for another worker."
+                        transient_causes = _TRANSIENT_LEADER_FATAL_CAUSES.intersection(
+                            e.causes or []
                         )
-                        self.running = False
+                        if transient_causes:
+                            # Upstream was unreachable, not a broken worker. The
+                            # transaction was already reset above; stay alive so a
+                            # restarting webdriver or LLM endpoint can't cascade
+                            # into every worker restarting at once.
+                            logger.warning(
+                                f"[Worker {self.worker_id}] Transient GenVM transport failure in leader "
+                                f"({', '.join(sorted(transient_causes))}) - keeping worker alive. "
+                                f"{tx_type.capitalize()} {tx_hash} was reset for another worker."
+                            )
+                        else:
+                            logger.warning(
+                                f"[Worker {self.worker_id}] Fatal GenVM error in leader - stopping worker. "
+                                f"{tx_type.capitalize()} {tx_hash} will be reset for another worker."
+                            )
+                            self.running = False
         except (ContractNotFoundError, _NoValidatorsError):
             # Re-raise for specific handling by caller
             raise

--- a/tests/unit/test_worker_transient_transport_fatal.py
+++ b/tests/unit/test_worker_transient_transport_fatal.py
@@ -1,0 +1,128 @@
+"""
+Tests for transient-transport handling of fatal GenVM leader errors.
+
+GenVM's shared HTTP helper marks every transport-level failure fatal
+(SENDING_REQUEST when the request can't be sent, READING_BODY when the
+response can't be read). Those fire whenever an upstream — the webdriver or
+an LLM endpoint — is momentarily unreachable, which says nothing about the
+health of the worker that observed it. Stopping the worker there turns one
+restarting dependency into every worker restarting at once, so these causes
+reset the transaction but leave the worker running. Genuinely fatal causes
+still stop the worker.
+"""
+
+import pytest
+from unittest.mock import MagicMock
+from sqlalchemy.orm import Session
+
+from backend.database_handler.models import TransactionStatus
+from backend.node.genvm.error_codes import GenVMInternalError
+
+
+def _make_worker():
+    from backend.consensus.worker import ConsensusWorker
+
+    def get_session_side_effect():
+        ctx = MagicMock()
+        inner = MagicMock(spec=Session)
+        inner.commit = MagicMock()
+        tx_row = MagicMock()
+        tx_row.status = TransactionStatus.PROPOSING
+        tx_row.consensus_data = None
+        tx_row.timestamp_awaiting_finalization = None
+        inner.query.return_value.filter_by.return_value.one.return_value = tx_row
+        ctx.__enter__ = MagicMock(return_value=inner)
+        ctx.__exit__ = MagicMock(return_value=None)
+        return ctx
+
+    worker = ConsensusWorker(
+        get_session=get_session_side_effect,
+        msg_handler=MagicMock(),
+        consensus_service=MagicMock(),
+        validators_manager=MagicMock(),
+        genvm_manager=MagicMock(),
+        worker_id="test-worker",
+    )
+    worker.running = True
+    worker.reset_transaction = MagicMock()
+    worker.release_transaction = MagicMock()
+    return worker
+
+
+def _fatal_leader_error(causes):
+    """A fatal leader error as GenVM reports it — is_fatal comes from the module."""
+    return GenVMInternalError(
+        message=f"GenVM internal error: {', '.join(causes)}",
+        error_code="INTERNAL_ERROR",
+        causes=list(causes),
+        is_fatal=True,
+        is_leader=True,
+        ctx=None,
+        detail="ModuleError { causes: [...], fatal: true }",
+    )
+
+
+async def _run_with_error(worker, error):
+    """Drive _transaction_context to completion with `error` raised inside it."""
+    session = MagicMock(spec=Session)
+    async with worker._transaction_context("0xdeadbeef", {}, session):
+        raise error
+
+
+class TestTransientTransportFatal:
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("cause", ["SENDING_REQUEST", "READING_BODY"])
+    async def test_transport_failure_keeps_worker_running(self, cause):
+        """An unreachable upstream resets the tx but must not stop the worker."""
+        worker = _make_worker()
+
+        await _run_with_error(worker, _fatal_leader_error([cause]))
+
+        assert worker.running is True, (
+            f"{cause} is a transport failure of an upstream, not a broken worker — "
+            "stopping here cascades one dead dependency into every worker"
+        )
+        assert worker.reset_transaction.called, "transaction must still be reset"
+
+    @pytest.mark.asyncio
+    async def test_genuine_fatal_still_stops_worker(self):
+        """Causes outside the transient set keep the existing stop-and-restart behavior."""
+        worker = _make_worker()
+
+        await _run_with_error(worker, _fatal_leader_error(["SOME_OTHER_FATAL_CAUSE"]))
+
+        assert worker.running is False
+        assert worker.reset_transaction.called
+
+    @pytest.mark.asyncio
+    async def test_mixed_causes_treated_as_transient(self):
+        """A transport cause anywhere in the chain is enough to keep the worker alive."""
+        worker = _make_worker()
+
+        await _run_with_error(
+            worker, _fatal_leader_error(["SENDING_REQUEST", "WEBPAGE_LOAD_FAILED"])
+        )
+
+        assert worker.running is True
+
+    @pytest.mark.asyncio
+    async def test_validator_error_never_stops_worker(self):
+        """Pre-existing behavior: validator-side errors leave consensus to continue."""
+        worker = _make_worker()
+        error = _fatal_leader_error(["SOME_OTHER_FATAL_CAUSE"])
+        error.is_leader = False
+
+        await _run_with_error(worker, error)
+
+        assert worker.running is True
+        assert not worker.reset_transaction.called
+
+    def test_transient_set_covers_genvm_transport_causes(self):
+        """
+        Guards the constant itself: these are the two causes GenVM's shared HTTP
+        helper raises with fatal=true (modules/implementation/src/scripting/mod.rs).
+        Narrowing the set silently re-opens the cascade.
+        """
+        from backend.consensus.worker import _TRANSIENT_LEADER_FATAL_CAUSES
+
+        assert {"SENDING_REQUEST", "READING_BODY"} <= _TRANSIENT_LEADER_FATAL_CAUSES


### PR DESCRIPTION
## Problem

A contract requested a domain with no A record. `studio-webdriver` (single replica) crash-looped on an unhandled puppeteer `TargetCloseError`, exit 1, roughly every 7 minutes. While it was down, **3 of 5 `studio-consensus-worker` pods went unhealthy and were liveness-killed in a repeating cycle.**

The chain:

1. GenVM's shared HTTP helper `send_request_get_lua_compatible_response_bytes` calls `.map_user_error(ErrorKind::SENDING_REQUEST, true)` — the `true` is the `fatal` flag, hardcoded. It fires on any `reqwest::send()` failure, so an unreachable webdriver looks identical to a broken VM.
2. `LUA_CAUSE_TO_CODE` has no entry for `SENDING_REQUEST`, so `error_codes.py:245` defaults it to `INTERNAL_ERROR`.
3. `base.py` reads `is_fatal` verbatim off the module and raises `GenVMInternalError`.
4. `worker.py` sees `is_fatal` and sets `self.running = False` → `/health` 503 → liveness kill.

## Fix

`SENDING_REQUEST` and `READING_BODY` mean *an upstream call failed*, not *this worker's state is broken*. The transaction is still reset for another worker, but the worker stays alive — otherwise one restarting dependency cascades into every worker restarting at once. Causes outside the set keep the existing stop-and-restart behavior.

Deliberately narrow: this is the containment fix for a live prd incident, not the structural one.

## Not fixed here

- **The webdriver crash itself** — unhandled `TargetCloseError` in `yeagerai/genlayer-genvm-webdriver:0.0.9`, separate repo. This PR stops one crashed dependency from taking down the fleet; it does not stop the crashes.
- **`web.lua` `Render()`** calls `lib.rs.request` bare while `Request()` wraps it in `pcall` + `reraise_with_fatality(..., false)`. Render should raise `WEBPAGE_LOAD_FAILED, fatal=false` so the contract gets a catchable error, and should guard the `tonumber(nil)` on a missing `resulting-status` header. → v0.123.
- **`llm.lua:123`** has the same bare `lib.rs.request` on the custom-plugin path (called unguarded at `:202`) — an unreachable custom endpoint kills workers the same way. → v0.123.
- **The `INTERNAL_ERROR` default for unknown causes** (`error_codes.py:245`) makes every future GenVM cause string a latent worker-killer. Inverting that default is the real structural fix. → v0.123.

## Testing

`tests/unit/test_worker_transient_transport_fatal.py` — 6 cases covering both transient causes, genuine fatal, mixed cause chains, and validator-side errors.

Mutation-checked: neutralizing `_TRANSIENT_LEADER_FATAL_CAUSES` to `frozenset()` fails 4 of the 6, so they can't pass against a stubbed guard.

Full backend unit suite: 731 passed.