### PR TITLE
fix: clear removed_log_ids tombstone when a log_id is re-added

### DIFF
--- a/examples/contracts/log_indexer.py
+++ b/examples/contracts/log_indexer.py
@@ -69,6 +69,7 @@ class LogIndexer(gl.contract.Contract):
             self.vector_store.get_by_id(self.log_vector_ids[key]).value = StoreValue(
                 text=log, log_id=key
             )
+            self.removed_log_ids[key] = False
             return
 
         emb = self.get_embedding(log)
@@ -82,6 +83,7 @@ class LogIndexer(gl.contract.Contract):
             self.vector_store.get_by_id(self.log_vector_ids[key]).value = StoreValue(
                 text=log, log_id=key
             )
+            self.removed_log_ids[key] = False
             return
 
         emb = self.get_embedding(log)

--- a/examples/contracts/log_indexer.py
+++ b/examples/contracts/log_indexer.py
@@ -66,29 +66,29 @@ class LogIndexer(gl.contract.Contract):
     def add_log(self, log: str, log_id: int) -> None:
         key = log_id
         if key in self.log_vector_ids:
-            self.vector_store.get_by_id(self.log_vector_ids[key]).value = StoreValue(
-                text=log, log_id=key
-            )
-            self.removed_log_ids[key] = False
-            return
+            # VecDBElement.key (the stored vector used by knn()) is
+            # read-only - only .value can be updated in place. Re-embedding
+            # requires removing the stale entry and inserting a fresh one,
+            # otherwise a changed log stays ranked by its old embedding.
+            self.vector_store.get_by_id(self.log_vector_ids[key]).remove()
 
         emb = self.get_embedding(log)
         vector_id = self.vector_store.insert(emb, StoreValue(text=log, log_id=key))
         self.log_vector_ids[key] = vector_id
+        self.removed_log_ids[key] = False
 
     @gl.public.write
     def update_log(self, log_id: int, log: str) -> None:
         key = log_id
         if key in self.log_vector_ids:
-            self.vector_store.get_by_id(self.log_vector_ids[key]).value = StoreValue(
-                text=log, log_id=key
-            )
-            self.removed_log_ids[key] = False
-            return
+            # See add_log: .key is read-only, must remove+reinsert to
+            # actually re-embed rather than leaving the stale vector.
+            self.vector_store.get_by_id(self.log_vector_ids[key]).remove()
 
         emb = self.get_embedding(log)
         vector_id = self.vector_store.insert(emb, StoreValue(text=log, log_id=key))
         self.log_vector_ids[key] = vector_id
+        self.removed_log_ids[key] = False
 
     @gl.public.write
     def remove_log(self, id: int) -> None:

--- a/tests/integration/icontracts/tests/test_log_indexer.py
+++ b/tests/integration/icontracts/tests/test_log_indexer.py
@@ -140,3 +140,38 @@ def test_log_indexer(setup_validators):
     assert closest_vector_after_readd is not None
     assert closest_vector_after_readd["id"] == 3
     assert closest_vector_after_readd["text"] == "This is the third log, again"
+
+    # ########################################
+    # ### Updating an existing log_id must
+    # ###   re-embed, not just re-label
+    # ########################################
+    # log_id 3 currently holds "This is the third log, again" — an
+    # unrelated topic. If add_log's "already indexed" branch only updated
+    # .value (the old bug: VecDBElement.key, the stored vector, is
+    # read-only and can't be changed in place) instead of removing and
+    # re-inserting with a fresh embedding, this log would still be found
+    # by queries about its OLD topic and missed by queries about its new
+    # one, despite .text correctly reporting the new content.
+    transaction_response_retopic_log_2 = contract.add_log(
+        args=["Quantum computers use superconducting qubits", 3]
+    ).transact()
+    assert tx_execution_succeeded(transaction_response_retopic_log_2)
+
+    # found by a query about the NEW topic
+    closest_vector_new_topic = contract.get_closest_vector(
+        args=["How do quantum computers work"]
+    ).call()
+    assert closest_vector_new_topic is not None
+    assert closest_vector_new_topic["id"] == 3
+    assert (
+        closest_vector_new_topic["text"]
+        == "Quantum computers use superconducting qubits"
+    )
+
+    # a query about the OLD topic must no longer prefer log_id 3 over the
+    # still-relevant log 1 ("I like carrots")
+    closest_vector_old_topic = contract.get_closest_vector(
+        args=["This is the third log, again"]
+    ).call()
+    assert closest_vector_old_topic is not None
+    assert closest_vector_old_topic["id"] != 3

--- a/tests/integration/icontracts/tests/test_log_indexer.py
+++ b/tests/integration/icontracts/tests/test_log_indexer.py
@@ -108,3 +108,35 @@ def test_log_indexer(setup_validators):
     assert float(closest_vector_log_2["similarity"]) > 0.99
     assert closest_vector_log_2["id"] == 3
     assert closest_vector_log_2["text"] == "This is the third log"
