### PR TITLE
feat(rate-limit): accept API keys in the URL path

### DIFF
--- a/backend/protocol_rpc/api_key_redaction.py
+++ b/backend/protocol_rpc/api_key_redaction.py
@@ -1,0 +1,83 @@
+"""Keep path-supplied API keys out of logs and error reports.
+
+API keys can be passed as a path segment (`/api/glk_...`) because the EVM
+toolchain only accepts a URL. The cost of that convenience is that the key
+travels somewhere URLs habitually get written down: uvicorn's access log,
+Sentry events and traces, proxy logs, browser history.
+
+We cannot do anything about logs outside this process, but anything this
+process emits is ours to scrub. Without that, enabling path keys would be a
+downgrade on the header-only design rather than an improvement — a key in
+CloudWatch or in a third-party error tracker is a leaked key.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from typing import Any, Optional
+
+# Matches a full key (`glk_` + 64 hex) and also partial/malformed ones, so a
+# truncated or mistyped key still gets scrubbed rather than logged verbatim.
+_API_KEY_RE = re.compile(r"glk_[0-9a-fA-F]{4,}")
+
+REDACTED = "glk_REDACTED"
+
+
+def redact_api_keys(value: str) -> str:
+    return _API_KEY_RE.sub(REDACTED, value)
+
+
+class ApiKeyRedactingFilter(logging.Filter):
+    """Scrubs API keys from log records, including uvicorn's access log.
+
+    uvicorn formats the request line via record.args rather than the message,
+    so both have to be rewritten.
+    """
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        if isinstance(record.msg, str) and "glk_" in record.msg:
+            record.msg = redact_api_keys(record.msg)
+
+        if record.args:
+            if isinstance(record.args, tuple):
+                record.args = tuple(
+                    redact_api_keys(a) if isinstance(a, str) else a for a in record.args
+                )
+            elif isinstance(record.args, dict):
+                record.args = {
+                    k: redact_api_keys(v) if isinstance(v, str) else v
+                    for k, v in record.args.items()
+                }
+        return True
+
+
+def install_log_redaction() -> None:
+    """Attach the filter to the loggers that render request paths."""
+    log_filter = ApiKeyRedactingFilter()
+    for name in ("uvicorn.access", "uvicorn.error", "gunicorn.access"):
+        logging.getLogger(name).addFilter(log_filter)
+    # Root catches application logs that interpolate a URL.
+    logging.getLogger().addFilter(log_filter)
+
+
+def _scrub(node: Any) -> Any:
+    if isinstance(node, str):
+        return redact_api_keys(node)
+    if isinstance(node, dict):
+        return {k: _scrub(v) for k, v in node.items()}
+    if isinstance(node, list):
+        return [_scrub(v) for v in node]
+    return node
+
+
+def scrub_sentry_event(event: dict, _hint: Optional[dict] = None) -> dict:
+    """before_send / before_send_transaction hook.
+
+    Sentry is configured with send_default_pii=True and full trace sampling, so
+    the request URL reaches it on every transaction, not just on errors. Scrub
+    the whole event rather than known fields — the URL is echoed into
+    `request.url`, the transaction name, breadcrumbs and span descriptions, and
+    missing one of those defeats the point.
+    """
+    return _scrub(event)

--- a/backend/protocol_rpc/fastapi_server.py
+++ b/backend/protocol_rpc/fastapi_server.py
@@ -13,6 +13,10 @@ from starlette.requests import ClientDisconnect
 # Load environment variables early so SENTRY_DSN is available for initialization
 load_dotenv()
 
+from backend.protocol_rpc.api_key_redaction import (
+    install_log_redaction,
+    scrub_sentry_event,
+)
 from backend.protocol_rpc.app_lifespan import RPCAppSettings, rpc_app_lifespan
 from backend.protocol_rpc.dependencies import (
     get_rpc_router_optional,
@@ -26,12 +30,19 @@ from backend.protocol_rpc.rpc_endpoint_manager import JSONRPCResponse
 from backend.protocol_rpc.websocket import GLOBAL_CHANNEL, websocket_handler
 
 
+install_log_redaction()
+
 SENTRY_DSN = os.getenv("SENTRY_DSN", None)
 if SENTRY_DSN:
     import sentry_sdk
 
     sentry_sdk.init(
         dsn=SENTRY_DSN,
+        # API keys can arrive as a path segment, and with send_default_pii and
+        # full trace sampling below, request URLs reach Sentry on *every*
+        # transaction. Scrub keys out before anything leaves the process.
+        before_send=scrub_sentry_event,
+        before_send_transaction=scrub_sentry_event,
         # Add data like request headers and IP for users,
         # see https://docs.sentry.io/platforms/python/data-management/data-collected/ for more info
         send_default_pii=True,
@@ -92,9 +103,22 @@ app.include_router(explorer_router)
 
 
 # JSON-RPC endpoint (supports single and batch requests)
+#
+# `/api/{api_key}` is the same endpoint with the key in the URL, matching how
+# every major RPC provider does it (Alchemy `/v2/<key>`, Infura `/v3/<key>`).
+# The EVM toolchain takes a single URL string and has nowhere to put a custom
+# header — MetaMask's "Add network" being the clearest case — so the header
+# form alone makes Studio unusable from those tools without a proxy in front.
+#
+# The key is consumed by RateLimitMiddleware before the request reaches here;
+# the path parameter exists only so the route matches. Anything that changes
+# which paths this route accepts must change `_is_rpc_path` in that middleware
+# to match, or the new paths become unlimited and unauthenticated.
 @app.post("/api")
+@app.post("/api/{api_key}")
 async def jsonrpc_endpoint(
     request: Request,
+    api_key: str | None = None,
     rpc_router: FastAPIRPCRouter | None = Depends(get_rpc_router_optional),
 ):
     """Main JSON-RPC endpoint with JSON-RPC 2.0 batch support."""

--- a/backend/protocol_rpc/rate_limit_middleware.py
+++ b/backend/protocol_rpc/rate_limit_middleware.py
@@ -17,6 +17,27 @@ from backend.protocol_rpc.rate_limiter import RateLimiterService, RateLimitUsage
 
 logger = logging.getLogger(__name__)
 
+# Keys may be supplied either as an X-API-Key header or as a single path
+# segment (`/api/glk_...`). The path form exists because the EVM toolchain —
+# MetaMask's "Add network", `foundry.toml`, `--rpc-url`, most viem/ethers
+# setups — accepts one URL string and offers no way to attach a header. Every
+# major RPC provider puts the key in the URL for that reason. Header-only
+# forced at least one integrator to plan a reverse proxy whose entire job was
+# turning a URL into a header.
+API_PATH = "/api"
+API_KEY_PREFIX = "glk_"
+
+
+def _rpc_path_segment(path: str) -> Optional[str]:
+    """Return the single path segment under /api/, or None if not that shape."""
+    if not path.startswith(API_PATH + "/"):
+        return None
+    segment = path[len(API_PATH) + 1 :]
+    if not segment or "/" in segment:
+        return None
+    return segment
+
+
 DEFAULT_TRUSTED_PROXY_CIDRS = (
     "127.0.0.0/8",
     "10.0.0.0/8",  # NOSONAR - RFC1918 private proxy range.
@@ -52,8 +73,11 @@ class RateLimitMiddleware(BaseHTTPMiddleware):
         self._trusted_proxy_networks = _load_trusted_proxy_networks()
 
     async def dispatch(self, request: Request, call_next) -> Response:
-        # Only rate-limit the JSON-RPC endpoint
-        if request.url.path != "/api" or request.method != "POST":
+        # Only rate-limit the JSON-RPC endpoint. This gate must cover every
+        # path the /api/{api_key} route can match, not just key-shaped ones —
+        # anything the route serves but this misses would be an unlimited,
+        # unauthenticated RPC endpoint.
+        if not self._is_rpc_path(request.url.path) or request.method != "POST":
             return await call_next(request)
 
         rate_limiter: Optional[RateLimiterService] = getattr(
@@ -62,7 +86,7 @@ class RateLimitMiddleware(BaseHTTPMiddleware):
         if rate_limiter is None or not rate_limiter.enabled:
             return await call_next(request)
 
-        api_key = request.headers.get("X-API-Key")
+        api_key = self._api_key(request)
         client_ip = self._client_ip(request)
         is_cheap_read = await self._is_cheap_read(request)
 
@@ -91,6 +115,29 @@ class RateLimitMiddleware(BaseHTTPMiddleware):
         if usage is not None:
             response.headers.update(usage.as_headers())
         return response
+
+    @staticmethod
+    def _is_rpc_path(path: str) -> bool:
+        return path == API_PATH or _rpc_path_segment(path) is not None
+
+    @staticmethod
+    def _api_key(request: Request) -> Optional[str]:
+        """Resolve the API key from the path, falling back to the header.
+
+        The path wins when both are present: it is what the caller typed into
+        their tool, whereas a header may have been injected by an intermediary
+        they cannot see.
+
+        Only `glk_`-prefixed segments count as keys. A segment of some other
+        shape is treated as no key at all rather than as a bad one, so it falls
+        through to anonymous limits instead of erroring — while a mistyped real
+        key still fails loudly as invalid, which is the confusing case worth
+        being loud about.
+        """
+        segment = _rpc_path_segment(request.url.path)
+        if segment and segment.startswith(API_KEY_PREFIX):
+            return segment
+        return request.headers.get("X-API-Key")
 
     async def _is_cheap_read(self, request: Request) -> bool:
         """Classify the request body, charging the stricter bucket on any doubt.

