### PR TITLE
feat(consensus): make validator execution concurrency configurable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -147,6 +147,9 @@ VALIDATORS_CONFIG_JSON='[
 JSONRPC_REPLICAS='1'
 CONSENSUS_WORKERS='3'
 MAX_PARALLEL_TXS_PER_WORKER='1'
+# Max validators executing concurrently per transaction (GenVM subprocesses).
+# Raise for large committees if memory allows.
+CONSENSUS_VALIDATOR_MAX_CONCURRENT='8'
 # Production Configuration (for Gunicorn deployment)
 WEB_CONCURRENCY='1'               # Number of Gunicorn workers (default: CPU cores * 2)
 # Service resources limit

--- a/backend/consensus/base.py
+++ b/backend/consensus/base.py
@@ -80,6 +80,13 @@ from backend.node.genvm import get_code_slot
 from backend.node.genvm.error_codes import GenVMInternalError, GenVMErrorCode
 from backend.node.base import Manager as GenVMManager
 
+# Cap on concurrently executing validators per transaction. Bounds GenVM
+# subprocess memory, fd, and DB-session usage; larger committees run through
+# this window. See issue #1721.
+VALIDATOR_MAX_CONCURRENT = max(
+    1, int(os.environ.get("CONSENSUS_VALIDATOR_MAX_CONCURRENT", "8"))
+)
+
 type NodeFactory = Callable[
     [
         dict,
@@ -1922,7 +1929,7 @@ class CommittingState(TransactionState):
         )
 
         # Execute the transaction with a semaphore to limit the number of concurrent validators
-        sem = asyncio.Semaphore(8)
+        sem = asyncio.Semaphore(VALIDATOR_MAX_CONCURRENT)
 
         # Build replacement pool: all validators minus those already assigned
         assigned_addresses: set[str] = set()

--- a/backend/protocol_rpc/endpoints.py
+++ b/backend/protocol_rpc/endpoints.py
@@ -66,8 +66,8 @@ import asyncio
 
 # Limit concurrent GenVM executions on the jsonrpc path to prevent uvloop fd
 # conflicts and DB pool exhaustion while calls hold request-scoped sessions.
-# Workers use asyncio.Semaphore(8) in consensus/base.py; keep the RPC path
-# bounded too.
+# Workers use CONSENSUS_VALIDATOR_MAX_CONCURRENT (default 8) in
+# consensus/base.py; keep the RPC path bounded too.
 _GENVM_CONCURRENCY = int(os.environ.get("GENVM_MAX_CONCURRENT", "8"))
 _genvm_semaphore = asyncio.Semaphore(_GENVM_CONCURRENCY)
 _genvm_admission_semaphore = asyncio.Semaphore(_GENVM_CONCURRENCY)


### PR DESCRIPTION
Fixes #1721

# What

- Replace the hardcoded `asyncio.Semaphore(8)` in `CommittingState.handle` with a module-level `VALIDATOR_MAX_CONCURRENT` read from the `CONSENSUS_VALIDATOR_MAX_CONCURRENT` env var (default 8, clamped to >= 1).
- Update the stale comment in `backend/protocol_rpc/endpoints.py` that referenced the hardcoded value.
- Document the new variable in `.env.example`.

# Why

A 47-validator committee currently runs through a fixed window of 8 concurrent validator executions (~6 sequential rounds), dominating transaction latency. The cap itself is legitimate (GenVM subprocess memory / fd / DB-pool bounds) but the value 8 was arbitrary and not tunable. Deployments with adequate memory can now size it to their committee sizes. Default behavior is unchanged.

# Testing done

- `python3 -m py_compile` on both edited modules.
- No behavior change with the variable unset (default 8).