### PR TITLE
fix: meter actual contract snapshot size

### DIFF
--- a/backend/protocol_rpc/contract_storage_quota.py
+++ b/backend/protocol_rpc/contract_storage_quota.py
@@ -26,8 +26,6 @@ from backend.protocol_rpc.exceptions import StorageQuotaExceeded
 
 logger = logging.getLogger(__name__)
 
-# Snapshot stores accepted + finalized slots; live current_state is one slot.
-_SNAPSHOT_SLOT_FACTOR = 2
 _REDIS_KEY_TTL_SECONDS = 48 * 3600
 _STORAGE_HELP = (
     "The public Studio is a shared sandbox with a per-contract daily "
@@ -112,9 +110,15 @@ def daily_byte_limit() -> int | None:
 
 
 def snapshot_cost_bytes(live_state_column_size: int | None) -> int:
+    """Estimate the next snapshot from the already-complete live state row.
+
+    ``current_state.data`` contains both accepted and finalized slots, matching
+    the shape copied into ``transactions.contract_snapshot``.  Multiplying it
+    again would double-count the snapshot cost.
+    """
     if not live_state_column_size:
         return 0
-    return live_state_column_size * _SNAPSHOT_SLOT_FACTOR
+    return live_state_column_size
 
 
 def redis_key(address: str, day: str | None = None) -> str:

--- a/tests/db-sqlalchemy/test_contract_storage_quota.py
+++ b/tests/db-sqlalchemy/test_contract_storage_quota.py
@@ -42,7 +42,7 @@ def test_live_state_column_size_does_not_require_python_hydrate(engine: Engine):
         size = live_state_column_size(session, CONTRACT)
         assert size is not None
         assert size > 0
-        assert snapshot_cost_bytes(size) == size * 2
+        assert snapshot_cost_bytes(size) == size
 
 
 def test_quota_disabled_when_env_unset(engine: Engine, monkeypatch):

--- a/tests/unit/test_contract_storage_quota.py
+++ b/tests/unit/test_contract_storage_quota.py
@@ -28,10 +28,10 @@ class MemoryRedis:
         return self.store[quota_key]
 
 
-def test_snapshot_cost_is_two_slots():
+def test_snapshot_cost_matches_complete_live_state_row():
     assert snapshot_cost_bytes(None) == 0
     assert snapshot_cost_bytes(0) == 0
-    assert snapshot_cost_bytes(10) == 20
+    assert snapshot_cost_bytes(10) == 10
 
 
 def test_first_write_of_day_always_allowed_even_if_over_limit():


### PR DESCRIPTION
## What changed
- meter `current_state.data` directly for the daily contract snapshot quota
- remove the extra 2× multiplier because the row already contains accepted and finalized state
- update unit and database-backed regression expectations

## Why
Production measurements show `current_state.data` and `transactions.contract_snapshot` are approximately the same size. The previous multiplier double-counted the expected storage cost.

## Impact
Quota values now correspond to actual stored snapshot bytes. This enables a 256 MiB/day production budget that applies meaningful backpressure without fully disabling the existing large contract.

## Validation
- `.venv/bin/python -m pytest -q tests/unit/test_contract_storage_quota.py` — 9 passed
- commit hooks: Black, autoflake, whitespace, merge-conflict and file-size checks passed
- database-backed quota tests left to CI because local `POSTGRES_URL` is not configured