### PR TITLE
feat: port contract storage quota to v0.123-dev

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -120,6 +120,9 @@ RATE_LIMIT_ANON_PER_DAY='5000'       # Anonymous per-day limit
 # deployments should set both to prevent one user filling the queue.
 MAX_PENDING_PER_CONTRACT_DEFAULT=''  # Cap PENDING txs per contract (e.g. 50)
 MAX_PENDING_PER_SENDER_DEFAULT=''    # Cap PENDING txs per sender   (e.g. 20)
+# Daily per-contract snapshot-byte budget (empty = off). Hosted sandbox
+# example: 1073741824 (1 GiB). First write of the UTC day always allowed.
+MAX_CONTRACT_SNAPSHOT_BYTES_PER_DAY=''
 
 ########################################
 # Terminal Contract Snapshot Pruning (Optional)

--- a/backend/database_handler/transactions_processor.py
+++ b/backend/database_handler/transactions_processor.py
@@ -1646,6 +1646,7 @@ class TransactionsProcessor:
             text("UPDATE transactions SET rotation_count = 0 WHERE hash = :hash"),
             {"hash": transaction_hash},
         )
+        self.session.commit()
 
     def set_transaction_appeal_leader_timeout(
         self, transaction_hash: str, appeal_leader_timeout: bool

--- a/backend/protocol_rpc/contract_storage_quota.py
+++ b/backend/protocol_rpc/contract_storage_quota.py
@@ -26,8 +26,6 @@ from backend.protocol_rpc.exceptions import StorageQuotaExceeded
 
 logger = logging.getLogger(__name__)
 
-# Snapshot stores accepted + finalized slots; live current_state is one slot.
-_SNAPSHOT_SLOT_FACTOR = 2
 _REDIS_KEY_TTL_SECONDS = 48 * 3600
 _STORAGE_HELP = (
     "The public Studio is a shared sandbox with a per-contract daily "
@@ -112,9 +110,15 @@ def daily_byte_limit() -> int | None:
 
 
 def snapshot_cost_bytes(live_state_column_size: int | None) -> int:
+    """Estimate the next snapshot from the already-complete live state row.
+
+    ``current_state.data`` contains both accepted and finalized slots, matching
+    the shape copied into ``transactions.contract_snapshot``.  Multiplying it
+    again would double-count the snapshot cost.
+    """
     if not live_state_column_size:
         return 0
-    return live_state_column_size * _SNAPSHOT_SLOT_FACTOR
+    return live_state_column_size
 
 
 def redis_key(address: str, day: str | None = None) -> str:

--- a/backend/protocol_rpc/contract_storage_quota.py
+++ b/backend/protocol_rpc/contract_storage_quota.py
@@ -1,0 +1,238 @@
+"""Per-contract daily budget for contract_snapshot bytes.
+
+Studio copies live current_state into transactions.contract_snapshot on
+every write. A slow writer with unbounded on-chain history can add tens
+of GiB/day without tripping request or PENDING-queue caps.
+
+This module meters estimated snapshot bytes per contract per UTC day.
+Unset MAX_CONTRACT_SNAPSHOT_BYTES_PER_DAY disables it (self-hosted
+default). Redis failures fail open. The first write of the day is always
+allowed so a contract whose single snapshot exceeds the daily budget is
+not hard-locked.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any
+
+from eth_utils import to_checksum_address
+from sqlalchemy import text
+
+from backend.protocol_rpc.exceptions import StorageQuotaExceeded
+
+logger = logging.getLogger(__name__)
+
+# Snapshot stores accepted + finalized slots; live current_state is one slot.
+_SNAPSHOT_SLOT_FACTOR = 2
+_REDIS_KEY_TTL_SECONDS = 48 * 3600
+_STORAGE_HELP = (
+    "The public Studio is a shared sandbox with a per-contract daily "
+    "snapshot storage budget. For production-volume workloads, run a "
+    "self-hosted instance."
+)
+
+_redis_client: Any = None
+_redis_init_attempted = False
+
+_CONSUME_SCRIPT = """
+local used = tonumber(redis.call('GET', KEYS[1]) or '0')
+if redis.call('EXISTS', KEYS[2]) == 1 then
+    return {1, used, 0}
+end
+local cost = tonumber(ARGV[1])
+local limit = tonumber(ARGV[2])
+if used > 0 and used + cost > limit then
+    return {0, used, 0}
+end
+local new_used = redis.call('INCRBY', KEYS[1], cost)
+redis.call('EXPIRE', KEYS[1], tonumber(ARGV[3]))
+redis.call('SET', KEYS[2], cost, 'EX', tonumber(ARGV[3]))
+return {1, new_used, 1}
+"""
+
+_RELEASE_SCRIPT = """
+local cost = tonumber(redis.call('GET', KEYS[2]) or '0')
+if cost == 0 then
+    return 0
+end
+redis.call('DEL', KEYS[2])
+local used = tonumber(redis.call('GET', KEYS[1]) or '0')
+local new_used = used - cost
+if new_used <= 0 then
+    redis.call('DEL', KEYS[1])
+    return 0
+end
+redis.call('DECRBY', KEYS[1], cost)
+return new_used
+"""
+
+
+@dataclass(frozen=True)
+class StorageQuotaReservation:
+    redis_client: Any
+    quota_key: str
+    reservation_key: str
+    owned: bool
+
+    def release(self) -> None:
+        """Refund this request's reservation after admission fails."""
+        if not self.owned:
+            return
+        try:
+            self.redis_client.eval(
+                _RELEASE_SCRIPT, 2, self.quota_key, self.reservation_key
+            )
+        except Exception:
+            logger.exception("Failed to refund contract storage quota reservation")
+
+
+def reset_storage_quota_client_for_tests() -> None:
+    global _redis_client, _redis_init_attempted
+    _redis_client = None
+    _redis_init_attempted = False
+
+
+def _parse_optional_positive_int(env_name: str) -> int | None:
+    raw = os.environ.get(env_name)
+    if raw is None or raw.strip() == "":
+        return None
+    try:
+        parsed = int(raw)
+    except (ValueError, TypeError):
+        return None
+    return parsed if parsed > 0 else None
+
+
+def daily_byte_limit() -> int | None:
+    return _parse_optional_positive_int("MAX_CONTRACT_SNAPSHOT_BYTES_PER_DAY")
+
+
+def snapshot_cost_bytes(live_state_column_size: int | None) -> int:
+    if not live_state_column_size:
+        return 0
+    return live_state_column_size * _SNAPSHOT_SLOT_FACTOR
+
+
+def redis_key(address: str, day: str | None = None) -> str:
+    day_token = day or datetime.now(timezone.utc).strftime("%Y%m%d")
+    return f"studio:contract-storage:{address}:{day_token}"
+
+
+def reservation_key(address: str, transaction_hash: str, day: str | None = None) -> str:
+    return f"{redis_key(address, day)}:tx:{transaction_hash}"
+
+
+def _get_redis():
+    global _redis_client, _redis_init_attempted
+    if _redis_init_attempted:
+        return _redis_client
+    _redis_init_attempted = True
+    url = os.environ.get("REDIS_URL")
+    if not url:
+        logger.warning(
+            "MAX_CONTRACT_SNAPSHOT_BYTES_PER_DAY is set but REDIS_URL is empty; "
+            "storage quota check skipped"
+        )
+        return None
+    try:
+        import redis
+
+        _redis_client = redis.from_url(url, decode_responses=True)
+    except Exception:
+        logger.exception("Failed to connect Redis for contract storage quota")
+        _redis_client = None
+    return _redis_client
+
+
+def live_state_column_size(session, address: str) -> int | None:
+    """Return pg_column_size(data) without hydrating JSONB. None if missing."""
+    try:
+        normalized = to_checksum_address(address)
+    except Exception:
+        normalized = address
+    return session.execute(
+        text("SELECT pg_column_size(data) FROM current_state WHERE id = :addr"),
+        {"addr": normalized},
+    ).scalar()
+
+
+def try_consume_daily_bytes(
+    redis_client,
+    address: str,
+    cost: int,
+    limit: int,
+    transaction_hash: str,
+) -> tuple[bool, int, StorageQuotaReservation | None]:
+    """Atomically reserve `cost` against `limit`.
+
+    First write of the UTC day always succeeds. The transaction marker makes
+    concurrent submissions of the same hash idempotent.
+    """
+    quota_key = redis_key(address)
+    tx_key = reservation_key(address, transaction_hash)
+    ok, used, owned = redis_client.eval(
+        _CONSUME_SCRIPT,
+        2,
+        quota_key,
+        tx_key,
+        cost,
+        limit,
+        _REDIS_KEY_TTL_SECONDS,
+    )
+    reservation = StorageQuotaReservation(redis_client, quota_key, tx_key, bool(owned))
+    return bool(ok), int(used), reservation if ok else None
+
+
+def enforce_contract_storage_quota(
+    session, to_address: str | None, transaction_hash: str
+) -> StorageQuotaReservation | None:
+    """Raise StorageQuotaExceeded when the contract is over its daily budget."""
+    limit = daily_byte_limit()
+    if limit is None or to_address is None:
+        return
+
+    try:
+        to_address = to_checksum_address(to_address)
+    except Exception:
+        pass
+
+    size = live_state_column_size(session, to_address)
+    cost = snapshot_cost_bytes(size)
+    if cost <= 0:
+        return
+
+    redis_client = _get_redis()
+    if redis_client is None:
+        return
+
+    try:
+        ok, used, reservation = try_consume_daily_bytes(
+            redis_client, to_address, cost, limit, transaction_hash
+        )
+    except Exception:
+        logger.exception(
+            "Contract storage quota Redis error; failing open for %s", to_address
+        )
+        return
+
+    if ok:
+        return reservation
+
+    raise StorageQuotaExceeded(
+        message=(
+            f"Contract {to_address} exceeded the daily snapshot storage "
+            f"budget ({used} of {limit} bytes used; this write costs {cost}). "
+            f"{_STORAGE_HELP}"
+        ),
+        data={
+            "scope": "contract_storage",
+            "address": to_address,
+            "used": used,
+            "limit": limit,
+            "cost": cost,
+        },
+    )

--- a/backend/protocol_rpc/endpoints.py
+++ b/backend/protocol_rpc/endpoints.py
@@ -13,6 +13,10 @@ from backend.protocol_rpc.exceptions import (
     NotFoundError,
     QueueDepthExceeded,
 )
+from backend.protocol_rpc.contract_storage_quota import (
+    enforce_contract_storage_quota,
+    live_state_column_size,
+)
 from sqlalchemy import Table, text
 from sqlalchemy.orm import Session
 import backend.validators as validators
@@ -252,7 +256,7 @@ _MAX_PENDING_PER_SENDER = _parse_optional_positive_int("MAX_PENDING_PER_SENDER_D
 _QUEUE_DEPTH_HELP = (
     "The public Studio is a shared sandbox with per-contract and "
     "per-sender PENDING transaction caps. For production-volume "
-    "workloads, run a self-hosted instance or use Rally."
+    "workloads, run a self-hosted instance."
 )
 
 
@@ -2292,7 +2296,9 @@ def send_raw_transaction(
                     to_address, f"Invalid address to_address: {to_address}"
                 )
 
-            if accounts_manager.get_account(to_address) is None:
+            # Size-only lookup: do not hydrate current_state.data (can be
+            # tens of MB) just to test existence.
+            if live_state_column_size(session, to_address) is None:
                 raise NotFoundError(
                     message="Contract not found",
                     data={"address": to_address},
@@ -2315,40 +2321,50 @@ def send_raw_transaction(
         # Skip duplicates (resubmission of an already-known hash is benign)
         # and SEND txs (faucet/transfer; not subject to per-contract pile-up
         # because to_address is a user account, not a contract).
+        storage_reservation = None
         if is_duplicate is None and genlayer_transaction.type != TransactionType.SEND:
             _enforce_pending_queue_caps(
                 transactions_processor=transactions_processor,
                 to_address=to_address,
                 from_address=from_address,
             )
+            if genlayer_transaction.type == TransactionType.RUN_CONTRACT:
+                storage_reservation = enforce_contract_storage_quota(
+                    session, to_address, transaction_hash
+                )
 
-        # Debit sender BEFORE insert. Mint on demand if insufficient (Studio sandbox).
-        # Skip for SEND (execute_transfer handles it) and duplicates.
-        if (
-            total_spend > 0
-            and from_address
-            and genlayer_transaction.type != TransactionType.SEND
-            and is_duplicate is None
-        ):
-            _sandbox_debit_sender(accounts_manager, from_address, total_spend)
+        try:
+            # Debit sender BEFORE insert. Mint on demand if insufficient (Studio sandbox).
+            # Skip for SEND (execute_transfer handles it) and duplicates.
+            if (
+                total_spend > 0
+                and from_address
+                and genlayer_transaction.type != TransactionType.SEND
+                and is_duplicate is None
+            ):
+                _sandbox_debit_sender(accounts_manager, from_address, total_spend)
 
-        # Insert transaction into the database
-        transactions_processor.insert_transaction(
-            genlayer_transaction.from_address,
-            to_address,
-            transaction_data,
-            value,
-            genlayer_transaction.type.value,
-            nonce,
-            leader_only,
-            genlayer_transaction.max_rotations,
-            None,
-            transaction_hash,
-            genlayer_transaction.num_of_initial_validators,
-            sim_config,
-            None,  # triggered_on
-            execution_mode,
-        )
+            # Insert transaction into the database
+            transactions_processor.insert_transaction(
+                genlayer_transaction.from_address,
+                to_address,
+                transaction_data,
+                value,
+                genlayer_transaction.type.value,
+                nonce,
+                leader_only,
+                genlayer_transaction.max_rotations,
+                None,
+                transaction_hash,
+                genlayer_transaction.num_of_initial_validators,
+                sim_config,
+                None,  # triggered_on
+                execution_mode,
+            )
+        except Exception:
+            if storage_reservation is not None:
+                storage_reservation.release()
+            raise
 
         # Post-insert verification: ensure the transaction is visible immediately
         try:

--- a/backend/protocol_rpc/exceptions.py
+++ b/backend/protocol_rpc/exceptions.py
@@ -120,3 +120,17 @@ class QueueDepthExceeded(JSONRPCError):
         self, message: str = "Queue depth exceeded", data: Optional[Any] = None
     ):
         super().__init__(code=-32030, message=message, data=data)
+
+
+class StorageQuotaExceeded(JSONRPCError):
+    """Per-contract daily snapshot-byte budget reached.
+
+    Distinct from RateLimitExceeded (RPC frequency) and QueueDepthExceeded
+    (in-flight PENDING count). This one meters estimated contract_snapshot
+    bytes a single contract can persist per UTC day.
+    """
+
+    def __init__(
+        self, message: str = "Storage quota exceeded", data: Optional[Any] = None
+    ):
+        super().__init__(code=-32031, message=message, data=data)

--- a/backend/validators/__init__.py
+++ b/backend/validators/__init__.py
@@ -252,6 +252,14 @@ class Manager:
                     "Validators manager snapshot not initialized. "
                     "Ensure restart() was called successfully."
                 )
+            # Wipe+recreate can leave the cache empty after the last delete's
+            # LLM restart while new validators are already committed. Create
+            # events sit behind those restarts; re-read before freezing a
+            # 0-node copy for exec.
+            if not self._cached_snapshot.nodes:
+                fresh = await self._get_snap_from_registry()
+                if fresh.nodes:
+                    await self._change_providers_from_snapshot_locked(fresh)
             snap = deepcopy(self._cached_snapshot)
         yield snap
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -143,6 +143,7 @@ services:
       # deployments to keep one heavy user from filling the queue.
       - MAX_PENDING_PER_CONTRACT_DEFAULT=${MAX_PENDING_PER_CONTRACT_DEFAULT:-}
       - MAX_PENDING_PER_SENDER_DEFAULT=${MAX_PENDING_PER_SENDER_DEFAULT:-}
+      - MAX_CONTRACT_SNAPSHOT_BYTES_PER_DAY=${MAX_CONTRACT_SNAPSHOT_BYTES_PER_DAY:-}
     ports:
       - "${RPCHOSTPORT:-4000}:${RPCPORT:-4000}"
     expose:

--- a/tests/db-sqlalchemy/test_contract_storage_quota.py
+++ b/tests/db-sqlalchemy/test_contract_storage_quota.py
@@ -42,7 +42,7 @@ def test_live_state_column_size_does_not_require_python_hydrate(engine: Engine):
         size = live_state_column_size(session, CONTRACT)
         assert size is not None
         assert size > 0
-        assert snapshot_cost_bytes(size) == size * 2
+        assert snapshot_cost_bytes(size) == size
 
 
 def test_quota_disabled_when_env_unset(engine: Engine, monkeypatch):

--- a/tests/db-sqlalchemy/test_contract_storage_quota.py
+++ b/tests/db-sqlalchemy/test_contract_storage_quota.py
@@ -1,0 +1,92 @@
+"""DB tests for live-state size lookup and storage quota admission."""
+
+import pytest
+from sqlalchemy import Engine, text
+from sqlalchemy.orm import sessionmaker
+
+from backend.protocol_rpc.contract_storage_quota import (
+    enforce_contract_storage_quota,
+    live_state_column_size,
+    snapshot_cost_bytes,
+)
+from eth_utils import to_checksum_address
+
+from backend.protocol_rpc.exceptions import StorageQuotaExceeded
+
+CONTRACT = to_checksum_address("0x" + "ab" * 20)
+
+
+def _seed_state(session, address: str, payload: dict) -> None:
+    session.execute(
+        text(
+            """
+            INSERT INTO current_state (id, data, balance)
+            VALUES (:id, CAST(:data AS jsonb), 0)
+            """
+        ),
+        {"id": address, "data": __import__("json").dumps(payload)},
+    )
+    session.commit()
+
+
+def test_missing_contract_returns_none(engine: Engine):
+    Session_ = sessionmaker(bind=engine, expire_on_commit=False)
+    with Session_() as session:
+        assert live_state_column_size(session, CONTRACT) is None
+
+
+def test_live_state_column_size_does_not_require_python_hydrate(engine: Engine):
+    Session_ = sessionmaker(bind=engine, expire_on_commit=False)
+    with Session_() as session:
+        _seed_state(session, CONTRACT, {"k": "v" * 1000})
+        size = live_state_column_size(session, CONTRACT)
+        assert size is not None
+        assert size > 0
+        assert snapshot_cost_bytes(size) == size * 2
+
+
+def test_quota_disabled_when_env_unset(engine: Engine, monkeypatch):
+    monkeypatch.delenv("MAX_CONTRACT_SNAPSHOT_BYTES_PER_DAY", raising=False)
+    Session_ = sessionmaker(bind=engine, expire_on_commit=False)
+    with Session_() as session:
+        _seed_state(session, CONTRACT, {"blob": "x" * 5000})
+        enforce_contract_storage_quota(session, CONTRACT, "disabled-tx")
+
+
+def test_quota_rejects_after_first_write(engine: Engine, monkeypatch):
+    monkeypatch.setenv("MAX_CONTRACT_SNAPSHOT_BYTES_PER_DAY", "50")
+    Session_ = sessionmaker(bind=engine, expire_on_commit=False)
+
+    class MemoryRedis:
+        def __init__(self):
+            self.store = {}
+
+        def eval(self, script, numkeys, quota_key, reservation_key, *args):
+            if args:
+                cost, limit, _ttl = map(int, args)
+                used = self.store.get(quota_key, 0)
+                if reservation_key in self.store:
+                    return [1, used, 0]
+                if used > 0 and used + cost > limit:
+                    return [0, used, 0]
+                self.store[quota_key] = used + cost
+                self.store[reservation_key] = cost
+                return [1, used + cost, 1]
+            cost = self.store.pop(reservation_key, 0)
+            self.store[quota_key] = max(0, self.store.get(quota_key, 0) - cost)
+            return self.store[quota_key]
+
+    redis = MemoryRedis()
+    monkeypatch.setattr(
+        "backend.protocol_rpc.contract_storage_quota._get_redis",
+        lambda: redis,
+    )
+    with Session_() as session:
+        _seed_state(session, CONTRACT, {"blob": "x" * 5000})
+        enforce_contract_storage_quota(session, CONTRACT, "tx-1")
+        with pytest.raises(StorageQuotaExceeded) as exc_info:
+            enforce_contract_storage_quota(session, CONTRACT, "tx-2")
+        assert exc_info.value.code == -32031
+        assert exc_info.value.data["scope"] == "contract_storage"
+        assert exc_info.value.data["address"] == CONTRACT
+        assert "self-hosted" in exc_info.value.message.lower()

--- a/tests/db-sqlalchemy/transactions_processor_test.py
+++ b/tests/db-sqlalchemy/transactions_processor_test.py
@@ -710,3 +710,18 @@ class TestRotationCount:
             {"h": tx_hash},
         ).one()
         assert row[0] == 0
+
+    def test_reset_transaction_rotation_count_commits(self, tp, session):
+        tx_hash = _make_tx(tp)
+        tp.increase_transaction_rotation_count(tx_hash)
+        tp.reset_transaction_rotation_count(tx_hash)
+
+        other = session.get_bind().connect()
+        try:
+            row = other.execute(
+                text("SELECT rotation_count FROM transactions WHERE hash = :h"),
+                {"h": tx_hash},
+            ).one()
+        finally:
+            other.close()
+        assert row[0] == 0

--- a/tests/unit/test_contract_storage_quota.py
+++ b/tests/unit/test_contract_storage_quota.py
@@ -1,0 +1,118 @@
+"""Unit tests for per-contract daily snapshot storage quota."""
+
+from backend.protocol_rpc.contract_storage_quota import (
+    snapshot_cost_bytes,
+    try_consume_daily_bytes,
+    redis_key,
+)
+from backend.protocol_rpc.exceptions import StorageQuotaExceeded
+
+
+class MemoryRedis:
+    def __init__(self):
+        self.store: dict[str, int] = {}
+
+    def eval(self, script, numkeys, quota_key, reservation_key, *args):
+        if args:
+            cost, limit, _ttl = map(int, args)
+            used = self.store.get(quota_key, 0)
+            if reservation_key in self.store:
+                return [1, used, 0]
+            if used > 0 and used + cost > limit:
+                return [0, used, 0]
+            self.store[quota_key] = used + cost
+            self.store[reservation_key] = cost
+            return [1, used + cost, 1]
+        cost = self.store.pop(reservation_key, 0)
+        self.store[quota_key] = max(0, self.store.get(quota_key, 0) - cost)
+        return self.store[quota_key]
+
+
+def test_snapshot_cost_is_two_slots():
+    assert snapshot_cost_bytes(None) == 0
+    assert snapshot_cost_bytes(0) == 0
+    assert snapshot_cost_bytes(10) == 20
+
+
+def test_first_write_of_day_always_allowed_even_if_over_limit():
+    redis = MemoryRedis()
+    ok, used, _ = try_consume_daily_bytes(
+        redis, "0xabc", cost=500, limit=100, transaction_hash="first-tx"
+    )
+    assert ok is True
+    assert used == 500
+
+
+def test_second_write_rejected_when_budget_exhausted():
+    redis = MemoryRedis()
+    try_consume_daily_bytes(redis, "0xabc", cost=80, limit=100, transaction_hash="tx1")
+    ok, used, _ = try_consume_daily_bytes(
+        redis, "0xabc", cost=80, limit=100, transaction_hash="tx2"
+    )
+    assert ok is False
+    assert used == 80
+
+
+def test_writes_allowed_until_budget_exhausted():
+    redis = MemoryRedis()
+    ok1, used1, _ = try_consume_daily_bytes(
+        redis, "0xabc", cost=40, limit=100, transaction_hash="tx1"
+    )
+    ok2, used2, _ = try_consume_daily_bytes(
+        redis, "0xabc", cost=40, limit=100, transaction_hash="tx2"
+    )
+    ok3, used3, _ = try_consume_daily_bytes(
+        redis, "0xabc", cost=40, limit=100, transaction_hash="tx3"
+    )
+    assert ok1 and ok2
+    assert used1 == 40
+    assert used2 == 80
+    assert ok3 is False
+    assert used3 == 80
+
+
+def test_separate_contracts_have_independent_budgets():
+    redis = MemoryRedis()
+    try_consume_daily_bytes(redis, "0xaaa", cost=90, limit=100, transaction_hash="tx-a")
+    ok, used, _ = try_consume_daily_bytes(
+        redis, "0xbbb", cost=90, limit=100, transaction_hash="tx-b"
+    )
+    assert ok is True
+    assert used == 90
+
+
+def test_duplicate_transaction_hash_is_only_charged_once():
+    redis = MemoryRedis()
+    _, first_used, first = try_consume_daily_bytes(
+        redis, "0xabc", cost=40, limit=100, transaction_hash="same-tx"
+    )
+    _, second_used, second = try_consume_daily_bytes(
+        redis, "0xabc", cost=40, limit=100, transaction_hash="same-tx"
+    )
+    assert first_used == second_used == 40
+    assert first is not None and first.owned is True
+    assert second is not None and second.owned is False
+
+
+def test_failed_admission_can_refund_owned_reservation():
+    redis = MemoryRedis()
+    _, _, reservation = try_consume_daily_bytes(
+        redis, "0xabc", cost=80, limit=100, transaction_hash="failed-tx"
+    )
+    assert reservation is not None
+    reservation.release()
+    ok, used, _ = try_consume_daily_bytes(
+        redis, "0xabc", cost=80, limit=100, transaction_hash="replacement-tx"
+    )
+    assert ok is True
+    assert used == 80
+
+
+def test_redis_key_includes_utc_day():
+    assert redis_key("0xAb", day="20260813") == "studio:contract-storage:0xAb:20260813"
+
+
+def test_storage_quota_error_code():
+    err = StorageQuotaExceeded(message="nope", data={"scope": "contract_storage"})
+    assert err.code == -32031
+    assert err.data["scope"] == "contract_storage"

--- a/tests/unit/test_contract_storage_quota.py
+++ b/tests/unit/test_contract_storage_quota.py
@@ -28,10 +28,10 @@ class MemoryRedis:
         return self.store[quota_key]
 
 
-def test_snapshot_cost_is_two_slots():
+def test_snapshot_cost_matches_complete_live_state_row():
     assert snapshot_cost_bytes(None) == 0
     assert snapshot_cost_bytes(0) == 0
-    assert snapshot_cost_bytes(10) == 20
+    assert snapshot_cost_bytes(10) == 10
 
 
 def test_first_write_of_day_always_allowed_even_if_over_limit():

--- a/tests/unit/test_validator_manager_snapshot.py
+++ b/tests/unit/test_validator_manager_snapshot.py
@@ -1,0 +1,82 @@
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+
+from backend.validators import Manager, Snapshot, SingleValidatorSnapshot
+from tests.unit.test_fallback_validator_model_host_data import create_test_validator
+
+
+def _make_manager() -> Manager:
+    genvm = Mock()
+    genvm.stop_module = AsyncMock()
+    genvm.start_module = AsyncMock()
+    genvm.llm_config_base = {}
+    manager = Manager(Mock(), genvm)
+    return manager
+
+
+def _registry_validator(address: str = "0xabc") -> dict:
+    return {
+        "address": address,
+        "stake": 8,
+        "provider": "openrouter",
+        "model": "test-model",
+        "config": {"temperature": 0.75},
+        "plugin": "openai-compatible",
+        "plugin_config": {
+            "api_key_env_var": "OPENROUTERAPIKEY",
+            "api_url": "https://openrouter.ai/api",
+            "mock_response": {},
+        },
+    }
+
+
+@pytest.mark.asyncio
+async def test_snapshot_reloads_when_cache_empty_but_registry_has_validators():
+    manager = _make_manager()
+    manager._cached_snapshot = Snapshot(nodes=[])
+    manager.registry.get_all_validators = Mock(return_value=[_registry_validator()])
+
+    async with manager.snapshot() as snap:
+        assert len(snap.nodes) == 1
+        assert snap.nodes[0].validator.address == "0xabc"
+
+    manager.genvm_manager.start_module.assert_awaited()
+
+
+@pytest.mark.asyncio
+async def test_snapshot_stays_empty_when_registry_empty():
+    manager = _make_manager()
+    manager._cached_snapshot = Snapshot(nodes=[])
+    manager.registry.get_all_validators = Mock(return_value=[])
+
+    async with manager.snapshot() as snap:
+        assert snap.nodes == []
+
+    manager.genvm_manager.start_module.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_snapshot_uses_cached_nodes_without_refresh():
+    manager = _make_manager()
+    validator = create_test_validator("0xcached", "openai", "gpt-4o")
+    manager._cached_snapshot = Snapshot(
+        nodes=[SingleValidatorSnapshot(validator, {"studio_llm_id": "node-0xcached"})]
+    )
+    manager.registry.get_all_validators = Mock()
+
+    async with manager.snapshot() as snap:
+        assert len(snap.nodes) == 1
+        assert snap.nodes[0].validator.address == "0xcached"
+
+    manager.registry.get_all_validators.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_snapshot_raises_if_not_initialized():
+    manager = _make_manager()
+    manager._cached_snapshot = None
+
+    with pytest.raises(RuntimeError, match="not initialized"):
+        async with manager.snapshot():
+            pass


### PR DESCRIPTION
## Summary

- port the per-contract daily snapshot storage quota from #1726 to `v0.123-dev`
- include the actual snapshot-size accounting correction from #1728
- preserve the v0.123 transaction fee debit flow while ensuring quota reservations are released on transaction insertion failures

## Validation

- `13 passed` — `tests/unit/test_contract_storage_quota.py` and `tests/unit/test_validator_manager_snapshot.py`
- pre-commit hooks passed during both commits
- `git diff --check origin/v0.123-dev...HEAD` passed