--- a/tests/unit/test_api_key_redaction.py
+++ b/tests/unit/test_api_key_redaction.py
@@ -1,0 +1,88 @@
+"""Unit tests for keeping path-supplied API keys out of logs and Sentry."""
+
+import logging
+
+
+from backend.protocol_rpc.api_key_redaction import (
+    REDACTED,
+    ApiKeyRedactingFilter,
+    redact_api_keys,
+    scrub_sentry_event,
+)
+
+FULL_KEY = "glk_" + "a1b2c3d4" * 8  # 64 hex chars
+
+
+class TestRedaction:
+    def test_full_key_is_redacted(self):
+        assert FULL_KEY not in redact_api_keys(f"POST /api/{FULL_KEY} 200")
+
+    def test_surrounding_text_is_preserved(self):
+        assert (
+            redact_api_keys(f"POST /api/{FULL_KEY} 200") == f"POST /api/{REDACTED} 200"
+        )
+
+    def test_partial_key_is_still_redacted(self):
+        """A truncated key is still a secret; do not log it verbatim."""
+        assert "glk_dead" not in redact_api_keys("path=/api/glk_deadbeef")
+
+    def test_non_key_text_untouched(self):
+        assert redact_api_keys("POST /api 200 OK") == "POST /api 200 OK"
+
+    def test_multiple_keys_in_one_line(self):
+        out = redact_api_keys(f"{FULL_KEY} and {FULL_KEY}")
+        assert FULL_KEY not in out
+        assert out.count(REDACTED) == 2
+
+
+class TestLogFilter:
+    def _record(self, msg, args=None):
+        return logging.LogRecord(
+            name="uvicorn.access",
+            level=logging.INFO,
+            pathname=__file__,
+            lineno=1,
+            msg=msg,
+            args=args,
+            exc_info=None,
+        )
+
+    def test_redacts_message(self):
+        record = self._record(f"GET /api/{FULL_KEY}")
+        ApiKeyRedactingFilter().filter(record)
+        assert FULL_KEY not in record.getMessage()
+
+    def test_redacts_args(self):
+        """uvicorn puts the request line in args, not msg — both must be scrubbed."""
+        record = self._record(
+            '%s - "%s %s" %d', ("1.2.3.4", "POST", f"/api/{FULL_KEY}", 200)
+        )
+        ApiKeyRedactingFilter().filter(record)
+        assert FULL_KEY not in record.getMessage()
+        assert REDACTED in record.getMessage()
+
+    def test_non_string_args_survive(self):
+        record = self._record("%s %d", ("ok", 200))
+        assert ApiKeyRedactingFilter().filter(record) is True
+        assert record.getMessage() == "ok 200"
+
+    def test_filter_never_drops_records(self):
+        assert ApiKeyRedactingFilter().filter(self._record("anything")) is True
+
+
+class TestSentryScrubbing:
+    def test_scrubs_nested_url(self):
+        event = {
+            "request": {"url": f"https://studio.genlayer.com/api/{FULL_KEY}"},
+            "transaction": f"POST /api/{FULL_KEY}",
+        }
+        out = scrub_sentry_event(event)
+        assert FULL_KEY not in str(out)
+
+    def test_scrubs_inside_lists(self):
+        event = {"breadcrumbs": [{"data": {"url": f"/api/{FULL_KEY}"}}]}
+        assert FULL_KEY not in str(scrub_sentry_event(event))
+
+    def test_preserves_structure_and_non_strings(self):
+        event = {"level": "error", "extra": {"count": 3, "ok": True, "tags": ["a"]}}
+        assert scrub_sentry_event(event) == event

