### PR TITLE
fix: align local Studio chain defaults

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -98,7 +98,9 @@ WEB_RENDER_RETRIES="2"
 # addresses are DB-authoritative and do not require this service.
 HARDHAT_URL=''
 HARDHAT_PORT='8545'
-GENLAYER_CHAIN_ID='61999'
+# Keep this aligned with the SDK localnet preset. Existing pre-v0.123 .env
+# files may still contain 61999 and must be updated before restarting Studio.
+GENLAYER_CHAIN_ID='61127'
 
 ########################################
 # LLM Providers Configuration

--- a/frontend/test/unit/stores/network.test.ts
+++ b/frontend/test/unit/stores/network.test.ts
@@ -16,6 +16,14 @@ describe('useNetworkStore', () => {
     vi.unstubAllEnvs();
   });
 
+  it('uses the canonical local Studio chain by default', () => {
+    const store = useNetworkStore();
+
+    expect(store.currentNetwork).toBe('localnet');
+    expect(store.chainId).toBe(61127);
+    expect(store.isStudio).toBe(true);
+  });
+
   it('keeps the deployment-configured Studio network selectable after switching to Bradbury', () => {
     window.__RUNTIME_CONFIG__ = {
       VITE_GENLAYER_NETWORK: 'studionet',

--- a/tests/unit/test_chain_id_defaults.py
+++ b/tests/unit/test_chain_id_defaults.py
@@ -1,0 +1,34 @@
+import re
+from pathlib import Path
+
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _decimal_capture(path: str, pattern: str) -> int:
+    source = (REPOSITORY_ROOT / path).read_text(encoding="utf-8")
+    match = re.search(pattern, source, re.MULTILINE)
+    assert match is not None, f"could not find the chain ID default in {path}"
+    return int(match.group(1))
+
+
+def test_tracked_local_chain_id_defaults_stay_aligned():
+    defaults = {
+        "environment": _decimal_capture(
+            ".env.example", r"^GENLAYER_CHAIN_ID=[\'\"]?(\d+)[\'\"]?$"
+        ),
+        "backend": _decimal_capture(
+            "backend/node/base.py",
+            r'os\.getenv\("HARDHAT_CHAIN_ID",\s*"(\d+)"\)',
+        ),
+        "hardhat": _decimal_capture(
+            "hardhat/hardhat.config.js",
+            r'readDotenvVariable\("HARDHAT_CHAIN_ID"\)\s*\?\?\s*"(\d+)"',
+        ),
+    }
+
+    assert defaults == {
+        "environment": 61127,
+        "backend": 61127,
+        "hardhat": 61127,
+    }


### PR DESCRIPTION
## Summary
- change the tracked local Studio bootstrap chain ID from the stale hosted-Studio value to canonical localnet `61127`
- document the required update for `.env` files copied before v0.123
- add a backend static regression keeping `.env.example`, backend fallback, and Hardhat fallback aligned
- add a frontend default-network regression for the SDK-backed localnet value

## Root cause
Studio and genlayer-js moved localnet to `61127`, but the tracked environment template retained `61999`. Copying that template caused local deployments to diverge from the published SDK preset and could surface `InvalidChainId` on signed submissions.

The cross-repository E2E previously masked this by forcing a runtime ID and rewriting SDK presets.

## Validation
- frontend network-store unit tests: 3 passed
- frontend TypeScript build check
- backend bootstrap-consistency test: 1 passed
- repository pre-commit hooks

## Related
- genlayerlabs/genlayer-py#115 (merged): corrects the Python localnet preset and adds signer-level regression coverage.