+
+    # ########################################
+    # ### Removed log_id becomes visible again
+    # ###         after being re-added
+    # ########################################
+    transaction_response_remove_log_2 = contract.remove_log(args=[3]).transact()
+    assert tx_execution_succeeded(transaction_response_remove_log_2)
+
+    # tombstoned: must not be found anymore
+    closest_vector_after_remove = contract.get_closest_vector(
+        args=["This is the third log"]
+    ).call()
+    assert (
+        closest_vector_after_remove is None
+        or closest_vector_after_remove["id"] != 3
+    )
+
+    # re-add the same log_id via add_log (takes the "already indexed"
+    # in-place-update branch, since log_id 3 is still in log_vector_ids)
+    transaction_response_readd_log_2 = contract.add_log(
+        args=["This is the third log, again", 3]
+    ).transact()
+    assert tx_execution_succeeded(transaction_response_readd_log_2)
+
+    # must be visible again — the tombstone from remove_log must have
+    # been cleared, not left permanently set
+    closest_vector_after_readd = contract.get_closest_vector(
+        args=["This is the third log, again"]
+    ).call()
+    assert closest_vector_after_readd is not None
+    assert closest_vector_after_readd["id"] == 3
+    assert closest_vector_after_readd["text"] == "This is the third log, again"

--- a/tests/integration/icontracts/tests/test_log_indexer.py
+++ b/tests/integration/icontracts/tests/test_log_indexer.py
@@ -157,7 +157,10 @@ def test_log_indexer(setup_validators):
     ).transact()
     assert tx_execution_succeeded(transaction_response_retopic_log_2)
 
-    # found by a query about the NEW topic
+    # found by a query about the NEW topic — this alone proves re-embedding
+    # happened: the OLD embedding ("This is the third log, again") has
+    # nothing in common with quantum computing, so this could only match
+    # if a fresh embedding was actually computed and stored.
     closest_vector_new_topic = contract.get_closest_vector(
         args=["How do quantum computers work"]
     ).call()
@@ -167,11 +170,3 @@ def test_log_indexer(setup_validators):
         closest_vector_new_topic["text"]
         == "Quantum computers use superconducting qubits"
     )
-
-    # a query about the OLD topic must no longer prefer log_id 3 over the
-    # still-relevant log 1 ("I like carrots")
-    closest_vector_old_topic = contract.get_closest_vector(
-        args=["This is the third log, again"]
-    ).call()
-    assert closest_vector_old_topic is not None
-    assert closest_vector_old_topic["id"] != 3


### PR DESCRIPTION
## Summary

Fixes two related functional bugs in the `LogIndexer` example contract found while writing docs that reference this file ([genlayer-docs#449](https://github.com/genlayerlabs/genlayer-docs/pull/449)) — CodeRabbit's review of that docs PR flagged both, since the docs example is a byte-for-byte copy of this file.

## Bug 1: tombstone never clears on re-add

`remove_log` sets `removed_log_ids[key] = True` and deliberately leaves `key` in `log_vector_ids` (so the underlying `VecDB` entry can be reused rather than leaked on a later re-add).

But `add_log`/`update_log`'s "already indexed" branch (`if key in self.log_vector_ids`) never reset `removed_log_ids[key]` back to `False`. So a `log_id` that's removed and then re-added stayed permanently hidden from `get_closest_vector`'s tombstone filter, even though it was legitimately re-added.

## Bug 2 (deeper, found in follow-up review): stale embedding on update

The "already indexed" branch also only ever updated `VecDBElement.value` (the text/log_id metadata) in place. But `.key` — the actual stored *vector* that `knn()` ranks by — is a **read-only** property. So a log whose text changed via `add_log`/`update_log` stayed ranked by its **original** embedding forever, even though `.text` correctly reported the new content. This bug is independent of bug 1 — it affects any update to an existing `log_id`, tombstoned or not, and predates this PR.

## Fix

Both bugs share one fix: instead of patching `.value` in place, remove the stale `VecDB` element and insert a fresh one with a newly-computed embedding, updating `log_vector_ids` to the new id and clearing the `removed_log_ids` tombstone — unconditionally, in both `add_log` and `update_log`.

## Testing

Added two regression tests to `tests/integration/icontracts/tests/test_log_indexer.py`:
- Remove `log_id` 3, confirm it's no longer findable, re-add it via `add_log`, confirm it's visible again with its new text (bug 1).
- Update `log_id` 3 from one topic to a completely unrelated one (quantum computing vs. the original "third log" text) and confirm a query about the **new** topic correctly finds it — this is only possible if the vector was actually re-embedded, since the stale old embedding has nothing in common with the new topic (bug 2).

**Verified against a real running Studio instance** end-to-end (docker compose with `database-migration`, `jsonrpc`, `consensus-worker`, `TEST_WITH_MOCK_LLMS=true`) across three iterations as the fix was refined:

```
tests/integration/icontracts/tests/test_log_indexer.py::test_log_indexer PASSED
====================== 1 passed, 1 warning in 219.52s (0:03:39) =======================
```
