### PR TITLE
fix: redact validator private keys from RPC

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,6 +16,7 @@ LOGCONFIG='dev'                   # dev/prod
 LOG_LEVEL='debug'                 # 'critical', 'error', 'warning', 'info', 'debug', 'trace'
 DISABLE_INFO_LOGS_ENDPOINTS='["ping", "eth_getTransactionByHash","gen_getContractSchema", "gen_getContractSchemaForCode", "net_version", "sim_getTransactionsForAddress", "sim_getConsensusContract", "eth_estimateGas", "eth_chainId", "eth_getBlockByNumber", "eth_gasPrice", "sim_getFinalityWindowTime"]'
 SHOW_VALIDATOR_PRIVATE_KEYS_IN_LOGS='false' # Set true only when debugging local validator signing.
+SHOW_VALIDATOR_PRIVATE_KEYS_IN_RPC='false'  # Set true only when inspecting validator signing data locally.
 
 ########################################
 # JsonRPC Server Configuration

--- a/backend/protocol_rpc/endpoints.py
+++ b/backend/protocol_rpc/endpoints.py
@@ -121,6 +121,40 @@ _gen_call_singleflight_tasks: dict[str, asyncio.Task[str]] = {}
 _gen_call_singleflight_lock = asyncio.Lock()
 
 
+def _show_validator_private_keys_in_rpc() -> bool:
+    return os.getenv("SHOW_VALIDATOR_PRIVATE_KEYS_IN_RPC", "").strip().lower() in {
+        "1",
+        "true",
+        "yes",
+        "on",
+    }
+
+
+def _is_private_key_field(key: Any) -> bool:
+    if not isinstance(key, str):
+        return False
+    normalized = key.replace("_", "").replace("-", "").lower()
+    return normalized == "privatekey" or normalized.endswith("privatekey")
+
+
+def _sanitize_rpc_private_keys(value: Any) -> Any:
+    """Return RPC data with private-key fields removed unless explicitly enabled."""
+    if _show_validator_private_keys_in_rpc():
+        return value
+
+    if isinstance(value, dict):
+        return {
+            key: _sanitize_rpc_private_keys(item)
+            for key, item in value.items()
+            if not _is_private_key_field(key)
+        }
+    if isinstance(value, list):
+        return [_sanitize_rpc_private_keys(item) for item in value]
+    if isinstance(value, tuple):
+        return tuple(_sanitize_rpc_private_keys(item) for item in value)
+    return value
+
+
 def _check_rate_limit(address: str) -> None:
     """Reject if address exceeds rate limit. Prunes old entries."""
     now = time.monotonic()
@@ -1660,7 +1694,7 @@ def get_transaction_by_hash(
             message=f"Transaction {transaction_hash} not found",
             data={"hash": transaction_hash},
         )
