### PR TITLE
ci: skip lint for contracts pinned to the v0.6 fee-era runner

### DIFF
--- a/.github/workflows/genvm-lint.yml
+++ b/.github/workflows/genvm-lint.yml
@@ -32,17 +32,20 @@ jobs:
       - name: Install genvm-linter
         run: pip install genvm-linter
 
-      # Contracts pinned to the genvm-main runner use the new SDK layout,
-      # which released genvm-linter (<= 0.11.0) cannot load yet
-      # ("No module named 'genlayer.py'"). Skip them until a linter release
-      # supports it (genvm-linter dxp-694), then drop this filter.
+      # Contracts pinned to runners newer than the released linter's bundled
+      # SDK cannot be loaded by genvm-linter (<= 0.11.0): the genvm-main
+      # runner (1zr6nqk...) fails with "No module named 'genlayer.py'", and
+      # the v0.6 fee-era runner (9b8kjyda2...) fails with
+      # "filename 'runners/py-genlayer/9b/8kjy....tar' not found". Skip both
+      # until a linter release bundles them (genvm-linter dxp-694), then
+      # drop this filter.
       - name: Lint example contracts
         run: |
           failed=0
           for f in examples/contracts/*.py; do
             echo "::group::$f"
-            if grep -q "py-genlayer:1zr6nqk597d97kg0dyxg0shhrykx5v02zjgnyrajapy4wlqvfvwh" "$f"; then
-              echo "SKIP: pinned to the genvm-main runner (unsupported by released genvm-linter)"
+            if grep -qE "py-genlayer:(1zr6nqk597d97kg0dyxg0shhrykx5v02zjgnyrajapy4wlqvfvwh|9b8kjyda2ycxyq4ea6g4yfpnydxhd52gqba5rb8dw7krkh5mn9p0)" "$f"; then
+              echo "SKIP: pinned to a runner unsupported by released genvm-linter"
             elif ! genvm-lint check "$f"; then
               failed=1
             fi
@@ -56,8 +59,8 @@ jobs:
           for f in tests/load/contracts/*.py tests/direct/contracts/*.py; do
             [ -f "$f" ] || continue
             echo "::group::$f"
-            if grep -q "py-genlayer:1zr6nqk597d97kg0dyxg0shhrykx5v02zjgnyrajapy4wlqvfvwh" "$f"; then
-              echo "SKIP: pinned to the genvm-main runner (unsupported by released genvm-linter)"
+            if grep -qE "py-genlayer:(1zr6nqk597d97kg0dyxg0shhrykx5v02zjgnyrajapy4wlqvfvwh|9b8kjyda2ycxyq4ea6g4yfpnydxhd52gqba5rb8dw7krkh5mn9p0)" "$f"; then
+              echo "SKIP: pinned to a runner unsupported by released genvm-linter"
             elif ! genvm-lint check "$f"; then
               failed=1
             fi


### PR DESCRIPTION
## What

Extends the genvm-lint workflow's existing unsupported-runner skip filter to also cover `py-genlayer:9b8kjyda2ycxyq4ea6g4yfpnydxhd52gqba5rb8dw7krkh5mn9p0` — the v0.6 fee-era runner that every lintable contract on `v0.123-dev` now pins.

## Why

Latest released genvm-linter (0.11.0, unchanged on PyPI) doesn't bundle that runner's SDK, so `Lint Intelligent Contracts` fails with `Failed to load SDK: "filename 'runners/py-genlayer/9b/8kjy....tar' not found"` on every contract — observed on PR #1723. Same situation and same documented remedy as the existing genvm-main skip (pending genvm-linter dxp-694); drop the whole filter when a linter release bundles the new SDK layout.

## Testing done

All 12 lintable contracts on this branch pin the new runner, so the job becomes skip-all — identical signal to today's guaranteed-red, but green and non-blocking. Filter verified by grep against `examples/contracts/*.py`.