### PR TITLE
fix(release): classify default GenVM tags

### DIFF
--- a/docker/Dockerfile.backend
+++ b/docker/Dockerfile.backend
@@ -166,10 +166,16 @@ COPY docker/scripts/download_genvm.sh /usr/local/bin/download-genvm
 COPY --from=genvm-runner-pin /genvm-pin/py-genlayer-pins /genvm-runner-pins
 RUN set -euo pipefail ; \
     effective_ref="$GENVM_REF" ; \
-    if [[ -z "$GENVM_TAG" && -z "$effective_ref" ]]; then \
-        effective_ref="$(< /genvm-default-version)" ; \
+    release_version="$GENVM_TAG" ; \
+    default_binding="$(< /genvm-default-version)" ; \
+    if [[ -z "$release_version" && -z "$effective_ref" ]]; then \
+        if [[ "$default_binding" =~ ^.+:[0-9a-fA-F]{7,40}$ ]]; then \
+            effective_ref="$default_binding" ; \
+        else \
+            release_version="$default_binding" ; \
+        fi ; \
     fi ; \
-    if [[ -n "$GENVM_TAG" && -n "$effective_ref" ]]; then \
+    if [[ -n "$release_version" && -n "$effective_ref" ]]; then \
         echo "ERROR: GENVM_TAG and GENVM_REF are mutually exclusive" ; exit 1 ; \
     fi ; \
     case "$GENVM_SOURCE_MODE" in \
@@ -207,7 +213,9 @@ RUN set -euo pipefail ; \
         if [[ -n "$effective_ref" ]]; then \
             echo "ERROR: release mode does not accept GENVM_REF; use GENVM_SOURCE_MODE=source" ; exit 1 ; \
         fi ; \
-        release_version="${GENVM_TAG:-$(< /genvm-default-version)}" ; \
+        if [[ -z "$release_version" ]]; then \
+            echo "ERROR: release mode requires GENVM_TAG or a release tag in third_party/genvm/version" ; exit 1 ; \
+        fi ; \
         release_arch="${TARGETARCH:-amd64}" ; \
         /usr/local/bin/download-genvm linux "$release_arch" "$release_version" \
             --out-dir /genvm --download-dir /tmp/genvm-download \

--- a/tests/unit/test_shared_genvm_image_layout.py
+++ b/tests/unit/test_shared_genvm_image_layout.py
@@ -67,9 +67,10 @@ def test_default_genvm_binding_is_loaded_in_both_build_stages():
     assert (
         dockerfile.count("COPY third_party/genvm/version /genvm-default-version") == 2
     )
-    for stage in (source_stage, runtime_stage):
-        assert 'effective_ref="$(< /genvm-default-version)"' in stage
-        assert '"$effective_ref" =~ ^.+:[0-9a-fA-F]{7,40}$' in stage
+    assert 'effective_ref="$(< /genvm-default-version)"' in source_stage
+    assert '"$effective_ref" =~ ^.+:[0-9a-fA-F]{7,40}$' in source_stage
+    assert 'default_binding="$(< /genvm-default-version)"' in runtime_stage
+    assert '"$default_binding" =~ ^.+:[0-9a-fA-F]{7,40}$' in runtime_stage
     assert 'GENVM_REF="$(< "$REPO_ROOT/third_party/genvm/version")"' in prepare_script
 
 
@@ -96,6 +97,16 @@ def test_release_backend_builds_use_an_immutable_genvm_release():
         "release backend jobs provide no GenVM override; "
         "third_party/genvm/version must be an immutable release tag, not a source ref"
     )
+
+    runtime_stage = _stage_body(DOCKERFILE.read_text(), "genvm-runtime")
+    assert 'release_version="$GENVM_TAG"' in runtime_stage
+    assert 'release_version="$default_binding"' in runtime_stage
+    assert 'effective_ref="$default_binding"' in runtime_stage
+    assert (
+        'release_version="${GENVM_TAG:-$(< /genvm-default-version)}"'
+        not in runtime_stage
+    )
+    assert 'download-genvm linux "$release_arch" "$release_version"' in runtime_stage
 
 
 def test_release_builds_define_optional_genvm_args_before_nounset_shells():


### PR DESCRIPTION
## Delivery context

Follow-up to failed Studio prerelease run [33718273352](https://github.com/genlayerlabs/genlayer-studio/actions/runs/33718273352) for `v0.123.0-rc.3`.

The tag and release routing were correct, and frontend, explorer, and database-migration multi-arch manifests published without moving `latest`. Both backend arm64 builds failed before download because the runtime stage loaded the checked-in release tag into `effective_ref`, correctly inferred release mode, then incorrectly rejected that default as though the caller had explicitly supplied `GENVM_REF`. The sibling amd64 jobs were cancelled by matrix fail-fast.

## Outcome

- classify a no-build-args checked-in `branch:SHA` as a source ref
- classify a no-build-args checked-in release tag as `release_version`
- preserve explicit `GENVM_TAG` / `GENVM_REF` mutual exclusion and mode validation
- fail clearly if explicit release mode has no release tag
- strengthen the fast cross-layer test so the exact no-build-args/default-release-tag path cannot regress before image/E2E execution

## Validation

- focused GenVM image + prerelease policy: 12 passed
- touched-file pre-commit: passed
- live base: `d089ccd245b16c7d3f1a6d62a0cf76250057a1b2`
- head: `22356746`
- synthetic merge: clean
- worktree: clean

After landing, cut a new `v0.123.0-rc.4`; do not reuse the already-created rc.3 tag.