-    return transaction
+    return _sanitize_rpc_private_keys(transaction)
 
 
 def get_studio_transaction_by_hash(
@@ -1677,7 +1711,7 @@ def get_studio_transaction_by_hash(
             message=f"Transaction {transaction_hash} not found",
             data={"hash": transaction_hash},
         )
-    return transaction
+    return _sanitize_rpc_private_keys(transaction)
 
 
 def get_transaction_status(
@@ -2411,8 +2445,10 @@ def get_transactions_for_address(
     if not accounts_manager.is_valid_address(address):
         raise InvalidAddressError(address)
 
-    return transactions_processor.get_transactions_for_address(
-        address, TransactionAddressFilter(filter)
+    return _sanitize_rpc_private_keys(
+        transactions_processor.get_transactions_for_address(
+            address, TransactionAddressFilter(filter)
+        )
     )
 
 
@@ -2497,7 +2533,7 @@ def get_block_by_number(
             "uncles": [],
         }
 
-    return block_details
+    return _sanitize_rpc_private_keys(block_details)
 
 
 def get_gas_price() -> str:
@@ -2617,7 +2653,7 @@ def get_block_by_hash(
     else:
         block_details["transactions"].append(block_hash)
 
-    return block_details
+    return _sanitize_rpc_private_keys(block_details)
 
 
 def get_contract(consensus_service: ConsensusService, contract_name: str) -> dict:
@@ -2754,7 +2790,7 @@ def update_transaction_status(
             code=-32602, message=f"Transaction not found: {transaction_hash}", data={}
         )
 
-    return updated_transaction
+    return _sanitize_rpc_private_keys(updated_transaction)
 
 
 def dev_get_pool_status(sqlalchemy_db) -> dict:

--- a/tests/unit/test_rpc_methods.py
+++ b/tests/unit/test_rpc_methods.py
@@ -52,6 +52,72 @@ def test_eth_get_transaction_by_hash_requests_no_contract_snapshot():
     )
 
 
+def test_eth_get_transaction_by_hash_redacts_private_keys_by_default(monkeypatch):
+    monkeypatch.delenv("SHOW_VALIDATOR_PRIVATE_KEYS_IN_RPC", raising=False)
+    transactions_processor = MagicMock()
+    stored_transaction = {
+        "hash": "0xabc",
+        "consensus_data": {
+            "leader_receipt": [
+                {
+                    "node_config": {
+                        "address": "0xvalidator",
+                        "private_key": "0xsecret",
+                    }
+                }
+            ],
+            "validators": [
+                {
+                    "node_config": {
+                        "address": "0xvalidator2",
+                        "privateKey": "0xsecret2",
+                    }
+                }
+            ],
+        },
+    }
+    transactions_processor.get_transaction_by_hash.return_value = stored_transaction
+
+    result = endpoints.get_transaction_by_hash(
+        transactions_processor=transactions_processor,
+        transaction_hash="0xabc",
+    )
+
+    leader_config = result["consensus_data"]["leader_receipt"][0]["node_config"]
+    validator_config = result["consensus_data"]["validators"][0]["node_config"]
+    assert leader_config == {"address": "0xvalidator"}
+    assert validator_config == {"address": "0xvalidator2"}
+    assert (
+        stored_transaction["consensus_data"]["leader_receipt"][0]["node_config"][
+            "private_key"
+        ]
+        == "0xsecret"
+    )
+
+
+def test_eth_get_transaction_by_hash_can_show_private_keys_for_local_debug(
+    monkeypatch,
+):
+    monkeypatch.setenv("SHOW_VALIDATOR_PRIVATE_KEYS_IN_RPC", "true")
+    transactions_processor = MagicMock()
+    stored_transaction = {
+        "hash": "0xabc",
+        "consensus_data": {
+            "leader_receipt": [
+                {"node_config": {"address": "0xvalidator", "private_key": "0xsecret"}}
+            ]
+        },
+    }
+    transactions_processor.get_transaction_by_hash.return_value = stored_transaction
+
+    result = endpoints.get_transaction_by_hash(
+        transactions_processor=transactions_processor,
+        transaction_hash="0xabc",
+    )
+
+    assert result == stored_transaction
+
+
 def test_eth_transaction_receipt_requests_no_contract_snapshot():
     transactions_processor = MagicMock()
     transactions_processor.get_transaction_by_hash.return_value = {


### PR DESCRIPTION
## What changed

- port the RPC private-key redaction from the v0.121 release line
- hide private-key fields from public transaction RPC payloads by default
- preserve stored/internal receipt data
- allow explicit local inspection with `SHOW_VALIDATOR_PRIVATE_KEYS_IN_RPC=true`

## Validation

- `pytest -q tests/unit/test_rpc_methods.py tests/unit/protocol_rpc/test_log_event_redaction.py` (14 passed)
- Black check passed
- `git diff --check` passed
- [plain full E2E matrix passed](https://github.com/genlayerlabs/genlayer-e2e/actions/runs/31850358980)

## E2E note

An earlier parameterized run incorrectly forced the v0.5 track, pairing this v0.123-dev Studio code with GenVM v0.2.11 and failing its unsupported `/ws` handshake. The authoritative plain `/run-e2e` invocation automatically selected the v0.6 train, built the compatible GenVM runtime, passed Studio warmup, and completed the full matrix successfully.
