### PR TITLE
Fix malformed Docker Compose command in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -88,7 +88,7 @@ Have ideas for new features or use cases? We're eager to hear them! But first:
 - **3.2. Run the frontend in dev mode**: to run the frontend separately from the backend and with hot reload enabled, first launch the backend without the frontend:
 
    ```sh
-   $ docker compose upjsonrpc webrequest ollama database-migration postgres
+   $ docker compose up jsonrpc webrequest ollama database-migration postgres
    ```
    Then launch the frontend in dev mode:
    ```sh


### PR DESCRIPTION
## What

Fix the malformed Docker Compose command in `CONTRIBUTING.md` by adding the missing space between `up` and `jsonrpc`.

##Why

The command should use up jsonrpc, as the jsonrpc service is defined in docker-compose.yml.

A separate issue was not created since this is a small documentation fix.

## Testing done

Verified the `jsonrpc` service is defined in `docker-compose.yml` and confirmed the corrected command follows the expected Docker Compose syntax.
