### PR TITLE
fix(release): default optional GenVM build args

### DIFF
--- a/docker/Dockerfile.backend
+++ b/docker/Dockerfile.backend
@@ -21,10 +21,10 @@ RUN --mount=type=bind,source=backend,target=/studio/backend,ro \
 FROM nixos/nix:2.30.2 AS genvm-source-build
 
 ARG TARGETARCH
-ARG GENVM_SOURCE_MODE
-ARG GENVM_TAG
-ARG GENVM_REF
-ARG GENVM_EXECUTOR_VERSION_NAME
+ARG GENVM_SOURCE_MODE=""
+ARG GENVM_TAG=""
+ARG GENVM_REF=""
+ARG GENVM_EXECUTOR_VERSION_NAME=""
 # Nix `cores` for the GenVM build (0 = all). Cap on memory-constrained or
 # emulated builders where a full-parallel Rust build can OOM.
 ARG GENVM_BUILD_CORES=0
@@ -110,10 +110,10 @@ RUN --mount=type=secret,id=nix_netrc,target=/etc/nix/netrc,required=false \
 FROM ubuntu:24.04 AS genvm-runtime
 
 ARG TARGETARCH
-ARG GENVM_TAG
-ARG GENVM_REF
-ARG GENVM_SOURCE_MODE
-ARG GENVM_EXECUTOR_VERSION_NAME
+ARG GENVM_TAG=""
+ARG GENVM_REF=""
+ARG GENVM_SOURCE_MODE=""
+ARG GENVM_EXECUTOR_VERSION_NAME=""
 
 ENV GENVM_TAG=$GENVM_TAG
 ENV GENVM_REF=$GENVM_REF

--- a/tests/unit/test_shared_genvm_image_layout.py
+++ b/tests/unit/test_shared_genvm_image_layout.py
@@ -28,6 +28,15 @@ def _stage_body(dockerfile: str, stage: str) -> str:
     return re.split(r"^FROM\s+", body, maxsplit=1, flags=re.MULTILINE)[0]
 
 
+def _arg_defaults(stage: str) -> dict[str, str | None]:
+    return {
+        name: default
+        for name, default in re.findall(
+            r"^ARG\s+([A-Z][A-Z0-9_]*)(?:=(.*))?$", stage, re.MULTILINE
+        )
+    }
+
+
 def test_backend_services_share_one_genvm_parent():
     dockerfile = DOCKERFILE.read_text()
     stages = _stages(dockerfile)
@@ -63,6 +72,32 @@ def test_default_genvm_binding_selects_source_mode_in_both_build_stages():
         assert 'effective_ref="$(< /genvm-default-version)"' in stage
         assert '"$effective_ref" =~ ^.+:[0-9a-fA-F]{7,40}$' in stage
     assert 'GENVM_REF="$(< "$REPO_ROOT/third_party/genvm/version")"' in prepare_script
+
+
+def test_release_builds_define_optional_genvm_args_before_nounset_shells():
+    dockerfile = DOCKERFILE.read_text()
+    workflow = yaml.safe_load(
+        (
+            REPO_ROOT / ".github" / "workflows" / "docker-build-and-push-all.yml"
+        ).read_text()
+    )
+    optional_args = {
+        "GENVM_SOURCE_MODE",
+        "GENVM_TAG",
+        "GENVM_REF",
+        "GENVM_EXECUTOR_VERSION_NAME",
+    }
+
+    # The release workflow intentionally provides no GenVM build args. Every
+    # optional value read by a `set -u` RUN must therefore have a Dockerfile
+    # default, or a clean release build fails before selecting its pinned GenVM.
+    for job_name in ("jsonrpc", "consensus-worker"):
+        assert "build_args" not in workflow["jobs"][job_name]["with"]
+
+    for stage_name in ("genvm-source-build", "genvm-runtime"):
+        defaults = _arg_defaults(_stage_body(dockerfile, stage_name))
+        assert optional_args <= defaults.keys()
+        assert {defaults[name] for name in optional_args} == {'""'}
 
 
 def test_debug_target_installs_debugpy_with_the_pip_cache():


### PR DESCRIPTION
## Delivery context

No cross-repository dependency. This is the minimal follow-up to the failed Studio v0.123.0-rc.1 image release.

## Problem and outcome

Release workflow run 33697483511 passed no GenVM build overrides. The backend Dockerfile declared optional arguments without defaults and then read them under `set -u`, so both arm64 backend builds failed immediately with `GENVM_REF: unbound variable`.

Define every optional GenVM argument as explicitly empty in both acquisition stages. A normal release can now fall through to the checked-in GenVM pin, while explicit source, release, and prebuilt overrides retain their existing behavior.

The v0.123.0-rc.1 tag remains immutable. After this PR lands and native checks pass, the replacement release should use v0.123.0-rc.2; the failed workflow must not be rerun unchanged.

## Implementation and validation

- added explicit empty defaults for GENVM_SOURCE_MODE, GENVM_TAG, GENVM_REF, and GENVM_EXECUTOR_VERSION_NAME in both backend Docker stages
- added a fast parser regression that verifies JSON-RPC and worker release jobs pass no overrides and every optional argument is defaulted before nounset shells
- focused image-layout tests: 7 passed
- Docker BuildKit check for linux/arm64 target prod: passed
- Ruff, Black, branch policy, diff checks, and repository pre-commit hooks: passed
- full E2E not requested because this is deterministic image-packaging behavior with no product-runtime change