### PR TITLE
fix(vrf): raise NoValidatorsAvailableError when total_stake is zero

### DIFF
--- a/backend/consensus/vrf.py
+++ b/backend/consensus/vrf.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 import numpy as np
-from backend.consensus.base import DEFAULT_VALIDATORS_COUNT
+from backend.consensus.base import DEFAULT_VALIDATORS_COUNT, NoValidatorsAvailableError
 
 
 def get_validators_for_transaction(
@@ -18,6 +18,10 @@ def get_validators_for_transaction(
     num_validators = min(num_validators, len(nodes))
 
     total_stake = sum(validator["stake"] for validator in nodes)
+    if total_stake == 0:
+        raise NoValidatorsAvailableError(
+            "Cannot select validators: all validators have zero stake."
+        )
     probabilities = [validator["stake"] / total_stake for validator in nodes]
 
     selected_validators = rng.choice(

--- a/tests/unit/test_vrf.py
+++ b/tests/unit/test_vrf.py
@@ -70,7 +70,7 @@ def test_get_validators_for_transaction_3():
     assert validators == [{"stake": 3}, {"stake": 2}, {"stake": 1}]
 
 
-def test_get_validators_for_transaction_zero_stake_raises():
+def test_get_validators_for_transaction_zero_stake_raises() -> None:
     """
     Regression test for #1732: ZeroDivisionError when all validators have stake=0.
     get_validators_for_transaction must raise NoValidatorsAvailableError instead of

--- a/tests/unit/test_vrf.py
+++ b/tests/unit/test_vrf.py
@@ -1,4 +1,6 @@
+import pytest
 from backend.consensus.vrf import get_validators_for_transaction
+from backend.consensus.base import NoValidatorsAvailableError
 from unittest.mock import Mock
 
 
@@ -66,3 +68,14 @@ def test_get_validators_for_transaction_3():
 
     rng.choice.assert_called_once()
     assert validators == [{"stake": 3}, {"stake": 2}, {"stake": 1}]
+
+
+def test_get_validators_for_transaction_zero_stake_raises():
+    """
+    Regression test for #1732: ZeroDivisionError when all validators have stake=0.
+    get_validators_for_transaction must raise NoValidatorsAvailableError instead of
+    crashing with ZeroDivisionError.
+    """
+    nodes = [{"stake": 0}, {"stake": 0}, {"stake": 0}]
+    with pytest.raises(NoValidatorsAvailableError, match="zero stake"):
+        get_validators_for_transaction(nodes, 2)


### PR DESCRIPTION
Fixes #1732

## Summary
`get_validators_for_transaction` crashed with `ZeroDivisionError` when all validators had `stake=0`. Added a guard before the probability list comprehension that raises `NoValidatorsAvailableError` (already used elsewhere in the consensus layer).

## Changes
- `backend/consensus/vrf.py` raises `NoValidatorsAvailableError` when `total_stake == 0`
- `tests/unit/test_vrf.py` regression test added

## Test plan
- [ ] `pytest tests/unit/test_vrf.py` passes including new regression test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validator selection when no available validators have stake.
  * Displays a clear “zero stake” error instead of failing with an unexpected calculation error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->