--- a/tests/unit/test_rate_limit_middleware.py
+++ b/tests/unit/test_rate_limit_middleware.py
@@ -556,3 +556,105 @@ class TestRateLimitHeaders:
         assert response.status_code == 429
         assert response.headers["Retry-After"] == "60"
         assert "X-RateLimit-Limit" not in response.headers
+
+
+class TestPathBasedApiKey:
+    """Keys may ride in the URL, because MetaMask et al. cannot send headers."""
+
+    @pytest.mark.asyncio
+    async def test_key_read_from_path(self):
+        limiter = AsyncMock()
+        limiter.enabled = True
+        limiter.check_rate_limit = AsyncMock(return_value=None)
+        key = "glk_" + "a" * 64
+        request = _make_request(path=f"/api/{key}")
+        request.app.state.rate_limiter = limiter
+
+        middleware = RateLimitMiddleware(app=MagicMock())
+        await middleware.dispatch(request, _make_call_next())
+
+        assert limiter.check_rate_limit.call_args[0][0] == key
+
+    @pytest.mark.asyncio
+    async def test_path_key_wins_over_header(self):
+        limiter = AsyncMock()
+        limiter.enabled = True
+        limiter.check_rate_limit = AsyncMock(return_value=None)
+        path_key = "glk_" + "a" * 64
+        request = _make_request(path=f"/api/{path_key}", api_key="glk_" + "b" * 64)
+        request.app.state.rate_limiter = limiter
+
+        middleware = RateLimitMiddleware(app=MagicMock())
+        await middleware.dispatch(request, _make_call_next())
+
+        assert limiter.check_rate_limit.call_args[0][0] == path_key
+
+    @pytest.mark.asyncio
+    async def test_header_still_works_without_path_key(self):
+        limiter = AsyncMock()
+        limiter.enabled = True
+        limiter.check_rate_limit = AsyncMock(return_value=None)
+        request = _make_request(api_key="glk_headerkey")
+        request.app.state.rate_limiter = limiter
+
+        middleware = RateLimitMiddleware(app=MagicMock())
+        await middleware.dispatch(request, _make_call_next())
+
+        assert limiter.check_rate_limit.call_args[0][0] == "glk_headerkey"
+
+    @pytest.mark.asyncio
+    async def test_non_key_segment_falls_through_to_anonymous(self):
+        """A non-key path is not a bad key — it should not error, just be anon."""
+        limiter = AsyncMock()
+        limiter.enabled = True
+        limiter.check_rate_limit = AsyncMock(return_value=None)
+        request = _make_request(path="/api/explorer")
+        request.app.state.rate_limiter = limiter
+
+        middleware = RateLimitMiddleware(app=MagicMock())
+        await middleware.dispatch(request, _make_call_next())
+
+        assert limiter.check_rate_limit.call_args[0][0] is None
+
+    @pytest.mark.asyncio
+    async def test_mistyped_key_is_still_treated_as_a_key(self):
+        """So it fails loudly as invalid instead of silently dropping to anon."""
+        limiter = AsyncMock()
+        limiter.enabled = True
+        limiter.check_rate_limit = AsyncMock(return_value=None)
+        request = _make_request(path="/api/glk_tooshort")
+        request.app.state.rate_limiter = limiter
+
+        middleware = RateLimitMiddleware(app=MagicMock())
+        await middleware.dispatch(request, _make_call_next())
+
+        assert limiter.check_rate_limit.call_args[0][0] == "glk_tooshort"
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("path", ["/api", "/api/glk_abc", "/api/anything"])
+    async def test_every_path_the_route_matches_is_rate_limited(self, path):
+        """Any path the route serves but the gate misses would be unlimited."""
+        limiter = AsyncMock()
+        limiter.enabled = True
+        limiter.check_rate_limit = AsyncMock(return_value=None)
+        request = _make_request(path=path)
+        request.app.state.rate_limiter = limiter
+
+        middleware = RateLimitMiddleware(app=MagicMock())
+        await middleware.dispatch(request, _make_call_next())
+
+        limiter.check_rate_limit.assert_called_once()
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("path", ["/api/explorer/stats", "/health", "/api/a/b"])
+    async def test_deeper_paths_are_not_treated_as_rpc(self, path):
+        limiter = AsyncMock()
+        limiter.enabled = True
+        limiter.check_rate_limit = AsyncMock(return_value=None)
+        request = _make_request(path=path)
+        request.app.state.rate_limiter = limiter
+
+        middleware = RateLimitMiddleware(app=MagicMock())
+        await middleware.dispatch(request, _make_call_next())
+
+        limiter.check_rate_limit.assert_not_called()


