### PR TITLE
fix: normalize faucet funding quantities

### DIFF
--- a/backend/protocol_rpc/endpoints.py
+++ b/backend/protocol_rpc/endpoints.py
@@ -3,6 +3,7 @@ import copy
 import math
 import random
 import json
+import re
 import time
 import eth_utils
 import logging
@@ -11,6 +12,7 @@ from dataclasses import dataclass
 from functools import partial, wraps
 from typing import Any, Final, NoReturn, get_args
 from backend.protocol_rpc.exceptions import (
+    InvalidParams,
     JSONRPCError,
     NotFoundError,
     QueueDepthExceeded,
@@ -550,7 +552,7 @@ def clear_db_tables(session: Session, tables: list) -> None:
 def fund_account(
     session: Session,
     account_address: str,
-    amount: int,
+    amount: int | str,
 ) -> str:
     """Fund an account within a request-scoped database session."""
     accounts_manager = AccountsManager(session)
@@ -559,14 +561,39 @@ def fund_account(
     if not accounts_manager.is_valid_address(account_address):
         raise InvalidAddressError(account_address)
 
+    if isinstance(amount, bool) or not isinstance(amount, (int, str)):
+        raise InvalidParams(message="amount must be a positive integer")
+    if isinstance(amount, str):
+        if re.fullmatch(r"[0-9]+", amount):
+            normalized_amount = int(amount, 10)
+        elif re.fullmatch(r"0[xX][0-9a-fA-F]+", amount):
+            normalized_amount = int(amount, 16)
+        else:
+            raise InvalidParams(message="amount must be a positive integer")
+    else:
+        normalized_amount = amount
+    if normalized_amount <= 0:
+        raise InvalidParams(message="amount must be a positive integer")
+
     import secrets
 
     nonce = transactions_processor.get_transaction_count(None)
     transaction_hash = "0x" + secrets.token_hex(32)
     transactions_processor.insert_transaction(
-        None, account_address, None, amount, 0, nonce, False, 0, None, transaction_hash
+        None,
+        account_address,
+        None,
+        normalized_amount,
+        0,
+        nonce,
+        False,
+        0,
+        None,
+        transaction_hash,
     )
-    accounts_manager.credit_tx_value_once(transaction_hash, account_address, amount)
+    accounts_manager.credit_tx_value_once(
+        transaction_hash, account_address, normalized_amount
+    )
     return transaction_hash
 
 

--- a/backend/protocol_rpc/rpc_methods.py
+++ b/backend/protocol_rpc/rpc_methods.py
@@ -48,7 +48,7 @@ def clear_db_tables(
 @rpc.method("sim_fundAccount")
 def fund_account(
     account_address: str,
-    amount: int,
+    amount: int | str,
     session: Session = Depends(get_db_session),
 ) -> str:
     return impl.fund_account(

--- a/frontend/test/metamask/balance-headless.spec.ts
+++ b/frontend/test/metamask/balance-headless.spec.ts
@@ -14,7 +14,7 @@ const RPC_URL = process.env.GENLAYER_RPC_URL ?? 'http://localhost:4000/api';
 // Anvil account 0
 const ADDRESS_CHECKSUMMED = '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266';
 const ADDRESS_LOWERCASE = ADDRESS_CHECKSUMMED.toLowerCase();
-const TEN_GEN_WEI = 10_000_000_000_000_000_000; // 10 * 1e18
+const TEN_GEN_WEI = 10_000_000_000_000_000_000n; // 10 * 1e18
 
 async function rpcCall(method: string, params: unknown = []) {
   const res = await fetch(RPC_URL, {
@@ -32,7 +32,7 @@ test.describe('eth_getBalance MetaMask compatibility', () => {
     // Fund account once
     await rpcCall('sim_fundAccount', {
       account_address: ADDRESS_CHECKSUMMED,
-      amount: TEN_GEN_WEI,
+      amount: TEN_GEN_WEI.toString(),
     });
   });
 

--- a/frontend/test/metamask/balance.spec.ts
+++ b/frontend/test/metamask/balance.spec.ts
@@ -42,7 +42,7 @@ async function rpcFundAccount(
     body: JSON.stringify({
       jsonrpc: '2.0',
       method: 'sim_fundAccount',
-      params: { account_address: address, amount: Number(amountWei) },
+      params: { account_address: address, amount: amountWei.toString() },
       id: 1,
     }),
   });

--- a/frontend/test/unit/services/JsonRpcService.behavioral.test.ts
+++ b/frontend/test/unit/services/JsonRpcService.behavioral.test.ts
@@ -83,6 +83,15 @@ describe('JsonRpcService — RPC method mapping', () => {
       );
     });
 
+    it('fundAccount preserves the exact decimal wei amount on the wire', async () => {
+      const amount = '10000000000000000000';
+      await service.fundAccount('0xaccount', amount);
+      expect(mockCall).toHaveBeenCalledWith({
+        method: 'sim_fundAccount',
+        params: ['0xaccount', amount],
+      });
+    });
+
     it('estimateTransactionFees calls sim_estimateTransactionFees', async () => {
       const params = { scenarioName: 'tip', type: 'write' };
       await service.estimateTransactionFees(params);

--- a/tests/unit/test_rpc_endpoint_manager.py
+++ b/tests/unit/test_rpc_endpoint_manager.py
@@ -1,7 +1,10 @@
 import pytest
 from fastapi import Depends, FastAPI
 from starlette.requests import Request
+from unittest.mock import MagicMock
 
+from backend.protocol_rpc import endpoints, rpc_methods
+from backend.protocol_rpc.dependencies import get_db_session
 from backend.protocol_rpc.exceptions import JSONRPCError, MethodNotFound
 from backend.protocol_rpc.rpc_endpoint_manager import (
     JSONRPCRequest,
@@ -58,6 +61,71 @@ async def test_manager_invokes_endpoint_with_dependencies():
         "endpoint_call",
         "endpoint_success",
     ]
+
+
+@pytest.mark.asyncio
+async def test_fund_account_normalizes_frontend_decimal_string_through_rpc(
+    monkeypatch,
+):
+    session = object()
+    accounts_manager = MagicMock()
+    accounts_manager.is_valid_address.return_value = True
+    transactions_processor = MagicMock()
+    transactions_processor.get_transaction_count.return_value = 9
+
+    monkeypatch.setattr("secrets.token_hex", lambda _size: "abc")
+    monkeypatch.setattr(endpoints, "AccountsManager", lambda _session: accounts_manager)
+    monkeypatch.setattr(
+        endpoints,
+        "TransactionsProcessor",
+        lambda _session: transactions_processor,
+    )
+
+    stub_logger = StubMessageHandler()
+    app = FastAPI()
+    app.dependency_overrides[get_db_session] = lambda: session
+    manager = RPCEndpointManager(stub_logger, dependency_overrides_provider=app)
+    manager.register(
+        RPCEndpointDefinition(name="sim_fundAccount", handler=rpc_methods.fund_account)
+    )
+
+    address = "0x" + "7" * 40
+    amount = "10000000000000000000"
+    request_payload = JSONRPCRequest(
+        method="sim_fundAccount", params=[address, amount], id=2
+    )
+    request = Request(
+        {
+            "type": "http",
+            "method": "POST",
+            "headers": [],
+            "app": app,
+            "query_string": b"",
+            "path": "/api",
+            "root_path": "",
+            "scheme": "http",
+            "server": ("localhost", 4000),
+        }
+    )
+
+    response = await manager.invoke(request_payload, request)
+
+    assert response.result == "0xabc"
+    transactions_processor.insert_transaction.assert_called_once_with(
+        None,
+        address,
+        None,
+        10_000_000_000_000_000_000,
+        0,
+        9,
+        False,
+        0,
+        None,
+        "0xabc",
+    )
+    accounts_manager.credit_tx_value_once.assert_called_once_with(
+        "0xabc", address, 10_000_000_000_000_000_000
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_simulator_sessions.py
+++ b/tests/unit/test_simulator_sessions.py
@@ -5,6 +5,7 @@ import pytest
 
 from backend.protocol_rpc import endpoints
 from backend.errors.errors import InvalidAddressError
+from backend.protocol_rpc.exceptions import InvalidParams
 from backend.domain.types import LLMProvider, TransactionType
 from backend.database_handler.models import TransactionStatus
 from backend.protocol_rpc.types import (
@@ -81,6 +82,83 @@ def test_fund_account_uses_request_scoped_session(monkeypatch):
     transactions_processor_instance.insert_transaction.assert_called_once_with(
         None, "0x" + "1" * 40, None, 25, 0, 12, False, 0, None, "0xabc"
     )
+    accounts_manager_instance.credit_tx_value_once.assert_called_once_with(
+        "0xabc", "0x" + "1" * 40, 25
+    )
+
+
+@pytest.mark.parametrize(
+    ("wire_amount", "expected_amount"),
+    [("10000000000000000000", 10_000_000_000_000_000_000), ("0x2a", 42)],
+)
+def test_fund_account_normalizes_string_amounts(
+    monkeypatch, wire_amount, expected_amount
+):
+    session = object()
+    accounts_manager_instance = MagicMock()
+    accounts_manager_instance.is_valid_address.return_value = True
+    transactions_processor_instance = MagicMock()
+    transactions_processor_instance.get_transaction_count.return_value = 3
+
+    monkeypatch.setattr("secrets.token_hex", lambda _size: "abc")
+    monkeypatch.setattr(
+        endpoints, "AccountsManager", lambda _session: accounts_manager_instance
+    )
+    monkeypatch.setattr(
+        endpoints,
+        "TransactionsProcessor",
+        lambda _session: transactions_processor_instance,
+    )
+
+    address = "0x" + "5" * 40
+    result = endpoints.fund_account(session, address, wire_amount)
+
+    assert result == "0xabc"
+    transactions_processor_instance.insert_transaction.assert_called_once_with(
+        None, address, None, expected_amount, 0, 3, False, 0, None, "0xabc"
+    )
+    accounts_manager_instance.credit_tx_value_once.assert_called_once_with(
+        "0xabc", address, expected_amount
+    )
+
+
+@pytest.mark.parametrize(
+    "invalid_amount",
+    [
+        "",
+        " 1",
+        "+1",
+        "1_000",
+        "1.5",
+        "0x",
+        "0xgg",
+        "not-a-number",
+        0,
+        -1,
+        True,
+        1.5,
+        None,
+    ],
+)
+def test_fund_account_rejects_non_positive_integer_amounts(monkeypatch, invalid_amount):
+    accounts_manager_instance = MagicMock()
+    accounts_manager_instance.is_valid_address.return_value = True
+    transactions_processor_instance = MagicMock()
+
+    monkeypatch.setattr(
+        endpoints, "AccountsManager", lambda _session: accounts_manager_instance
+    )
+    monkeypatch.setattr(
+        endpoints,
+        "TransactionsProcessor",
+        lambda _session: transactions_processor_instance,
+    )
+
+    with pytest.raises(InvalidParams, match="amount must be a positive integer"):
+        endpoints.fund_account(object(), "0x" + "6" * 40, invalid_amount)
+
+    transactions_processor_instance.insert_transaction.assert_not_called()
+    accounts_manager_instance.credit_tx_value_once.assert_not_called()
 
 
 def test_fund_account_raises_for_invalid_address(monkeypatch):

--- a/tests/unit/test_studio_fees.py
+++ b/tests/unit/test_studio_fees.py
@@ -1823,7 +1823,14 @@ def test_non_ghost_internal_message_is_skipped_and_refunded_once(
     assert record["skippedRefundAmount"] == expected_account_refund
 
 
-def test_local_message_authority_applies_ghost_factory_and_per_child_failures():
+def test_local_message_authority_applies_ghost_factory_and_per_child_failures(
+    monkeypatch,
+):
+    simulator_chain_id = 61128
+    monkeypatch.setattr(
+        "backend.consensus.base.get_simulator_chain_id",
+        lambda: simulator_chain_id,
+    )
     registered = "0x2222222222222222222222222222222222222222"
     missing = "0x3333333333333333333333333333333333333333"
     parent_hash = "0x" + ("11" * 32)
@@ -1892,7 +1899,9 @@ def test_local_message_authority_applies_ghost_factory_and_per_child_failures():
 
     zero = "0x" + ("00" * 32)
     assert processor.locked is True
-    expected_salted_child = genvm_salted_child_address(registered, 42, 61999)
+    expected_salted_child = genvm_salted_child_address(
+        registered, 42, simulator_chain_id
+    )
     assert {address.lower() for address in processor.locked_recipients} == {
         registered.lower(),
         expected_salted_child.lower(),


### PR DESCRIPTION
## Problem and outcome

Studio's faucet UI preserves exact wei amounts by sending them as decimal strings. The JSON-RPC dispatcher binds those values verbatim, so the backend's `amount: int` annotation did not convert them. The string reached `credit_tx_value_once()` and failed at `amount <= 0`, producing the user-visible funding error.

This change normalizes funding quantities at the shared faucet endpoint before any transaction or balance write. It accepts JSON integers plus strict decimal or hexadecimal integer strings, rejects malformed and non-positive values with JSON-RPC `-32602`, and preserves exact values larger than JavaScript's safe-integer range.

The normalization is intentionally endpoint-local. Globally coercing annotated RPC arguments would be unsafe because many protocol parameters are intentionally strings.

## Implementation and validation

- The RPC method truthfully accepts `int | str`; the endpoint converts once and passes an integer to both transaction insertion and account credit.
- Backend regressions cover the production `10 GEN` decimal string, hexadecimal compatibility, invalid forms, and zero side effects on rejection.
- A dispatcher-level regression exercises the actual `sim_fundAccount` route with the browser's decimal-string payload.
- The frontend service test locks the exact string wire representation.
- Both MetaMask browser helpers now send string quantities instead of converting bigint values to JavaScript numbers, so the full-path checks match production.
- The release base's ghost-address test no longer hard-codes the retired `61999` chain ID: it injects a non-default chain ID and proves local message authoring uses it. This repairs the deterministic backend-unit failure exposed by the PR without coupling the test to deployment configuration.

Validation:

- 45 focused faucet and dispatcher backend tests passed
- all 467 Studio fee tests passed
- chain-default and ghost-address regressions passed
- 22 frontend RPC-service tests passed
- frontend production type-check and build passed
- Playwright discovered all 4 updated MetaMask tests successfully
- Ruff, Black, ESLint, Prettier, and repository pre-commit hooks passed
- `git diff --check` passed

## Delivery context

This is a narrow follow-up directly on the live `v0.123-dev` RC5 head. It has no cross-repository dependency and does not change consensus or SDK interfaces.

The regression was introduced by #1714, which correctly replaced a lossy JavaScript number with an exact decimal string but had no backend or cross-boundary test using that wire type. Open PR #1625 targets `main` and is not sufficient for this case because it compares the raw string with zero before normalizing it.
