### PR TITLE
fix(release): pin GenVM RC artifacts

### DIFF
--- a/tests/unit/test_shared_genvm_image_layout.py
+++ b/tests/unit/test_shared_genvm_image_layout.py
@@ -3,7 +3,6 @@ from pathlib import Path
 
 import yaml
 
-
 REPO_ROOT = Path(__file__).resolve().parents[2]
 DOCKERFILE = REPO_ROOT / "docker" / "Dockerfile.backend"
 
@@ -57,7 +56,7 @@ def test_backend_services_share_one_genvm_parent():
     assert "USER worker-user" in dockerfile
 
 
-def test_default_genvm_binding_selects_source_mode_in_both_build_stages():
+def test_default_genvm_binding_is_loaded_in_both_build_stages():
     dockerfile = DOCKERFILE.read_text()
     source_stage = _stage_body(dockerfile, "genvm-source-build")
     runtime_stage = _stage_body(dockerfile, "genvm-runtime")
@@ -72,6 +71,31 @@ def test_default_genvm_binding_selects_source_mode_in_both_build_stages():
         assert 'effective_ref="$(< /genvm-default-version)"' in stage
         assert '"$effective_ref" =~ ^.+:[0-9a-fA-F]{7,40}$' in stage
     assert 'GENVM_REF="$(< "$REPO_ROOT/third_party/genvm/version")"' in prepare_script
+
+
+def test_release_backend_builds_use_an_immutable_genvm_release():
+    workflow = yaml.safe_load(
+        (
+            REPO_ROOT / ".github" / "workflows" / "docker-build-and-push-all.yml"
+        ).read_text()
+    )
+    default_binding = (
+        (REPO_ROOT / "third_party" / "genvm" / "version").read_text().strip()
+    )
+
+    # The distributed release jobs do not prepare or transfer the sandboxed
+    # Nix closure required by a branch:SHA source binding. With no build args,
+    # Docker falls back to the checked-in binding, so it must name a published,
+    # immutable GenVM release. This catches release-image failures before E2E.
+    for job_name in ("jsonrpc", "consensus-worker"):
+        assert "build_args" not in workflow["jobs"][job_name]["with"]
+    assert re.fullmatch(
+        r"v[0-9]+\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z.]+)?",
+        default_binding,
+    ), (
+        "release backend jobs provide no GenVM override; "
+        "third_party/genvm/version must be an immutable release tag, not a source ref"
+    )
 
 
 def test_release_builds_define_optional_genvm_args_before_nounset_shells():

--- a/third_party/genvm/version
+++ b/third_party/genvm/version
@@ -1,1 +1,1 @@
-v0.6-dev:3c96be6defe30fd9843d47bedc0c66bec324d0fa
+v0.6.0-rc3


### PR DESCRIPTION
## Delivery context

Follow-up for the Studio v0.123.0 prerelease train. The previous v0.123.0-rc.2 image run failed before image publication because release backend jobs provide no source-build closure, while the checked-in GenVM binding was a `branch:SHA` source pin.

Resolved prerequisite: [genvm-manager v0.6.0-rc3](https://github.com/genlayerlabs/genvm-manager/releases/tag/v0.6.0-rc3), tag `8bad3d19b9076f0f10e278ef8e54e9e5139527b8`, is published as a prerelease with the exact four platform/universal assets. Its runtime/artifact source and executor pins are identical to the previously reviewed Studio source pin; the only additional commit content is portable release-test harness coverage.

The preview dispatcher and `studio-next.genlayer.com` support are already landed in [devexp-argocd-apps#693](https://github.com/genlayerlabs/devexp-argocd-apps/pull/693).

## Outcome

- pin Studio backend image builds to immutable `v0.6.0-rc3` release artifacts
- add a fast cross-layer release-policy regression proving distributed backend jobs provide no GenVM build args and therefore require an immutable release tag, not a source ref whose closure is absent
- prevent this class of failure before image/E2E execution

## Validation

- focused GenVM image + release policy: 12 passed
- full repository pre-commit: passed
- full frontend Vitest: 34 files / 220 tests passed
- production frontend build with `VITE_APP_VERSION=v0.123.0-rc.3`: passed; bundle contains the exact version
- branch/tag release policy: passed
- live base: `db32ec9599e1cfbba3cb4f74c4499ae832c4ad4d`
- head: `8277d29da1861593418943a28cd547263106bba3`
- synthetic merge: clean
- worktree: clean

After landing, cut `v0.123.0-rc.3` from exact live `v0.123-dev`; do not reuse rc.1 or rc.2.