### PR DESCRIPTION
# What

`POST /api/{api_key}` now routes to the same JSON-RPC handler, so a key can be supplied in the URL as well as via the `X-API-Key` header.

- Path wins when both are present; the header still works for server-side callers
- Only `glk_`-prefixed segments count as keys — any other segment falls through to anonymous
- New `backend/protocol_rpc/api_key_redaction.py` scrubs keys from logs and Sentry

# Why

The header-only design makes Studio unusable from most of the EVM toolchain. **MetaMask's "Add network" takes a URL and has no header field at all**, and the same is true of `foundry.toml`, `--rpc-url`, and most viem/ethers setups. Every major provider puts the key in the path for exactly this reason (Alchemy `/v2/<key>`, Infura `/v3/<key>`, QuickNode, Ankr).

This is not hypothetical. An integrator we issued a key to said they would have to stand up a backend proxy *"for them to be able to use it properly as most of the use comes from testing deployments through metamask"*. That proxy's entire job would be turning a URL into a header — and a shared proxy is also what pushes a team onto one shared key rather than one key per person, which loses per-user attribution and means one heavy user starves the rest.

Secondary: `X-API-Key` is not CORS-safelisted, so every browser call currently pays a preflight `OPTIONS` before the `POST`. The path form has no preflight.

# Testing done

- 823 unit tests pass (17 new)
- Verified against the real `app` object that both `/api` and `/api/{api_key}` register, and that `/api/explorer/*` is not shadowed: `POST /api/explorer/stats` correctly 405s to the explorer GET route rather than being captured by the path param, and `/api/a/b` 404s
- Redaction covers full keys, partial/truncated keys, uvicorn's args-based access line, and nested Sentry payloads (lists, dicts, transaction names)

# Decisions made

- **The middleware path gate covers every path the route can match**, not only key-shaped ones. A path the route serves but the gate misses would be an unlimited, unauthenticated RPC endpoint. A parametrised test pins that correspondence so the two cannot drift apart.
- **A mistyped key is still treated as a key**, so it fails loudly as `Invalid API key` rather than silently falling back to anonymous limits. Silent downgrade is the exact confusion an earlier user hit ("check the header is actually attached"). A segment that is not key-shaped at all is *not* an error — it is simply anonymous.
- **The path takes precedence over the header**, because it is what the caller typed rather than something an intermediary may have injected.
- **Log and Sentry scrubbing is part of this change, not a follow-up.** Keys in URLs get written down where headers are not, and two of those places were ours: `access_log=True` sends full paths to stdout, and Sentry runs with `send_default_pii=True` and `traces_sample_rate=1.0`, so request URLs leave the process on *every* transaction, not just errors. Shipping path keys without this would have been a downgrade on header-only rather than an improvement.
- The Sentry hook walks the entire event rather than known fields, because the URL is echoed into `request.url`, the transaction name, breadcrumbs and span descriptions — missing one defeats the purpose.

# Checks

- [x] I have tested this code
- [x] I have reviewed my own PR
- [ ] I have created an issue for this PR
- [x] I have set a descriptive PR title compliant with conventional commits

# Reviewing tips

- **`_is_rpc_path` and the route decorators must stay in lockstep.** That is the one place a mistake is dangerous rather than merely wrong.
- Worth sanity-checking the redaction regex against your own expectations: it deliberately matches `glk_` + 4-or-more hex so partial keys are caught too.
- Keys in URLs still land in logs we do not control — proxies, browser history, `Referer`. That is the accepted trade every provider makes, and it argues for making key rotation self-serve. Rotation is currently impossible on prod because `ADMIN_API_KEY` is unset there, which is worth fixing separately.
- Ordering note: `install_log_redaction()` runs before `sentry_sdk.init`, so the filter is in place before anything can log.

# User facing release notes

- API keys can now be passed in the URL — `https://studio.genlayer.com/api/<key>` — in addition to the `X-API-Key` header. This makes keyed access work from MetaMask, Foundry, and any other tool that accepts only an RPC URL.